### PR TITLE
added tags to terminology sets associated with the mart

### DIFF
--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -43,6 +43,7 @@ seeds:
       tags:
         - terminology
         - data_profiling
+        - aip_mart
       column_types:
         bill_type_code : |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar {%- endif -%}
@@ -465,6 +466,7 @@ seeds:
         - readmissions
         - data_profiling
         - claims_preprocessing
+        - aip_mart
       column_types:
         ms_drg_code : |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar {%- endif -%}
@@ -602,6 +604,7 @@ seeds:
         - terminology
         - claims_preprocessing
         - data_profiling
+        - aip_mart
       column_types:
         revenue_center_code : |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar {%- endif -%}
@@ -615,6 +618,7 @@ seeds:
       tags:
         - terminology
         - data_profiling
+        - aip_mart
       column_types:
         apr_drg_code : |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar {%- endif -%}


### PR DESCRIPTION
I added tags to the relevant terminology sets in the terminology yml so that when you run ```dbt build -select +tag:aip_mart``` only the 4 terminology sets we need to load are loaded.  Just saving us some time :-)