### PR TITLE
Bugfix: primary_diagnosis_code_type incorrectly mapped in encounter

### DIFF
--- a/integration_tests/models/encounter.sql
+++ b/integration_tests/models/encounter.sql
@@ -13,6 +13,7 @@ cast(null as {{ dbt.type_string() }} ) as encounter_id
 , cast(null as {{ dbt.type_string() }} ) as discharge_disposition_description
 , cast(null as {{ dbt.type_string() }} ) as attending_provider_id
 , cast(null as {{ dbt.type_string() }} ) as facility_npi
+, cast(null as {{ dbt.type_string() }} ) as primary_diagnosis_code_type
 , cast(null as {{ dbt.type_string() }} ) as primary_diagnosis_code
 , cast(null as {{ dbt.type_string() }} ) as primary_diagnosis_description
 , cast(null as {{ dbt.type_string() }} ) as ms_drg_code

--- a/models/core/staging/core__stg_clinical_encounter.sql
+++ b/models/core/staging/core__stg_clinical_encounter.sql
@@ -18,7 +18,7 @@ select
     , cast(discharge_disposition_description as {{ dbt.type_string() }} ) as discharge_disposition_description
     , cast(attending_provider_id as {{ dbt.type_string() }} ) as attending_provider_id
     , cast(facility_npi as {{ dbt.type_string() }} ) as facility_npi
-    , cast(primary_diagnosis_code as {{ dbt.type_string() }} ) as primary_diagnosis_code_type
+    , cast(primary_diagnosis_code_type as {{ dbt.type_string() }} ) as primary_diagnosis_code_type
     , cast(primary_diagnosis_code as {{ dbt.type_string() }} ) as primary_diagnosis_code
     , cast(primary_diagnosis_description as {{ dbt.type_string() }} ) as primary_diagnosis_description
     , cast(ms_drg_code as {{ dbt.type_string() }} ) as ms_drg_code


### PR DESCRIPTION
## Describe your changes
In core staging, clinical encounter primary_diagnosis_code_type was getting mapped to the code instead of the type. Updated stage to map to the correct field. 


## How has this been tested?
Ran with bamboo_connector and validated the code type field is correct. 


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have updated the version number in dbt_project.yml file to reflect the release number of this PR
- [ ] I have updated the docs files (by running dbt docs generate/serve and copying the necessary files into the docs folder)
- [ ] I have commented my code as necessary
- [X] I have added at least one Github label to this PR
- [X] My code follows style guidelines
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](https://media2.giphy.com/media/3o6nUPPGvsKSiNqvNC/giphy.gif?cid=ecf05e47kjxbtodeo3z7r1h8xahcwpvhlfh8eu89j9wwtlku&ep=v1_gifs_search&rid=giphy.gif&ct=g)


## Loom link
