### PR TITLE
Bugfix: change cast from INT to NUMERIC for service_unit_quantity

### DIFF
--- a/models/core/staging/core__stg_claims_medical_claim.sql
+++ b/models/core/staging/core__stg_claims_medical_claim.sql
@@ -40,7 +40,7 @@ select
     , cast(med.ms_drg_code as {{ dbt.type_string() }} ) as ms_drg_code
     , cast(med.apr_drg_code as {{ dbt.type_string() }} ) as apr_drg_code
     , cast(med.revenue_center_code as {{ dbt.type_string() }} ) as revenue_center_code
-    , cast(med.service_unit_quantity as {{ dbt.type_int() }} ) as service_unit_quantity
+    , cast(med.service_unit_quantity as {{ dbt.type_numeric() }} ) as service_unit_quantity
     , cast(med.hcpcs_code as {{ dbt.type_string() }} ) as hcpcs_code
     , cast(med.hcpcs_modifier_1 as {{ dbt.type_string() }} ) as hcpcs_modifier_1
     , cast(med.hcpcs_modifier_2 as {{ dbt.type_string() }} ) as hcpcs_modifier_2


### PR DESCRIPTION
## Describe your changes
We were casting service_unit_quantity as an INT64 but it should be numeric. 
According to CMS: CLM_LINE_SRVC_UNIT_Q TY has FORMAT: -9(18).9999
https://www.cms.gov/files/document/cclf-file-data-elements-resource.pdf


## How has this been tested?
Updated and ran model and downstream models on live customer data. 


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have updated the version number in dbt_project.yml file to reflect the release number of this PR
- [ ] I have updated the docs files (by running dbt docs generate/serve and copying the necessary files into the docs folder)
- [ ] I have commented my code as necessary
- [X] I have added at least one Github label to this PR
- [X] My code follows style guidelines
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](https://media3.giphy.com/media/1xOQlQxrIX4Jw6lBZI/giphy.webp?cid=790b7611j7g61m5y1mw3jcpt45k3er42vsr8yx2tsp17zq4t&ep=v1_gifs_search&rid=giphy.webp&ct=g)


## Loom link
