### PR TITLE
BUGFIX: Correct union logic for shared exclusions in Quality Measures 

### DIFF
--- a/models/quality_measures/intermediate/shared_exclusions/quality_measures__int_shared_exclusions_advanced_illness.sql
+++ b/models/quality_measures/intermediate/shared_exclusions/quality_measures__int_shared_exclusions_advanced_illness.sql
@@ -145,9 +145,9 @@ with patients_with_frailty as (
             || ' and '
             || condition_exclusions.concept_name
           as exclusion_reason
-        , null as procedure_date
         , med_claim_exclusions.claim_start_date
         , med_claim_exclusions.claim_end_date
+        , cast(null as date) as procedure_date
     from patients_with_frailty
          inner join med_claim_exclusions
             on patients_with_frailty.patient_id = med_claim_exclusions.patient_id
@@ -166,8 +166,8 @@ with patients_with_frailty as (
             || ' and '
             || condition_exclusions.concept_name
           as exclusion_reason
-        , null as claim_start_date
-        , null as claim_end_date
+        , cast(null as date) as claim_start_date
+        , cast(null as date) as claim_end_date
         , procedure_exclusions.procedure_date
     from patients_with_frailty
          inner join procedure_exclusions
@@ -193,9 +193,9 @@ with patients_with_frailty as (
             || ' and '
             || condition_exclusions.concept_name
           as exclusion_reason
-        , null as procedure_date
         , med_claim_exclusions.claim_start_date
         , med_claim_exclusions.claim_end_date
+        , cast(null as date) as procedure_date
     from patients_with_frailty
          inner join med_claim_exclusions
             on patients_with_frailty.patient_id = med_claim_exclusions.patient_id
@@ -220,8 +220,8 @@ with patients_with_frailty as (
             || ' and '
             || condition_exclusions.concept_name
           as exclusion_reason
-        , null as claim_start_date
-        , null as claim_end_date
+        , cast(null as date) as claim_start_date
+        , cast(null as date) as claim_end_date
         , procedure_exclusions.procedure_date
     from patients_with_frailty
          inner join procedure_exclusions


### PR DESCRIPTION
## Describe your changes
Fixed union logic in new shared exclusion model for advanced illness in Quality Measures mart.

* FIxed order of columns
* Added data type casting for null placeholders


## How has this been tested?
Ran `dbt build --full-refresh` in BiqQuery and Redshift.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have updated the version number in dbt_project.yml file to reflect the release number of this PR
- [ ] I have updated the docs files (by running dbt docs generate/serve and copying the necessary files into the docs folder)
- [ ] I have commented my code as necessary
- [x] I have added at least one Github label to this PR
- [ ] My code follows style guidelines
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
