### PR TITLE
Added tuva prefix to schema name

### DIFF
--- a/models/claims_expanded/_claims_expanded_models.yml
+++ b/models/claims_expanded/_claims_expanded_models.yml
@@ -3,6 +3,8 @@ version: 2
 models:
   - name: medical_claim_expanded
     config:
-      schema: claims_expanded
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_claims_expanded
+        {% else %}claims_expanded{%- endif -%}
       materialized: table
       tags: claims_expanded


### PR DESCRIPTION
## Describe your changes
Claims Expanded is the only schema that is missing the tuva prefix when I run it. 
I reused the code from other models.yml to add it.

## How has this been tested?
I tested it by running it locally. I set the tuva_schema_prefix variable in the main dbt_project.yml.
It correctly prefixed it to the schema name in the output warehouse, in Snowflake. 

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have updated the version number in dbt_project.yml file to reflect the release number of this PR
- [ ] I have updated the docs files (by running dbt docs generate/serve and copying the necessary files into the docs folder)
- [ ] I have commented my code as necessary
- [ ] I have added at least one Github label to this PR
- [ ] My code follows style guidelines
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
