### PR TITLE
BUG: Update date cast macro for Postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ release_notes/
 dbt_packages/
 .mise.toml
 .venv/
+__pycache__/

--- a/integration_tests/macros/try_to_cast_date.sql
+++ b/integration_tests/macros/try_to_cast_date.sql
@@ -30,33 +30,7 @@
 
 {%- macro postgres__try_to_cast_date(column_name, date_format) -%}
 
-    {%- if date_format == 'YYYY-MM-DD' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{4}-[0-9]{2}-[0-9]{2}'
-      then to_date( {{ column_name }}, 'YYYY-MM-DD')
-      else date(NULL)
-    end
-    {%- elif date_format == 'YYYYMMDD' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{4}[0-9]{2}[0-9]{2}'
-      then to_date( {{ column_name }}, 'YYYYMMDD')
-      else date(NULL)
-    end
-    {%- elif date_format == 'MM/DD/YYYY' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{2}/[0-9]{2}/[0-9]{4}'
-      then to_date( {{ column_name }}, 'MM/DD/YYYY')
-      else date(NULL)
-    end
-    {%- elif date_format == 'YYYY-MM-DD HH:MI:SS' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}'
-      then to_date( {{ column_name }}, 'YYYY-MM-DD HH:MI:SS')
-      else date(NULL)
-    end
-    {%- else -%}
-    date(NULL)
-    {%- endif -%}
+    {{ dbt.safe_cast(column_name, api.Column.translate_type("date")).strip() }}
 
 {%- endmacro -%}
 

--- a/macros/try_to_cast_date.sql
+++ b/macros/try_to_cast_date.sql
@@ -30,33 +30,7 @@
 
 {%- macro postgres__try_to_cast_date(column_name, date_format) -%}
 
-    {%- if date_format == 'YYYY-MM-DD' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{4}-[0-9]{2}-[0-9]{2}'
-      then to_date( {{ column_name }}, 'YYYY-MM-DD')
-      else date(NULL)
-    end
-    {%- elif date_format == 'YYYYMMDD' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{4}[0-9]{2}[0-9]{2}'
-      then to_date( {{ column_name }}, 'YYYYMMDD')
-      else date(NULL)
-    end
-    {%- elif date_format == 'MM/DD/YYYY' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{2}/[0-9]{2}/[0-9]{4}'
-      then to_date( {{ column_name }}, 'MM/DD/YYYY')
-      else date(NULL)
-    end
-    {%- elif date_format == 'YYYY-MM-DD HH:MI:SS' -%}
-    case
-      when {{ column_name }} similar to '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}'
-      then to_date( {{ column_name }}, 'YYYY-MM-DD HH:MI:SS')
-      else date(NULL)
-    end
-    {%- else -%}
-    date(NULL)
-    {%- endif -%}
+    {{ dbt.safe_cast(column_name, api.Column.translate_type("date")).strip() }}
 
 {%- endmacro -%}
 


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

In Postgres some date casting functions were failing using the 'try_to_cast_date' macro. For Postgres adapter switched this logic to use `dbt.safe_cast`.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

dbt build 

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3ZkanpwYTVhenFrczZib3JiaTMweGNjMHRlaW9jemFtc25ud2doMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fNfjecL8gJfsv7wP5l/giphy.webp)


## Loom link
