### PR TITLE
Adding ltrim macro

### DIFF
--- a/macros/ltrim.sql
+++ b/macros/ltrim.sql
@@ -1,0 +1,25 @@
+{#
+
+    This macros performs a left trim of a string based on another string. Some databases order these 
+    arguments differently!
+
+#}
+
+{%- macro ltrim(column_name, trimstr) -%}
+
+    {{ return(adapter.dispatch('ltrim')(column_name, trimstr)) }}
+
+{%- endmacro -%}
+
+{%- macro default__ltrim(column_name, trimstr) -%}
+
+    ltrim({{ column_name }}, '{{ trimstr }}')
+
+{%- endmacro -%}
+
+
+{%- macro databricks__ltrim(column_name, trimstr) -%}
+
+    ltrim('{{ trimstr }}', {{ column_name }})
+
+{%- endmacro -%}

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_bill_type_voting.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_bill_type_voting.sql
@@ -12,7 +12,7 @@ with normalize as(
         , bill.bill_type_code
     from {{ ref('normalized_input__stg_medical_claim') }} med
     inner join {{ ref('terminology__bill_type') }} bill
-        on ltrim(med.bill_type_code,'0') = bill.bill_type_code
+        on {{ ltrim('med.bill_type_code', '0') }} = bill.bill_type_code
     where claim_type = 'institutional'
 )
 , distinct_counts as(


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

I added `ltrim.sql` macro which uses adapter.dispatch to pipe in different logic for different databases.  Main reason is that Databricks' LTRIM function arguments are reversed!!
https://learn.microsoft.com/en-us/azure/databricks/sql/language-manual/functions/ltrim

I also updated `normalized_input__int_bill_type_voting.sql` to use this macro.  Confirmed that this is the only model that uses `ltrim` today.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

I performed a `dbt compile` on the above-mentioned model to make sure it was producing correctly formatted query.

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.

Confirm if there are any adapters that have a similar issue

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
