### PR TITLE
Flagging claims with enrollment

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -24,7 +24,7 @@ vars:
   ## The vars directly below enable all models related to the type of healthcare data being used
 
   clinical_enabled: true
- # claims_enabled: true
+  claims_enabled: true
 
 
   ## The vars directly below enable a single data mart.  See the Quickstart

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -60,6 +60,6 @@ inner join claim_year_month claim
     and mm.payer = claim.payer
     and mm.plan = claim.plan
     and mm.year_month >= claim.inferred_claim_start_year_month
-    and mm.year_month <= inferred_claim_end_year_month
+    and mm.year_month <= claim.inferred_claim_end_year_month
 
 

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -38,8 +38,8 @@ with claim_dates as(
         , inferred_claim_end_date
         , inferred_claim_start_column_used
         , inferred_claim_end_column_used
-        , cast(date_part('year', inferred_claim_start_date) as {{ dbt.type_string() }} ) || lpad(cast(date_part('month', inferred_claim_start_date) as {{ dbt.type_string() }} ),2,'0') AS inferred_claim_start_year_month
-        , cast(date_part('year', inferred_claim_end_date) as {{ dbt.type_string() }} ) || lpad(cast(date_part('month', inferred_claim_end_date) as {{ dbt.type_string() }} ),2,'0') AS inferred_claim_end_year_month
+        , cast({{ date_part("year", "inferred_claim_start_date")}} as {{ dbt.type_string() }} ) || lpad(cast({{ date_part("month", "inferred_claim_start_date")}} as {{ dbt.type_string() }} ),2,'0') AS inferred_claim_start_year_month
+        , cast({{ date_part("year", "inferred_claim_end_date")}} as {{ dbt.type_string() }} ) || lpad(cast({{ date_part("month", "inferred_claim_end_date")}} as {{ dbt.type_string() }} ),2,'0') AS inferred_claim_end_year_month
     from claim_dates
 
 )

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -1,3 +1,9 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
+   )
+}}
+
 
 with claim_dates as(
     select
@@ -47,6 +53,7 @@ select
     , claim.inferred_claim_end_year_month
     , claim.inferred_claim_start_column_used
     , claim.inferred_claim_end_column_used
+    , cast('{{ var('tuva_last_run')}}' as {{ dbt.type_timestamp() }} ) as tuva_last_run
 from {{ ref('core__member_months')}} mm
 inner join claim_year_month claim
     on mm.patient_id = claim.patient_id

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -1,0 +1,58 @@
+
+with claim_dates as(
+    select
+        cast(claim_id as {{ dbt.type_string() }} )|| '-' ||cast(claim_line_number as {{ dbt.type_string() }} ) as medical_claim_id
+        , patient_id
+        , payer
+        , plan
+        , coalesce(claim_start_date, admission_date, claim_end_date, discharge_date) as inferred_claim_start_date
+        , coalesce(claim_end_date, discharge_date, claim_start_date, admission_date) as inferred_claim_end_date
+        , case
+            when claim_start_date is not null then 'claim_start_date'
+            when claim_start_date is null and admission_date is not null then 'admission_date'
+            when claim_start_date is null and admission_date is null and claim_end_date is not null then 'claim_end_date'
+            when claim_start_date is null and admission_date is null and claim_end_date is null and discharge_date is not null then 'discharge_date'
+        end as inferred_claim_start_column_used
+        , case
+            when claim_end_date is not null then 'claim_end_date'
+            when claim_end_date is null and discharge_date is not null then 'discharge_date'
+            when claim_end_date is null and discharge_date is null and claim_start_date is not null then 'claim_start_date'
+            when claim_end_date is null and discharge_date is null and claim_start_date is null and admission_date is not null then 'admission_date'
+        end as inferred_claim_end_column_used
+    from {{ ref('normalized_input__medical_claim')}}
+)
+
+, claim_year_month as(
+    select
+        medical_claim_id
+        , patient_id
+        , payer
+        , plan
+        , inferred_claim_start_date
+        , inferred_claim_end_date
+        , inferred_claim_start_column_used
+        , inferred_claim_end_column_used
+        , cast(date_part('year', inferred_claim_start_date) as TEXT ) || lpad(cast(date_part('month', inferred_claim_start_date) as TEXT ),2,'0') AS inferred_claim_start_year_month
+        , cast(date_part('year', inferred_claim_end_date) as TEXT ) || lpad(cast(date_part('month', inferred_claim_end_date) as TEXT ),2,'0') AS inferred_claim_end_year_month
+    from claim_dates
+
+)
+
+select
+    claim.medical_claim_id
+    , claim.patient_id
+    , claim.payer
+    , claim.plan
+    , claim.inferred_claim_start_year_month
+    , claim.inferred_claim_end_year_month
+    , claim.inferred_claim_start_column_used
+    , claim.inferred_claim_end_column_used
+from {{ ref('core__member_months')}} mm
+inner join claim_year_month claim
+    on mm.patient_id = claim.patient_id
+    and mm.payer = claim.payer
+    and mm.plan = claim.plan
+    and mm.year_month >= claim.inferred_claim_start_year_month
+    and mm.year_month <= inferred_claim_end_year_month
+
+

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -38,13 +38,13 @@ with claim_dates as(
         , inferred_claim_end_date
         , inferred_claim_start_column_used
         , inferred_claim_end_column_used
-        , cast(date_part('year', inferred_claim_start_date) as TEXT ) || lpad(cast(date_part('month', inferred_claim_start_date) as TEXT ),2,'0') AS inferred_claim_start_year_month
-        , cast(date_part('year', inferred_claim_end_date) as TEXT ) || lpad(cast(date_part('month', inferred_claim_end_date) as TEXT ),2,'0') AS inferred_claim_end_year_month
+        , cast(date_part('year', inferred_claim_start_date) as {{ dbt.type_string() }} ) || lpad(cast(date_part('month', inferred_claim_start_date) as {{ dbt.type_string() }} ),2,'0') AS inferred_claim_start_year_month
+        , cast(date_part('year', inferred_claim_end_date) as {{ dbt.type_string() }} ) || lpad(cast(date_part('month', inferred_claim_end_date) as {{ dbt.type_string() }} ),2,'0') AS inferred_claim_end_year_month
     from claim_dates
 
 )
 
-select
+select distinct
     claim.medical_claim_id
     , claim.patient_id
     , claim.payer

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -11,19 +11,17 @@ with claim_dates as(
         , patient_id
         , payer
         , plan
-        , coalesce(claim_start_date, admission_date, claim_end_date, discharge_date) as inferred_claim_start_date
-        , coalesce(claim_end_date, discharge_date, claim_start_date, admission_date) as inferred_claim_end_date
+        , coalesce(claim_line_start_date, claim_start_date, admission_date) as inferred_claim_start_date
+        , coalesce(claim_line_end_date, claim_end_date, discharge_date) as inferred_claim_end_date
         , case
-            when claim_start_date is not null then 'claim_start_date'
-            when claim_start_date is null and admission_date is not null then 'admission_date'
-            when claim_start_date is null and admission_date is null and claim_end_date is not null then 'claim_end_date'
-            when claim_start_date is null and admission_date is null and claim_end_date is null and discharge_date is not null then 'discharge_date'
+            when claim_line_start_date is not null then 'claim_line_start_date'
+            when claim_line_start_date is null and claim_start_date is not null then 'claim_start_date'
+            when claim_line_start_date is null and claim_start_date is null and admission_date is not null then 'admission_date'
         end as inferred_claim_start_column_used
         , case
-            when claim_end_date is not null then 'claim_end_date'
-            when claim_end_date is null and discharge_date is not null then 'discharge_date'
-            when claim_end_date is null and discharge_date is null and claim_start_date is not null then 'claim_start_date'
-            when claim_end_date is null and discharge_date is null and claim_start_date is null and admission_date is not null then 'admission_date'
+            when claim_line_end_date is not null then 'claim_line_end_date'
+            when claim_line_end_date is null and claim_end_date is not null then 'claim_end_date'
+            when claim_line_end_date is null and claim_end_date is null and discharge_date is not null then 'discharge_date'
         end as inferred_claim_end_column_used
     from {{ ref('normalized_input__medical_claim')}}
 )

--- a/models/claims_preprocessing/claims_preprocessing_models.yml
+++ b/models/claims_preprocessing/claims_preprocessing_models.yml
@@ -259,12 +259,12 @@ models:
         description: Name of the plan.
       - name: inferred_claim_start_year_month
         description: |
-          The claim start date year and month.  If claims start date is missing then the following column will be used, 
-          in the following order if also NULL:  admission date, claim end date, discharge date
+          The claim start date year and month.  If claim line start date is missing then the following column will be used, 
+          in the following order if also NULL:  claim start date, admission date
       - name: inferred_claim_end_year_month
         description: |
-          The claim end date year and month.  If claims end date is missing then the following column will be used, 
-          in the following order if also NULL:  discharge date, claim start date, admission date
+          The claim end date year and month.  If claim line end date is missing then the following column will be used, 
+          in the following order if also NULL:  claim end date, discharge date
       - name: inferred_claim_start_column_used
         description: The name of the column used to populated inferred_claim_start_year_month.
       - name: inferred_claim_end_column_used

--- a/models/claims_preprocessing/claims_preprocessing_models.yml
+++ b/models/claims_preprocessing/claims_preprocessing_models.yml
@@ -236,6 +236,41 @@ models:
         - claims_preprocessing
       materialized: ephemeral
 
+#### Claims Enrollment
+## Final
+  - name: claims_enrollment__flag_claims_with_enrollment
+    description: This table contains claims with matching enrollment
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_claims_preprocessing
+        {% else %}claims_preprocessing{%- endif -%}
+      alias: flag_claims_with_enrollment
+      tags:
+        - claims_preprocessing
+      materialized: table
+    columns:
+      - name: medical_claim_id
+        description: Unique identifier for the medical claim.
+      - name: patient_id
+        description: Unique identifier for each patient in the dataset.
+      - name: payer
+        description: Name of the payer.
+      - name: plan
+        description: Name of the plan.
+      - name: inferred_claim_start_year_month
+        description: |
+          The claim start date year and month.  If claims start date is missing then the following column will be used, 
+          in the following order if also NULL:  admission date, claim end date, discharge date
+      - name: inferred_claim_end_year_month
+        description: |
+          The claim end date year and month.  If claims end date is missing then the following column will be used, 
+          in the following order if also NULL:  discharge date, claim start date, admission date
+      - name: inferred_claim_start_column_used
+        description: The name of the column used to populated inferred_claim_start_year_month.
+      - name: inferred_claim_end_column_used
+        description: The name of the column used to populated inferred_claim_start_column_used.
+
+
 #### Emergency Department
 ## Final
 

--- a/models/core/final/core__member_months.sql
+++ b/models/core/final/core__member_months.sql
@@ -4,21 +4,21 @@
 }}
 
 with month_start_and_end_dates as (
-select 
-  concat(cast(year as {{ dbt.type_string() }} ),lpad(cast(month as {{ dbt.type_string() }}),2,'0')) as year_month
-, min(full_date) as month_start_date
-, max(full_date) as month_end_date
-from {{ ref('reference_data__calendar')}}
-group by 1
+  select
+      concat(cast(year as {{ dbt.type_string() }} ),lpad(cast(month as {{ dbt.type_string() }}),2,'0')) as year_month
+    , min(full_date) as month_start_date
+    , max(full_date) as month_end_date
+  from {{ ref('reference_data__calendar')}}
+  group by 1
 )
 
 select distinct
-  a.patient_id
-, year_month
-, a.payer
-, a.plan
-, data_source
-, '{{ var('tuva_last_run')}}' as tuva_last_run
+    a.patient_id
+  , year_month
+  , a.payer
+  , a.plan
+  , data_source
+  , '{{ var('tuva_last_run')}}' as tuva_last_run
 from {{ ref('core__eligibility') }} a
 inner join month_start_and_end_dates b
   on a.enrollment_start_date <= b.month_end_date

--- a/models/core/staging/core__stg_claims_encounter.sql
+++ b/models/core/staging/core__stg_claims_encounter.sql
@@ -56,7 +56,7 @@ select
     , cast(discharge_disposition_code as {{ dbt.type_string() }} ) as discharge_disposition_code
     , cast(discharge_disposition_description as {{ dbt.type_string() }} ) as discharge_disposition_description
     , cast(null as {{ dbt.type_string() }} ) as attending_provider_id
-, cast(null as {{ dbt.type_string() }} ) as attending_provider_name
+    , cast(null as {{ dbt.type_string() }} ) as attending_provider_name
     , cast(facility_id as {{ dbt.type_string() }} ) as facility_id
     , cast(facility_name as {{ dbt.type_string() }} ) as facility_name
     , cast(primary_diagnosis_code_type as {{ dbt.type_string() }} ) as primary_diagnosis_code_type

--- a/models/core/staging/core__stg_claims_medical_claim.sql
+++ b/models/core/staging/core__stg_claims_medical_claim.sql
@@ -14,12 +14,81 @@
 --      service_category_2
 -- *************************************************
 
-
+with medical_claim_stage as(
+    select
+        cast(med.claim_id as {{ dbt.type_string() }} )|| '-' ||cast(med.claim_line_number as {{ dbt.type_string() }} ) as medical_claim_id
+        , cast(med.claim_id as {{ dbt.type_string() }} ) as claim_id
+        , cast(med.claim_line_number as {{ dbt.type_int() }} ) as claim_line_number
+        , cast(coalesce(ap.encounter_id,ed.encounter_id) as {{ dbt.type_string() }} ) as encounter_id
+        , cast(med.claim_type as {{ dbt.type_string() }} ) as claim_type
+        , cast(med.patient_id as {{ dbt.type_string() }} ) as patient_id
+        , cast(med.member_id as {{ dbt.type_string() }} ) as member_id
+        , cast(med.payer as {{ dbt.type_string() }} ) as payer
+        , cast(med.plan as {{ dbt.type_string() }} ) as plan
+        , {{ try_to_cast_date('med.claim_start_date', 'YYYY-MM-DD') }} as claim_start_date
+        , {{ try_to_cast_date('med.claim_end_date', 'YYYY-MM-DD') }} as claim_end_date
+        , {{ try_to_cast_date('med.claim_line_start_date', 'YYYY-MM-DD') }} as claim_line_start_date
+        , {{ try_to_cast_date('med.claim_line_end_date', 'YYYY-MM-DD') }} as claim_line_end_date
+        , {{ try_to_cast_date('med.admission_date', 'YYYY-MM-DD') }} as admission_date
+        , {{ try_to_cast_date('med.discharge_date', 'YYYY-MM-DD') }} as discharge_date
+        , cast(srv_group.service_category_1 as {{ dbt.type_string() }} ) as service_category_1
+        , cast(srv_group.service_category_2 as {{ dbt.type_string() }} ) as service_category_2
+        , cast(med.admit_source_code as {{ dbt.type_string() }} ) as admit_source_code
+        , cast(med.admit_source_description as {{ dbt.type_string() }} ) as admit_source_description
+        , cast(med.admit_type_code as {{ dbt.type_string() }} ) as admit_type_code
+        , cast(med.admit_type_description as {{ dbt.type_string() }} ) as admit_type_description
+        , cast(med.discharge_disposition_code as {{ dbt.type_string() }} ) as discharge_disposition_code
+        , cast(med.discharge_disposition_description as {{ dbt.type_string() }} ) as discharge_disposition_description
+        , cast(med.place_of_service_code as {{ dbt.type_string() }} ) as place_of_service_code
+        , cast(med.place_of_service_description as {{ dbt.type_string() }} ) as place_of_service_description
+        , cast(med.bill_type_code as {{ dbt.type_string() }} ) as bill_type_code
+        , cast(med.bill_type_description as {{ dbt.type_string() }} ) as bill_type_description
+        , cast(med.ms_drg_code as {{ dbt.type_string() }} ) as ms_drg_code
+        , cast(med.ms_drg_description as {{ dbt.type_string() }} ) as ms_drg_description
+        , cast(med.apr_drg_code as {{ dbt.type_string() }} ) as apr_drg_code
+        , cast(med.apr_drg_description as {{ dbt.type_string() }} ) as apr_drg_description
+        , cast(med.revenue_center_code as {{ dbt.type_string() }} ) as revenue_center_code
+        , cast(med.revenue_center_description as {{ dbt.type_string() }} ) as revenue_center_description
+        , cast(med.service_unit_quantity as {{ dbt.type_numeric() }} ) as service_unit_quantity
+        , cast(med.hcpcs_code as {{ dbt.type_string() }} ) as hcpcs_code
+        , cast(med.hcpcs_modifier_1 as {{ dbt.type_string() }} ) as hcpcs_modifier_1
+        , cast(med.hcpcs_modifier_2 as {{ dbt.type_string() }} ) as hcpcs_modifier_2
+        , cast(med.hcpcs_modifier_3 as {{ dbt.type_string() }} ) as hcpcs_modifier_3
+        , cast(med.hcpcs_modifier_4 as {{ dbt.type_string() }} ) as hcpcs_modifier_4
+        , cast(med.hcpcs_modifier_5 as {{ dbt.type_string() }} ) as hcpcs_modifier_5
+        , cast(med.rendering_id as {{ dbt.type_string() }} ) as rendering_id
+        , cast(med.rendering_name as {{ dbt.type_string() }} ) as rendering_name
+        , cast(med.billing_id as {{ dbt.type_string() }} ) as billing_id
+        , cast(med.billing_name as {{ dbt.type_string() }} ) as billing_name
+        , cast(med.facility_id as {{ dbt.type_string() }} ) as facility_id
+        , cast(med.facility_name as {{ dbt.type_string() }} ) as facility_name
+        , {{ try_to_cast_date('med.paid_date', 'YYYY-MM-DD') }} as paid_date
+        , cast(med.paid_amount as {{ dbt.type_numeric() }} ) as paid_amount
+        , cast(med.allowed_amount as {{ dbt.type_numeric() }} ) as allowed_amount
+        , cast(med.charge_amount as {{ dbt.type_numeric() }} ) as charge_amount
+        , cast(med.coinsurance_amount as {{ dbt.type_numeric() }} ) as coinsurance_amount
+        , cast(med.copayment_amount as {{ dbt.type_numeric() }} ) as copayment_amount
+        , cast(med.deductible_amount as {{ dbt.type_numeric() }} ) as deductible_amount
+        , cast(med.total_cost_amount as {{ dbt.type_numeric() }} ) as total_cost_amount
+        , cast(med.in_network_flag as int ) as in_network_flag
+        , cast(med.data_source as {{ dbt.type_string() }} ) as data_source
+        , cast('{{ var('tuva_last_run')}}' as {{ dbt.type_timestamp() }} ) as tuva_last_run
+    from {{ ref('normalized_input__medical_claim') }} med
+    left join {{ ref('service_category__service_category_grouper') }} srv_group
+        on med.claim_id = srv_group.claim_id
+        and med.claim_line_number = srv_group.claim_line_number
+    left join {{ ref('acute_inpatient__encounter_id') }} ap
+        on med.claim_id = ap.claim_id
+        and med.claim_line_number = ap.claim_line_number
+    left join {{ ref('emergency_department__int_encounter_id') }} ed
+        on med.claim_id = ed.claim_id
+        and med.claim_line_number = ed.claim_line_number
+)
 select
-    cast(med.claim_id as {{ dbt.type_string() }} )|| '-' ||cast(med.claim_line_number as {{ dbt.type_string() }} ) as medical_claim_id
+    cast(med.medical_claim_id as {{ dbt.type_string() }} ) as medical_claim_id
     , cast(med.claim_id as {{ dbt.type_string() }} ) as claim_id
     , cast(med.claim_line_number as {{ dbt.type_int() }} ) as claim_line_number
-    , cast(coalesce(ap.encounter_id,ed.encounter_id) as {{ dbt.type_string() }} ) as encounter_id 
+    , cast(encounter_id as {{ dbt.type_string() }} ) as encounter_id
     , cast(med.claim_type as {{ dbt.type_string() }} ) as claim_type
     , cast(med.patient_id as {{ dbt.type_string() }} ) as patient_id
     , cast(med.member_id as {{ dbt.type_string() }} ) as member_id
@@ -31,8 +100,8 @@ select
     , {{ try_to_cast_date('med.claim_line_end_date', 'YYYY-MM-DD') }} as claim_line_end_date
     , {{ try_to_cast_date('med.admission_date', 'YYYY-MM-DD') }} as admission_date
     , {{ try_to_cast_date('med.discharge_date', 'YYYY-MM-DD') }} as discharge_date
-    , cast(srv_group.service_category_1 as {{ dbt.type_string() }} ) as service_category_1
-    , cast(srv_group.service_category_2 as {{ dbt.type_string() }} ) as service_category_2
+    , cast(service_category_1 as {{ dbt.type_string() }} ) as service_category_1
+    , cast(service_category_2 as {{ dbt.type_string() }} ) as service_category_2
     , cast(med.admit_source_code as {{ dbt.type_string() }} ) as admit_source_code
     , cast(med.admit_source_description as {{ dbt.type_string() }} ) as admit_source_description
     , cast(med.admit_type_code as {{ dbt.type_string() }} ) as admit_type_code
@@ -71,15 +140,14 @@ select
     , cast(med.deductible_amount as {{ dbt.type_numeric() }} ) as deductible_amount
     , cast(med.total_cost_amount as {{ dbt.type_numeric() }} ) as total_cost_amount
     , cast(med.in_network_flag as int ) as in_network_flag
+    , cast(
+        case
+            when enroll.medical_claim_id is not null then 1
+                else 0
+        end as int) as enrollment_flag
     , cast(med.data_source as {{ dbt.type_string() }} ) as data_source
-    , cast('{{ var('tuva_last_run')}}' as {{ dbt.type_timestamp() }} ) as tuva_last_run
-from {{ ref('normalized_input__medical_claim') }} med
-left join {{ ref('service_category__service_category_grouper') }} srv_group
-    on med.claim_id = srv_group.claim_id
-    and med.claim_line_number = srv_group.claim_line_number
-left join {{ ref('acute_inpatient__encounter_id') }} ap
-    on med.claim_id = ap.claim_id
-    and med.claim_line_number = ap.claim_line_number
-left join {{ ref('emergency_department__int_encounter_id') }} ed
-    on med.claim_id = ed.claim_id
-    and med.claim_line_number = ed.claim_line_number
+    , cast(tuva_last_run as {{ dbt.type_timestamp() }} ) as tuva_last_run
+from medical_claim_stage med
+left join {{ ref('claims_enrollment__flag_claims_with_enrollment') }} enroll
+    on med.medical_claim_id = enroll.medical_claim_id
+

--- a/models/core/staging/core__stg_claims_medical_claim.sql
+++ b/models/core/staging/core__stg_claims_medical_claim.sql
@@ -88,7 +88,7 @@ select
     cast(med.medical_claim_id as {{ dbt.type_string() }} ) as medical_claim_id
     , cast(med.claim_id as {{ dbt.type_string() }} ) as claim_id
     , cast(med.claim_line_number as {{ dbt.type_int() }} ) as claim_line_number
-    , cast(encounter_id as {{ dbt.type_string() }} ) as encounter_id
+    , cast(med.encounter_id as {{ dbt.type_string() }} ) as encounter_id
     , cast(med.claim_type as {{ dbt.type_string() }} ) as claim_type
     , cast(med.patient_id as {{ dbt.type_string() }} ) as patient_id
     , cast(med.member_id as {{ dbt.type_string() }} ) as member_id
@@ -100,8 +100,8 @@ select
     , {{ try_to_cast_date('med.claim_line_end_date', 'YYYY-MM-DD') }} as claim_line_end_date
     , {{ try_to_cast_date('med.admission_date', 'YYYY-MM-DD') }} as admission_date
     , {{ try_to_cast_date('med.discharge_date', 'YYYY-MM-DD') }} as discharge_date
-    , cast(service_category_1 as {{ dbt.type_string() }} ) as service_category_1
-    , cast(service_category_2 as {{ dbt.type_string() }} ) as service_category_2
+    , cast(med.service_category_1 as {{ dbt.type_string() }} ) as service_category_1
+    , cast(med.service_category_2 as {{ dbt.type_string() }} ) as service_category_2
     , cast(med.admit_source_code as {{ dbt.type_string() }} ) as admit_source_code
     , cast(med.admit_source_description as {{ dbt.type_string() }} ) as admit_source_description
     , cast(med.admit_type_code as {{ dbt.type_string() }} ) as admit_type_code
@@ -146,7 +146,7 @@ select
                 else 0
         end as int) as enrollment_flag
     , cast(med.data_source as {{ dbt.type_string() }} ) as data_source
-    , cast(tuva_last_run as {{ dbt.type_timestamp() }} ) as tuva_last_run
+    , cast(med.tuva_last_run as {{ dbt.type_timestamp() }} ) as tuva_last_run
 from medical_claim_stage med
 left join {{ ref('claims_enrollment__flag_claims_with_enrollment') }} enroll
     on med.medical_claim_id = enroll.medical_claim_id


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
- Added model to flag claims that have corresponding enrollment during the same time period the service occurred
- Added flag to core.medical_claims

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
- local dbt build
- CI testing

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
Review the logic and confirm:
1. Should we infer the claims start date with claim_start_date is missing?  (and claim_end_date)
2. Do we require the whole claim to occur during a valid period of enrollment or just the claim_end_date?

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [x] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [x] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [x] (New models) I have added the variable `tuva_last_run` to the final output
- [x] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
https://www.loom.com/share/258ac5998b6f46aba8ad98de3dc97e79?sid=98b4cc08-d827-43f4-9a8a-07011330ad56