### PR TITLE
bug fix for multiple org names in one encounter

### DIFF
--- a/models/claims_preprocessing/acute_inpatient/final/acute_inpatient__summary.sql
+++ b/models/claims_preprocessing/acute_inpatient/final/acute_inpatient__summary.sql
@@ -77,14 +77,11 @@ group by 1
 
 , facility as (
     select
-        a.encounter_id
+          a.encounter_id
         , max(a.facility_id) as facility_id
-        , b.provider_organization_name
         , count(distinct facility_id) as npi_count
-    from {{ ref('acute_inpatient__institutional_encounter_id') }} a
-    left join {{ ref('terminology__provider') }} b
-    on a.facility_id = b.npi
-    group by 1,3
+    from {{ ref('emergency_department__int_institutional_encounter_id') }} a
+    group by a.encounter_id
 )
 
 select
@@ -99,7 +96,7 @@ select
 , c.diagnosis_code_1 as primary_diagnosis_code
 , coalesce(icd10cm.long_description, icd9cm.long_description) as primary_diagnosis_description
 , f.facility_id as facility_id
-, f.provider_organization_name as facility_name
+, b.provider_organization_name as facility_name
 , c.ms_drg_code
 , j.ms_drg_description
 , j.medical_surgical
@@ -130,6 +127,8 @@ left join patient e
   on a.patient_id = e.patient_id
 left join facility f
   on a.encounter_id = f.encounter_id
+left join {{ ref('terminology__provider') }} b
+  on f.facility_id = b.npi
 left join {{ ref('terminology__discharge_disposition') }} g
   on c.discharge_disposition_code = g.discharge_disposition_code
 left join {{ ref('terminology__admit_source') }} h

--- a/models/claims_preprocessing/acute_inpatient/final/acute_inpatient__summary.sql
+++ b/models/claims_preprocessing/acute_inpatient/final/acute_inpatient__summary.sql
@@ -80,7 +80,7 @@ group by 1
           a.encounter_id
         , max(a.facility_id) as facility_id
         , count(distinct facility_id) as npi_count
-    from {{ ref('emergency_department__int_institutional_encounter_id') }} a
+    from {{ ref('acute_inpatient__institutional_encounter_id') }} a
     group by a.encounter_id
 )
 

--- a/models/claims_preprocessing/emergency_department/final/emergency_department__summary.sql
+++ b/models/claims_preprocessing/emergency_department/final/emergency_department__summary.sql
@@ -80,12 +80,9 @@ with distinct_encounters as (
     select
           a.encounter_id
         , max(a.facility_id) as facility_id
-        , b.provider_organization_name
         , count(distinct facility_id) as npi_count
     from {{ ref('emergency_department__int_institutional_encounter_id') }} a
-    left join {{ ref('terminology__provider') }} b
-      on a.facility_id = b.npi
-    group by 1,3
+    group by a.encounter_id
 )
 
 select
@@ -100,7 +97,7 @@ select
     , c.diagnosis_code_1 as primary_diagnosis_code
     , coalesce(icd10cm.long_description, icd9cm.long_description) as primary_diagnosis_description
     , f.facility_id
-    , f.provider_organization_name as facility_name
+    , b.provider_organization_name as facility_name
     , c.ms_drg_code
     , j.ms_drg_description
     , j.medical_surgical
@@ -131,6 +128,8 @@ left join patient e
   on a.patient_id = e.patient_id
 left join facility f
   on a.encounter_id = f.encounter_id
+left join {{ ref('terminology__provider') }} b
+  on f.facility_id = b.npi
 left join {{ ref('terminology__discharge_disposition') }} g
   on c.discharge_disposition_code = g.discharge_disposition_code
 left join {{ ref('terminology__admit_source') }} h


### PR DESCRIPTION
## Describe your changes
bug in encounter definitions for ed/inpatient causing duplicate encounter IDs. 


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
ran on lds five percent dataset which no longer has the duplicate encounters.
ci testing

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
