### PR TITLE
Databricks load seed syntax fix

### DIFF
--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -179,8 +179,8 @@ FROM (
   {% if env_var('AWS_SESSION_TOKEN', False) %}
   WITH (
     CREDENTIAL (
-      AWS_ACCESS_KEY = "{{ env_var('AWS_ACCESS_KEY') }}",
-      AWS_SECRET_KEY = "{{ env_var('AWS_SECRET_KEY') }}",
+      AWS_ACCESS_KEY = "{{ env_var('AWS_ACCESS_KEY_ID') }}",
+      AWS_SECRET_KEY = "{{ env_var('AWS_SECRET_ACCESS_KEY') }}",
       AWS_SESSION_TOKEN = "{{ env_var('AWS_SESSION_TOKEN') }}"
     )
   )


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
- Edited the load_seed.sql macro.  Changed the databricks code to use the default syntax that Amazon uses when setting up credentials

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
- Confirmed the changes help resolve a permissions issue.

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
n/a

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
