### PR TITLE
Quality measure syntax fix

### DIFF
--- a/macros/try_to_cast_date.sql
+++ b/macros/try_to_cast_date.sql
@@ -71,3 +71,10 @@
     try_cast( {{ column_name }} as date )
 
 {%- endmacro -%}
+
+{%- macro athena__try_to_cast_date(column_name, date_format) -%}
+    (case
+        when typeof({{ column_name }}) = 'date' then date({{ column_name }})
+        else try_cast(substring(try_cast({{ column_name }} as varchar), 1, 10) as date)
+    end)
+{%- endmacro -%}

--- a/models/data_quality/final/data_quality__quality_trend.sql
+++ b/models/data_quality/final/data_quality__quality_trend.sql
@@ -5,14 +5,14 @@
 
 
 with cte as (
-select {{ try_to_cast_date('substring(d.source_date,1,10)' ) }} as source_date_type
+select {{ try_to_cast_date('d.source_date' ) }} as source_date_type
     ,summary_sk
     ,SUM(CASE WHEN BUCKET_NAME = 'valid' THEN 1 ELSE 0 END) as VALID_NUM
     ,SUM(CASE WHEN BUCKET_NAME <> 'null' THEN 1 ELSE 0 END) as FILL_NUM
     ,COUNT(DRILL_DOWN_VALUE) as DENOM
 from {{ ref('data_quality__data_quality_detail') }} d
 group by
-    {{ try_to_cast_date('substring(d.source_date,1,10)' ) }}
+    {{ try_to_cast_date('d.source_date') }}
     ,summary_sk
 
 )

--- a/models/data_quality/final/data_quality__quality_trend.sql
+++ b/models/data_quality/final/data_quality__quality_trend.sql
@@ -11,7 +11,7 @@ select d.source_date as source_date_type
     ,COUNT(DRILL_DOWN_VALUE) as DENOM
 from {{ ref('data_quality__data_quality_detail') }} d
 group by
-    source_date_type
+    d.source_date
     ,summary_sk
 
 )

--- a/models/data_quality/final/data_quality__quality_trend.sql
+++ b/models/data_quality/final/data_quality__quality_trend.sql
@@ -24,7 +24,7 @@ select
     , sum(FILL_NUM) as FILL_NUM
     , sum(DENOM)  as DENOM
 from cte
-left join {{ ref('terminology__dqi_calendar') }} c on cte.source_date_type = c.full_date
+left join {{ ref('reference_data__calendar') }} c on cte.source_date_type = c.full_date
 group by
       c.first_day_of_month
     , summary_sk

--- a/models/data_quality/final/data_quality__quality_trend.sql
+++ b/models/data_quality/final/data_quality__quality_trend.sql
@@ -3,15 +3,16 @@
    )
 }}
 
+
 with cte as (
-select d.source_date as source_date_type
+select {{ try_to_cast_date('substring(d.source_date,1,10)' ) }} as source_date_type
     ,summary_sk
     ,SUM(CASE WHEN BUCKET_NAME = 'valid' THEN 1 ELSE 0 END) as VALID_NUM
     ,SUM(CASE WHEN BUCKET_NAME <> 'null' THEN 1 ELSE 0 END) as FILL_NUM
     ,COUNT(DRILL_DOWN_VALUE) as DENOM
 from {{ ref('data_quality__data_quality_detail') }} d
 group by
-    d.source_date
+    {{ try_to_cast_date('substring(d.source_date,1,10)' ) }}
     ,summary_sk
 
 )
@@ -22,9 +23,9 @@ select
     , sum(VALID_NUM) as VALID_NUM
     , sum(FILL_NUM) as FILL_NUM
     , sum(DENOM)  as DENOM
-    , '{{ var('tuva_last_run')}}' as tuva_last_run
 from cte
-left join {{ ref('reference_data__calendar') }} c on cte.source_date_type = c.full_date
+left join {{ ref('terminology__dqi_calendar') }} c on cte.source_date_type = c.full_date
 group by
       c.first_day_of_month
     , summary_sk
+

--- a/models/data_quality/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_death_flag.sql
+++ b/models/data_quality/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_death_flag.sql
@@ -11,7 +11,7 @@ SELECT DISTINCT
     ,'ELIGIBILITY' AS CLAIM_TYPE
     ,'DEATH_FLAG' AS FIELD_NAME
     ,CASE
-        WHEN M.DEATH_FLAG in (1,0) THEN 'valid'
+        WHEN M.DEATH_FLAG in ('1','0') THEN 'valid'
         WHEN M.DEATH_FLAG is null then 'null'
         ELSE 'invalid'
         END AS BUCKET_NAME

--- a/models/data_quality/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_death_flag.sql
+++ b/models/data_quality/intermediate/atomic_checks/claims/eligibility/data_quality__eligibility_death_flag.sql
@@ -11,7 +11,7 @@ SELECT DISTINCT
     ,'ELIGIBILITY' AS CLAIM_TYPE
     ,'DEATH_FLAG' AS FIELD_NAME
     ,CASE
-        WHEN M.DEATH_FLAG in ('1','0') THEN 'valid'
+        WHEN M.DEATH_FLAG in (1,0) THEN 'valid'
         WHEN M.DEATH_FLAG is null then 'null'
         ELSE 'invalid'
         END AS BUCKET_NAME

--- a/models/data_quality/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_ms_drg_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_ms_drg_description.sql
@@ -12,6 +12,6 @@ SELECT
     ,'MS_DRG_DESCRIPTION' AS FIELD_NAME
     ,case when M.MS_DRG_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
     ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-    ,CAST(LEFT(MS_DRG_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+    ,CAST(SUBSTRING(MS_DRG_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }})
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 FROM {{ ref('encounter')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_ms_drg_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_ms_drg_description.sql
@@ -12,6 +12,6 @@ SELECT
     ,'MS_DRG_DESCRIPTION' AS FIELD_NAME
     ,case when M.MS_DRG_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
     ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-    ,CAST(SUBSTRING(MS_DRG_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }})
+    ,CAST(SUBSTRING(MS_DRG_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) as FIELD_VALUE
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 FROM {{ ref('encounter')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_primary_diagnosis_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_primary_diagnosis_description.sql
@@ -12,6 +12,6 @@ SELECT
     ,'PRIMARY_DIAGNOSIS_DESCRIPTION' AS FIELD_NAME
     ,case when M.PRIMARY_DIAGNOSIS_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
     ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-    ,CAST(LEFT(PRIMARY_DIAGNOSIS_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+    ,CAST(SUBSTRING(PRIMARY_DIAGNOSIS_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 FROM {{ ref('encounter')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/lab_result/data_quality__lab_result_normalized_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/lab_result/data_quality__lab_result_normalized_description.sql
@@ -13,6 +13,6 @@
                 ,'NORMALIZED_DESCRIPTION' AS FIELD_NAME
                 ,case when M.NORMALIZED_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(NORMALIZED_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(NORMALIZED_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('lab_result')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/lab_result/data_quality__lab_result_source_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/lab_result/data_quality__lab_result_source_description.sql
@@ -13,6 +13,6 @@
                 ,'SOURCE_DESCRIPTION' AS FIELD_NAME
                 ,case when M.SOURCE_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(SOURCE_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(SOURCE_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('lab_result')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_atc_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_atc_description.sql
@@ -13,6 +13,6 @@
                 ,'ATC_DESCRIPTION' AS FIELD_NAME
                 ,case when M.ATC_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(ATC_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(ATC_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('medication')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_ndc_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_ndc_description.sql
@@ -18,7 +18,7 @@ SELECT
     ,case when M.NDC_CODE is not null and TERM.NDC is null
           then 'NDC code type does not join to Terminology ndc table'
     else null end as INVALID_REASON
-    ,CAST(LEFT(NDC_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+    ,CAST(SUBSTRING(NDC_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 FROM {{ ref('medication')}} M
 LEFT JOIN {{ ref('terminology__ndc')}} TERM on M.NDC_CODE = TERM.NDC

--- a/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_rxnorm_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_rxnorm_description.sql
@@ -13,6 +13,6 @@
                 ,'RXNORM_DESCRIPTION' AS FIELD_NAME
                 ,case when M.RXNORM_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(RXNORM_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(RXNORM_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('medication')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_source_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/medication/data_quality__medication_source_description.sql
@@ -13,6 +13,6 @@
                 ,'SOURCE_DESCRIPTION' AS FIELD_NAME
                 ,case when M.SOURCE_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(SOURCE_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(SOURCE_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('medication')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/observation/data_quality__observation_normalized_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/observation/data_quality__observation_normalized_description.sql
@@ -13,6 +13,6 @@
                 ,'NORMALIZED_DESCRIPTION' AS FIELD_NAME
                 ,case when M.NORMALIZED_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(NORMALIZED_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(NORMALIZED_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('observation')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/observation/data_quality__observation_result.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/observation/data_quality__observation_result.sql
@@ -13,6 +13,6 @@
                 ,'RESULT' AS FIELD_NAME
                 ,case when M.RESULT is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(RESULT, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(RESULT, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('observation')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/observation/data_quality__observation_source_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/observation/data_quality__observation_source_description.sql
@@ -13,6 +13,6 @@
                 ,'SOURCE_DESCRIPTION' AS FIELD_NAME
                 ,case when M.SOURCE_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(SOURCE_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(SOURCE_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('observation')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/procedure/data_quality__procedure_normalized_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/procedure/data_quality__procedure_normalized_description.sql
@@ -13,6 +13,6 @@
                 ,'NORMALIZED_DESCRIPTION' AS FIELD_NAME
                 ,case when M.NORMALIZED_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(NORMALIZED_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(NORMALIZED_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('procedure')}} M

--- a/models/data_quality/intermediate/atomic_checks/clinical/procedure/data_quality__procedure_source_description.sql
+++ b/models/data_quality/intermediate/atomic_checks/clinical/procedure/data_quality__procedure_source_description.sql
@@ -13,6 +13,6 @@
                 ,'SOURCE_DESCRIPTION' AS FIELD_NAME
                 ,case when M.SOURCE_DESCRIPTION is not null then 'valid' else 'null' end as BUCKET_NAME
                 ,cast(null as {{ dbt.type_string() }}) as INVALID_REASON
-                ,CAST(LEFT(SOURCE_DESCRIPTION, 255) as {{ dbt.type_string() }}) AS FIELD_VALUE
+                ,CAST(SUBSTRING(SOURCE_DESCRIPTION, 1, 255) AS {{ dbt.type_string() }}) AS FIELD_VALUE
                 , '{{ var('tuva_last_run')}}' as tuva_last_run
             FROM {{ ref('procedure')}} M

--- a/models/data_quality/intermediate/union_processing/claims/data_quality__data_quality_claims_detail.sql
+++ b/models/data_quality/intermediate/union_processing/claims/data_quality__data_quality_claims_detail.sql
@@ -6,7 +6,7 @@
 WITH CTE as (
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -22,7 +22,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -38,7 +38,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -54,7 +54,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -70,7 +70,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -86,7 +86,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -102,7 +102,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -118,7 +118,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -134,7 +134,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -150,7 +150,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -166,7 +166,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -182,7 +182,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -198,7 +198,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -214,7 +214,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -230,7 +230,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -246,7 +246,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -262,7 +262,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -278,7 +278,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -294,7 +294,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -310,7 +310,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -326,7 +326,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -342,7 +342,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -358,7 +358,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -374,7 +374,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -390,7 +390,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -406,7 +406,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -422,7 +422,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -438,7 +438,7 @@ union all
 
 SELECT
     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -453,7 +453,7 @@ SELECT
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -468,7 +468,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -483,7 +483,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -498,7 +498,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -513,7 +513,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -528,7 +528,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -543,7 +543,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -558,7 +558,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -573,7 +573,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -588,7 +588,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -603,7 +603,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -618,7 +618,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -633,7 +633,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -648,7 +648,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -663,7 +663,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -678,7 +678,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -693,7 +693,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -708,7 +708,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -723,7 +723,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -738,7 +738,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -753,7 +753,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -768,7 +768,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -783,7 +783,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -798,7 +798,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -813,7 +813,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -828,7 +828,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -843,7 +843,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -858,7 +858,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -873,7 +873,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -888,7 +888,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -903,7 +903,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -918,7 +918,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -933,7 +933,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -948,7 +948,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -963,7 +963,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -978,7 +978,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -993,7 +993,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1008,7 +1008,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1023,7 +1023,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1038,7 +1038,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1053,7 +1053,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1068,7 +1068,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1083,7 +1083,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1098,7 +1098,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1113,7 +1113,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1128,7 +1128,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1143,7 +1143,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1158,7 +1158,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1173,7 +1173,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1188,7 +1188,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1203,7 +1203,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1218,7 +1218,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1233,7 +1233,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1248,7 +1248,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1263,7 +1263,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1278,7 +1278,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1293,7 +1293,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1308,7 +1308,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1323,7 +1323,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1338,7 +1338,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1353,7 +1353,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1368,7 +1368,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1383,7 +1383,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1398,7 +1398,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1413,7 +1413,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1428,7 +1428,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1443,7 +1443,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1458,7 +1458,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1473,7 +1473,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1488,7 +1488,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1503,7 +1503,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 union all
 
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value
@@ -1519,7 +1519,7 @@ SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
 
 -- noinspection SqlNoDataSourceInspection
 SELECT     cast(data_source as {{ dbt.type_string() }}) as data_source
-	, cast(source_date as date) as source_date
+	, cast(source_date as {{ dbt.type_string() }}) as source_date
 	, cast(table_name as {{ dbt.type_string() }}) as table_name
 	, cast(drill_down_key as {{ dbt.type_string() }}) as drill_down_key
 	, cast(drill_down_value as {{ dbt.type_string() }}) as drill_down_value

--- a/models/data_quality/intermediate/union_processing/clinical/data_quality__data_quality_clinical_detail.sql
+++ b/models/data_quality/intermediate/union_processing/clinical/data_quality__data_quality_clinical_detail.sql
@@ -668,6 +668,16 @@ SELECT * FROM {{ ref('data_quality__observation_patient_id') }}
 
 )
 
-SELECT *
-,DENSE_RANK() OVER (ORDER BY DATA_SOURCE, TABLE_NAME, FIELD_NAME) + 100000 as SUMMARY_SK
+SELECT
+    Data_SOURCE,
+    cast(SOURCE_DATE as {{ dbt.type_string() }}) as source_date,
+    TABLE_NAME,
+    DRILL_DOWN_KEY,
+    DRILL_DOWN_VALUE,
+    FIELD_NAME,
+    BUCKET_NAME,
+    INVALID_REASON,
+    FIELD_VALUE,
+    tuva_last_run,
+    DENSE_RANK() OVER (ORDER BY Data_SOURCE, TABLE_NAME, FIELD_NAME) + 100000 as SUMMARY_SK
 FROM CTE

--- a/models/quality_measures/intermediate/nqf0041_influenza_immunization/quality_measures__int_nqf0041__performance_period.sql
+++ b/models/quality_measures/intermediate/nqf0041_influenza_immunization/quality_measures__int_nqf0041__performance_period.sql
@@ -73,8 +73,8 @@ with period_end as (
       *
     , case
         when extract(month from performance_period_end) between 1 and 8
-            then (extract(year from performance_period_end) - 1) || '-08-01'
-        else extract(year from performance_period_end) || '-08-01'
+            then cast((extract(year from performance_period_end) - 1) AS {{ dbt.type_string() }}) || '-08-01'
+        else cast(extract(year from performance_period_end) AS {{ dbt.type_string() }}) || '-08-01'
       end as lookback_period_august
   from period_begin
 


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
removing LEFT from clinical data quality tables and changing to substring
changing data type of source date in data quality tables to string to surface potential non date values in data quality dashboard 
casting date and string concatenation issue in quality measure (athena)
casting date in data quality trend table for join to date table in power bi
changing eligibility death date flag values from int to string to match field data type


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
run in athena enviro
ci testing

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
