### PR TITLE
Postgres implementation of load_seed macro

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Please summarize the specific items you’d like the reviewer(s) to look into.
 
 ## Checklist before requesting a review
 - [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
-- [ ] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
+- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
 - [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
 - [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
 - [ ] (New models) I have added the variable `tuva_last_run` to the final output

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,6 +40,11 @@ vars:
     # Default timezone is UTC
     tuva_last_run: '{{ run_started_at.astimezone(modules.pytz.timezone("UTC")) }}'
 
+
+    ## Tuva seed S3 bucket override (for PG only) - also optional prefix in case the bucket has other content
+    #tuva_seeds_s3_bucket: "tuva-public-resources"
+    #tuva_seeds_s3_key_prefix: "tuva/seeds/example/prefix"
+
 on-run-end:
   - "{{ log_warning_for_seeds() }}"
 

--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -229,6 +229,56 @@ COPY_OPTIONS (
 
 
 
+-- postgres - note this requires some pre-work on your part you need to clone
+-- the data from the tuva public resource bucket to re-assemble it into a single
+-- file per seed - also ensure you've set the Content-Type system header on each
+-- to be gzip (https://stackoverflow.com/a/74439053) otherwise the extension
+-- won't know to decompress it.
+--
+-- TODO: revisit removing column list, I think it'll work fine with '' for cols
+{% macro postgres__load_seed(uri,pattern,compression,headers,null_marker) %}
+{%- set columns = adapter.get_columns_in_relation(this) -%}
+{%- set collist = [] -%}
+{%- for col in columns -%}
+  {%- do collist.append(col.name) -%}
+{%- endfor -%}
+{%- set cols = collist|join(",") -%}
+
+{%- set s3_bucket = var("tuva_seeds_s3_bucket", uri.split("/")[0]) -%}
+{%- set s3_key = uri.split("/")[1:]|join("/") + "/" + pattern + "_0.csv.gz" -%}
+{%- if var("tuva_seeds_s3_key_prefix", "") != "" -%}
+{%- set s3_key = var("tuva_seeds_s3_key_prefix") + "/" + s3_key -%}
+{%- endif -%}
+{%- set s3_region = "us-east-1" -%}
+{%- set options = ["(", "format csv", ", encoding ''utf8''"] -%}
+{%- do options.append(", null ''\\N''") if null_marker == true -%}
+{%- do options.append(")") -%}
+{%- set options_s = options | join("") -%}
+
+{% set sql %}
+SELECT aws_s3.table_import_from_s3(
+   '{{ this }}',
+   '{{ cols }}',
+   '{{ options_s }}',
+   aws_commons.create_s3_uri('{{s3_bucket}}', '{{s3_key}}', '{{s3_region}}')
+)
+{% endset %}
+
+{% call statement('postgressql',fetch_result=true) %}
+{{ sql }}
+{% endcall %}
+
+{% if execute %}
+{# debugging { log(sql, True)} #}
+{% set results = load_result('postgressql') %}
+{{ log("Loaded data from external s3 resource\n  loaded to: " ~ this ~ "\n  from: s3://" ~ s3_bucket ~ "/" ~ s3_key ,True) }}
+{# debugging { log(results, True) } #}
+{% endif %}
+
+{% endmacro %}
+
+
+
 {% macro default__load_seed(uri,pattern,compression,headers,null_marker) %}
 {% if execute %}
 {% do log('No adapter found, seed not loaded',info = True) %}

--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -229,11 +229,12 @@ COPY_OPTIONS (
 
 
 
--- postgres - note this requires some pre-work on your part you need to clone
+-- postgres - note this requires some pre-work on your part -  you need to clone
 -- the data from the tuva public resource bucket to re-assemble it into a single
--- file per seed - also ensure you've set the Content-Type system header on each
--- to be gzip (https://stackoverflow.com/a/74439053) otherwise the extension
--- won't know to decompress it.
+-- file per seed with quoted null's unquoted - also ensure you've set the
+-- Content-Type system header on each to be gzip
+-- (https://stackoverflow.com/a/74439053) otherwise the extension won't know to
+-- decompress it.
 --
 -- TODO: revisit removing column list, I think it'll work fine with '' for cols
 {% macro postgres__load_seed(uri,pattern,compression,headers,null_marker) %}


### PR DESCRIPTION
## Describe your changes
Implements a AWS RDS-centric implementation of a postgres load_seed macro implementation.

This relies on two optional variables set in your dbt project to override the S3 bucket name and optionally provide a prefix.

This assumes you've created a pg-friendly format of the seed data ([this repo](https://github.com/waymark-care/tuva-postgres-seed-converter) can be used to generate one). This macro implementation also requires that you have setup your RDS cluster/instance with a IAM Role that has the proper privileges to access the S3 bucket where the seed data is stored.

Also fixed PR template style guide link.

## How has this been tested?
We've run this a few times using dbt cloud in individual and our production environments. We have not however done exhaustive testing around data quality.

## Reviewer focus
This implementation is AWS+RDS specific, so it is unlikely to work for a postgres instance that is not hosted via AWS' RDS offering. There may be other pg extensions to read data from S3, but those have not been explored or tested. 

## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/contribution-guides/development-style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
