### PR TITLE
Fixing PMPM prep join issue

### DIFF
--- a/models/financial_pmpm/final/financial_pmpm__pmpm_prep.sql
+++ b/models/financial_pmpm/final/financial_pmpm__pmpm_prep.sql
@@ -70,21 +70,25 @@ left join {{ ref('financial_pmpm__service_category_1_paid_pivot') }} b
   and a.year_month = b.year_month
   and a.payer = b.payer
   and a.plan = b.plan
+  and a.data_source = b.data_source
 left join {{ ref('financial_pmpm__service_category_2_paid_pivot') }} c
   on a.patient_id = c.patient_id
   and a.year_month = c.year_month
   and a.payer = c.payer
   and a.plan = c.plan
+  and a.data_source = b.data_source
 left join {{ ref('financial_pmpm__service_category_1_allowed_pivot') }} d
   on a.patient_id = d.patient_id
   and a.year_month = d.year_month
   and a.payer = d.payer
   and a.plan = d.plan
+  and a.data_source = b.data_source
 left join {{ ref('financial_pmpm__service_category_2_allowed_pivot') }} e
   on a.patient_id = e.patient_id
   and a.year_month = e.year_month
   and a.payer = e.payer
-  and a.plan = e.plan   
+  and a.plan = e.plan
+  and a.data_source = b.data_source   
 )
 
 select *


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
add data_source to join on pmpm causing issues with overlapping member_id across data_sources

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
ran on synthetic data

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
