### PR TITLE
Nqf0053 fabric

### DIFF
--- a/models/quality_measures/intermediate/nqf0053_osteoporosis_management_in_women_who_had_a_fracture/quality_measures__int_nqf0053_exclusions.sql
+++ b/models/quality_measures/intermediate/nqf0053_osteoporosis_management_in_women_who_had_a_fracture/quality_measures__int_nqf0053_exclusions.sql
@@ -3,254 +3,14 @@
    )
 }}
 
-{%- set performance_period_begin -%}
-(
-  select 
-    performance_period_begin
-  from {{ ref('quality_measures__int_nqf0053__performance_period') }}
+with
 
-)
-{%- endset -%}
-
-{%- set performance_period_end -%}
-(
-  select 
-    performance_period_end
-  from {{ ref('quality_measures__int_nqf0053__performance_period') }}
-
-)
-{%- endset -%}
-
-{%- set lookback_period_december -%}
-(
-  select 
-    lookback_period_december
-  from {{ ref('quality_measures__int_nqf0053__performance_period') }}
-
-)
-{%- endset -%}
-
-
-with frailty as (
-
-    select
-        patient_id
-      , exclusion_date
-      , exclusion_reason
-    from {{ ref('quality_measures__int_shared_exclusions_frailty') }}
-    where exclusion_date between {{ performance_period_begin }} and {{ performance_period_end }}
-
-)
-
-, frailty_within_defined_window as (
+combined_exclusions as (
 
   select
-      patient_id
-    , exclusion_date
-    , exclusion_reason
-  from {{ ref('quality_measures__int_shared_exclusions_frailty') }}
-  where exclusion_date between 
-    {{ dbt.dateadd (
-        datepart = "month"
-        , interval = -6
-        , from_date_or_timestamp = performance_period_begin
-        ) 
-    }}
-    and {{ lookback_period_december }}
-
-)
-
-, valid_hospice_palliative as (
-
-    select
-          patient_id
-        , exclusion_date
-        , exclusion_reason
-        , exclusion_type
-    from {{ref('quality_measures__int_shared_exclusions_hospice_palliative')}}
-    where exclusion_date between {{ performance_period_begin }} and {{ performance_period_end }}
-
-)
-
-, exclusion_procedure_and_medication as (
-
-    select 
-          patient_id
-        , exclusion_date
-        , exclusion_reason
-        , exclusion_type
-    from {{ref('quality_measures__int_nqf0053_exclude_procedures_medications')}}
-
-)
-
-, valid_institutional_snp as (
-
-  select 
-      patient_id
-    , exclusion_date
-    , exclusion_reason
-    , exclusion_type
-  from {{ref('quality_measures__int_shared_exclusions_institutional_snp')}}
-  where exclusion_date between 
-    {{dbt.dateadd(
-                      datepart = "month"
-                    , interval = -6
-                    , from_date_or_timestamp = performance_period_begin
-                )       
-    }}
-  
-  and {{ lookback_period_december }}
-
-)
-
-, valid_dementia_exclusions as (
-
-  select
-      source.patient_id
-    , source.exclusion_date
-    , source.exclusion_reason
-    , source.exclusion_type
-  from {{ref('quality_measures__int_shared_exclusions_dementia')}} source
-  inner join frailty
-    on source.patient_id = frailty.patient_id
-  where (
-    source.dispensing_date
-      between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp= performance_period_begin ) }}
-          and {{ performance_period_end }}
-    or source.paid_date
-      between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp= performance_period_begin ) }}
-          and {{ performance_period_end }}
-    )
-
-)
-
--- advanced illness start
-, advanced_illness_exclusion as (
-
-  select
-    source.*
-  from {{ ref('quality_measures__int_shared_exclusions_advanced_illness') }} as source
-  inner join frailty
-    on source.patient_id = frailty.patient_id
-  where source.exclusion_date
-    between
-      {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp=performance_period_begin) }}
-      and {{ performance_period_end }}
-
-)
-
-, acute_inpatient_advanced_illness as (
-
-  select
-    *
-  from advanced_illness_exclusion
-  where patient_type = 'acute_inpatient'
-
-)
-
-, nonacute_outpatient_advanced_illness as (
-
-  select
-    *
-  from advanced_illness_exclusion
-  where patient_type = 'nonacute_outpatient'
-
-)
-
-, acute_inpatient_counts as (
-
-    select
-          patient_id
-        , exclusion_type
-        , count(distinct exclusion_date) as encounter_count
-    from acute_inpatient_advanced_illness
-    group by patient_id, exclusion_type
-
-)
-
-, nonacute_outpatient_counts as (
-
-    select
-          patient_id
-        , exclusion_type
-        , count(distinct exclusion_date) as encounter_count
-    from nonacute_outpatient_advanced_illness
-    group by patient_id, exclusion_type
-
-)
-
-, valid_advanced_illness_exclusions as (
-
-    select
-          acute_inpatient_advanced_illness.patient_id
-        , acute_inpatient_advanced_illness.exclusion_date
-        , acute_inpatient_advanced_illness.exclusion_reason
-        , acute_inpatient_advanced_illness.exclusion_type
-    from acute_inpatient_advanced_illness
-    left join acute_inpatient_counts
-      on acute_inpatient_advanced_illness.patient_id = acute_inpatient_counts.patient_id
-    where acute_inpatient_counts.encounter_count >= 1
-
-    union all
-
-    select
-        nonacute_outpatient_advanced_illness.patient_id
-      , nonacute_outpatient_advanced_illness.exclusion_date
-      , nonacute_outpatient_advanced_illness.exclusion_reason
-      , nonacute_outpatient_advanced_illness.exclusion_type
-    from nonacute_outpatient_advanced_illness
-    left join nonacute_outpatient_counts
-      on nonacute_outpatient_advanced_illness.patient_id = nonacute_outpatient_counts.patient_id
-    where nonacute_outpatient_counts.encounter_count >= 2
-
-
-)
--- advanced illness end
-
-, frailty_patients_within_defined_window as (
-
-    select
-          frailty_within_defined_window.patient_id
-        , frailty_within_defined_window.exclusion_date
-        , frailty_within_defined_window.exclusion_reason
-        , 'measure specific exclusion for defined window' as exclusion_type
-    from frailty_within_defined_window
-    
-)
-
-, exclusions as (
-
-    select * from valid_advanced_illness_exclusions
-
-    union all
-
-    select * from valid_dementia_exclusions
-
-    union all
-
-    select * from valid_institutional_snp
-
-    union all
-
-    select * from valid_hospice_palliative
-
-    union all
-
-    select * from exclusion_procedure_and_medication
-
-    union all
-
-    select * from frailty_patients_within_defined_window
-
-)
-
-
-, combined_exclusions as (
-
-  select 
       exclusions.*
     , denominator.age
-  from exclusions
+  from {{ ref('quality_measures__int_nqf0053_exclusions_stage_1') }} as exclusions
   inner join {{ref('quality_measures__int_nqf0053_denominator')}} as denominator
       on exclusions.patient_id = denominator.patient_id
 
@@ -258,27 +18,27 @@ with frailty as (
 
 , valid_exclusions as (
 
-    select 
-        * 
+    select
+        *
     from combined_exclusions
     where exclusion_type = 'institutional_snp'
     and age >= 66
 
-    union all 
+    union all
 
-    select 
+    select
         *
     from combined_exclusions
     where exclusion_type in
     (
         'advanced_illness'
       , 'dementia'
-    ) 
+    )
     and age between 66 and 80
 
-    union all 
+    union all
 
-    select 
+    select
       *
     from combined_exclusions
     where exclusion_type = 'measure specific exclusion for defined window'
@@ -286,7 +46,7 @@ with frailty as (
 
     union all
 
-    select 
+    select
         *
     from combined_exclusions
     where exclusion_type in

--- a/models/quality_measures/intermediate/nqf0053_osteoporosis_management_in_women_who_had_a_fracture/quality_measures__int_nqf0053_exclusions_stage_1.sql
+++ b/models/quality_measures/intermediate/nqf0053_osteoporosis_management_in_women_who_had_a_fracture/quality_measures__int_nqf0053_exclusions_stage_1.sql
@@ -244,4 +244,7 @@ with frailty as (
 
 )
 
-select * from exclusions
+select
+      *
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from exclusions

--- a/models/quality_measures/intermediate/nqf0053_osteoporosis_management_in_women_who_had_a_fracture/quality_measures__int_nqf0053_exclusions_stage_1.sql
+++ b/models/quality_measures/intermediate/nqf0053_osteoporosis_management_in_women_who_had_a_fracture/quality_measures__int_nqf0053_exclusions_stage_1.sql
@@ -1,0 +1,247 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+{%- set performance_period_begin -%}
+(
+  select
+    performance_period_begin
+  from {{ ref('quality_measures__int_nqf0053__performance_period') }}
+
+)
+{%- endset -%}
+
+{%- set performance_period_end -%}
+(
+  select
+    performance_period_end
+  from {{ ref('quality_measures__int_nqf0053__performance_period') }}
+
+)
+{%- endset -%}
+
+{%- set lookback_period_december -%}
+(
+  select
+    lookback_period_december
+  from {{ ref('quality_measures__int_nqf0053__performance_period') }}
+
+)
+{%- endset -%}
+
+
+with frailty as (
+
+    select
+        patient_id
+      , exclusion_date
+      , exclusion_reason
+    from {{ ref('quality_measures__int_shared_exclusions_frailty') }}
+    where exclusion_date between {{ performance_period_begin }} and {{ performance_period_end }}
+
+)
+
+, frailty_within_defined_window as (
+
+  select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+  from {{ ref('quality_measures__int_shared_exclusions_frailty') }}
+  where exclusion_date between
+    {{ dbt.dateadd (
+        datepart = "month"
+        , interval = -6
+        , from_date_or_timestamp = performance_period_begin
+        )
+    }}
+    and {{ lookback_period_december }}
+
+)
+
+, valid_hospice_palliative as (
+
+    select
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+        , exclusion_type
+    from {{ref('quality_measures__int_shared_exclusions_hospice_palliative')}}
+    where exclusion_date between {{ performance_period_begin }} and {{ performance_period_end }}
+
+)
+
+, exclusion_procedure_and_medication as (
+
+    select
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+        , exclusion_type
+    from {{ref('quality_measures__int_nqf0053_exclude_procedures_medications')}}
+
+)
+
+, valid_institutional_snp as (
+
+  select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+    , exclusion_type
+  from {{ref('quality_measures__int_shared_exclusions_institutional_snp')}}
+  where exclusion_date between
+    {{dbt.dateadd(
+                      datepart = "month"
+                    , interval = -6
+                    , from_date_or_timestamp = performance_period_begin
+                )
+    }}
+
+  and {{ lookback_period_december }}
+
+)
+
+, valid_dementia_exclusions as (
+
+  select
+      source.patient_id
+    , source.exclusion_date
+    , source.exclusion_reason
+    , source.exclusion_type
+  from {{ref('quality_measures__int_shared_exclusions_dementia')}} source
+  inner join frailty
+    on source.patient_id = frailty.patient_id
+  where (
+    source.dispensing_date
+      between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp= performance_period_begin ) }}
+          and {{ performance_period_end }}
+    or source.paid_date
+      between {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp= performance_period_begin ) }}
+          and {{ performance_period_end }}
+    )
+
+)
+
+-- advanced illness start
+, advanced_illness_exclusion as (
+
+  select
+    source.*
+  from {{ ref('quality_measures__int_shared_exclusions_advanced_illness') }} as source
+  inner join frailty
+    on source.patient_id = frailty.patient_id
+  where source.exclusion_date
+    between
+      {{ dbt.dateadd(datepart="year", interval=-1, from_date_or_timestamp=performance_period_begin) }}
+      and {{ performance_period_end }}
+
+)
+
+, acute_inpatient_advanced_illness as (
+
+  select
+    *
+  from advanced_illness_exclusion
+  where patient_type = 'acute_inpatient'
+
+)
+
+, nonacute_outpatient_advanced_illness as (
+
+  select
+    *
+  from advanced_illness_exclusion
+  where patient_type = 'nonacute_outpatient'
+
+)
+
+, acute_inpatient_counts as (
+
+    select
+          patient_id
+        , exclusion_type
+        , count(distinct exclusion_date) as encounter_count
+    from acute_inpatient_advanced_illness
+    group by patient_id, exclusion_type
+
+)
+
+, nonacute_outpatient_counts as (
+
+    select
+          patient_id
+        , exclusion_type
+        , count(distinct exclusion_date) as encounter_count
+    from nonacute_outpatient_advanced_illness
+    group by patient_id, exclusion_type
+
+)
+
+, valid_advanced_illness_exclusions as (
+
+    select
+          acute_inpatient_advanced_illness.patient_id
+        , acute_inpatient_advanced_illness.exclusion_date
+        , acute_inpatient_advanced_illness.exclusion_reason
+        , acute_inpatient_advanced_illness.exclusion_type
+    from acute_inpatient_advanced_illness
+    left join acute_inpatient_counts
+      on acute_inpatient_advanced_illness.patient_id = acute_inpatient_counts.patient_id
+    where acute_inpatient_counts.encounter_count >= 1
+
+    union all
+
+    select
+        nonacute_outpatient_advanced_illness.patient_id
+      , nonacute_outpatient_advanced_illness.exclusion_date
+      , nonacute_outpatient_advanced_illness.exclusion_reason
+      , nonacute_outpatient_advanced_illness.exclusion_type
+    from nonacute_outpatient_advanced_illness
+    left join nonacute_outpatient_counts
+      on nonacute_outpatient_advanced_illness.patient_id = nonacute_outpatient_counts.patient_id
+    where nonacute_outpatient_counts.encounter_count >= 2
+
+
+)
+-- advanced illness end
+
+, frailty_patients_within_defined_window as (
+
+    select
+          frailty_within_defined_window.patient_id
+        , frailty_within_defined_window.exclusion_date
+        , frailty_within_defined_window.exclusion_reason
+        , 'measure specific exclusion for defined window' as exclusion_type
+    from frailty_within_defined_window
+
+)
+
+, exclusions as (
+
+    select * from valid_advanced_illness_exclusions
+
+    union all
+
+    select * from valid_dementia_exclusions
+
+    union all
+
+    select * from valid_institutional_snp
+
+    union all
+
+    select * from valid_hospice_palliative
+
+    union all
+
+    select * from exclusion_procedure_and_medication
+
+    union all
+
+    select * from frailty_patients_within_defined_window
+
+)
+
+select * from exclusions

--- a/models/quality_measures/quality_measures_models.yml
+++ b/models/quality_measures/quality_measures_models.yml
@@ -990,7 +990,9 @@ models:
           from the measure.
       - name: exclusion_type
         description: >
-          Type of exclusion from the measure. 
+          Type of exclusion from the measure.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
 
   - name: quality_measures__int_nqf0053_exclusions
     config:

--- a/models/quality_measures/quality_measures_models.yml
+++ b/models/quality_measures/quality_measures_models.yml
@@ -432,7 +432,7 @@ models:
         description: Patient's maximum age during encounter as of the performance_period.
       - name: qualifying_types
         description: Indicative letter of patient's type of encounter.
-      
+
   - name: quality_measures__int_nqf0034_exclude_colectomy_cancer
     config:
       schema: |
@@ -453,7 +453,7 @@ models:
           from the measure.
       - name: exclusion_type
         description: Measure specific exclusion for historical record of colectomy cancer.
-      - name: tuva_last_run 
+      - name: tuva_last_run
         desciption: The date and timestamp of the dbt run.
 
   - name: quality_measures__int_nqf0034_exclusions
@@ -464,7 +464,7 @@ models:
       tags: quality_measures
       materialized: table
     description: >
-      Combined exclusion logic for the reporting version of NQF 0034, Colorectal Cancer Screening.      
+      Combined exclusion logic for the reporting version of NQF 0034, Colorectal Cancer Screening.
     columns:
       - name: patient_id
         description: Unique patient_id for each person.
@@ -535,7 +535,7 @@ models:
         description: Version of the measure.
       - name: tuva_last_run
         description: The date and timestamp of the dbt run.
-      
+
   - name: quality_measures__int_nqf0034_numerator
     config:
       schema: |
@@ -565,7 +565,7 @@ models:
       materialized: view
     description: >
       Performance Period definition for NQF 0034 Colorectal Cancer screening.
-    
+
 ### Diabetes Hemoglobin a1c
   - name: quality_measures__int_nqf0059__performance_period
     config:
@@ -968,6 +968,30 @@ models:
       - name: tuva_last_run
         description: The date and timestamp of the dbt run.
 
+  - name: quality_measures__int_nqf0053_exclusions_stage_1
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_nqf0053_exclusions_stage_1
+      tags: quality_measures
+      materialized: table
+    description: >
+      Combined exclusion logic for the reporting version of NQF 0053, Osteoporosis Management in women who had a fracture.
+      First stage of final exclusion logic.
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: exclusion_date
+        description: >
+          Date of event or service that excludes patient from the measure.
+      - name: exclusion_reason
+        description: >
+          Reason (usually the value set concept name) that excludes patient 
+          from the measure.
+      - name: exclusion_type
+        description: >
+          Type of exclusion from the measure. 
+
   - name: quality_measures__int_nqf0053_exclusions
     config:
       schema: |
@@ -994,7 +1018,7 @@ models:
           a measure although they experience the denominator index event.
       - name: tuva_last_run
         description: The date and timestamp of the dbt run.
-        
+
   - name: quality_measures__int_nqf0053_exclude_procedures_medications
     config:
       schema: |
@@ -1015,7 +1039,7 @@ models:
           from the measure.
       - name: exclusion_type
         description: measure specific exclusion for procedure medication.
-      - name: tuva_last_run 
+      - name: tuva_last_run
         desciption: The date and timestamp of the dbt run.
 
   - name: quality_measures__int_nqf0053_long
@@ -1396,7 +1420,7 @@ models:
       materialized: view
     description: >
       Performance Period definition for Statin Therapy for the Prevention and Treatment of Cardiovascular Disease
-  
+
   - name: quality_measures__int_cqm438_denominator_criteria1
     config:
       schema: |


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

Fabric could not run the mart as a single mart so broke quality_measures__int_nqf_0053_exclusions into 2 marts. 

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

Ran marts with TTP Demo in dev environment

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [X] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [X] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [X] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGR5aDRvajB0MnYxc2YxOTBmbWxsZmQ2M3JocTdhb3U2dnZ0ZDlwMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/YSSleL7VvZcDdKjOuN/giphy.webp)


## Loom link
