### PR TITLE
adding los groups to table for PBI

### DIFF
--- a/models/data_quality/mart_review/final/mart_review__inpatient.sql
+++ b/models/data_quality/mart_review/final/mart_review__inpatient.sql
@@ -1,61 +1,47 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False))
- | as_bool
-   )
-}}
+    enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+) }}
 
-WITH cte AS (
-    SELECT DISTINCT location_id, npi, name
-    FROM {{ ref('core__location')}}
+with cte as (
+    select distinct
+        location_id
+      , npi
+      , name
+    from {{ ref('core__location') }}
 )
 
-SELECT e.*,
-    {{ dbt.concat([
-        'e.patient_id',
-        "'|'",
-        'e.data_source'
-    ]) }} as patient_source_key,
-    {{ dbt.concat([
-        'e.encounter_id',
-        "'|'",
-        'e.data_source'
-    ]) }} as encounter_source_key,
-    {{ dbt.concat([
-        'e.ms_drg_code',
-        "' | '",
-        'e.ms_drg_description'
-    ]) }} as drgwithdescription,
-    {{ dbt.concat([
-        'e.primary_diagnosis_code',
-        "' | '",
-        'e.primary_diagnosis_description'
-    ]) }} as primary_diagnosis_and_description,
-    {{ dbt.concat([
-        'e.admit_source_code',
-        "' | '",
-        'e.admit_source_description'
-    ]) }} as admit_source_code_and_description,
-    {{ dbt.concat([
-        'e.admit_type_code',
-        "' | '",
-        'e.admit_type_description'
-    ]) }} as admit_type_code_and_description,
-    {{ dbt.concat([
-        'e.discharge_disposition_code',
-        "' | '",
-        'e.discharge_disposition_description'
-    ]) }} as discharge_code_and_description,
-    p.ccsr_parent_category,
-    p.ccsr_category,
-    p.ccsr_category_description,
-    {{ dbt.concat([
-        'p.ccsr_category',
-        "' | '",
-        'p.ccsr_category_description'
-    ]) }} as ccsr_category_and_description,
-    b.body_system
-from {{ ref('core__encounter')}} e
-left join cte l on e.facility_id = l.location_id
-left join {{ ref('ccsr__dx_vertical_pivot') }} p on e.primary_diagnosis_code = p.code and p.ccsr_category_rank = 1
-left join {{ ref('ccsr__dxccsr_v2023_1_body_systems') }} b on p.ccsr_parent_category = b.ccsr_parent_category
-where e.encounter_type = 'acute inpatient'
+, final as (
+    select
+        e.*
+      , {{ dbt.concat(['e.patient_id', "'|'", 'e.data_source']) }} as patient_source_key
+      , {{ dbt.concat(['e.encounter_id', "'|'", 'e.data_source']) }} as encounter_source_key
+      , {{ dbt.concat(['e.ms_drg_code', "' | '", 'e.ms_drg_description']) }} as drgwithdescription
+      , {{ dbt.concat(['e.primary_diagnosis_code', "' | '", 'e.primary_diagnosis_description']) }} as primary_diagnosis_and_description
+      , {{ dbt.concat(['e.admit_source_code', "' | '", 'e.admit_source_description']) }} as admit_source_code_and_description
+      , {{ dbt.concat(['e.admit_type_code', "' | '", 'e.admit_type_description']) }} as admit_type_code_and_description
+      , {{ dbt.concat(['e.discharge_disposition_code', "' | '", 'e.discharge_disposition_description']) }} as discharge_code_and_description
+      , p.ccsr_parent_category
+      , p.ccsr_category
+      , p.ccsr_category_description
+      , {{ dbt.concat(['p.ccsr_category', "' | '", 'p.ccsr_category_description']) }} as ccsr_category_and_description
+      , b.body_system
+      , case 
+            when e.length_of_stay <= 1 then '1. 0-1 day'
+            when e.length_of_stay <= 3 then '2. 2-3 days'
+            when e.length_of_stay <= 5 then '3. 4-5 days'
+            when e.length_of_stay <= 7 then '4. 6-7 days'
+            when e.length_of_stay <= 14 then '5. 8-14 days'
+            when e.length_of_stay <= 30 then '6. 15-30 days'
+        end as los_groups
+    from {{ ref('core__encounter') }} as e
+    left join cte as l
+      on e.facility_id = l.location_id
+    left join {{ ref('ccsr__dx_vertical_pivot') }} as p
+      on e.primary_diagnosis_code = p.code
+      and p.ccsr_category_rank = 1
+    left join {{ ref('ccsr__dxccsr_v2023_1_body_systems') }} as b
+      on p.ccsr_parent_category = b.ccsr_parent_category
+    where e.encounter_type = 'acute inpatient'
+)
+
+select * from final


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
Adding case statement to data_quality.mart_review__inpatient.sql to create an los_group column for use in Power BI.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
Ran locally

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`
