### PR TITLE
adding drg weights to terminology

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -124,6 +124,8 @@ seeds:
         +post-hook: "{{ load_seed('tuva-public-resources/versioned_terminology/0.10.5','medicare_orec.csv',compression=true,null_marker=true) }}"
       terminology__medicare_status:
         +post-hook: "{{ load_seed('tuva-public-resources/versioned_terminology/0.10.5','medicare_status.csv',compression=true,null_marker=true) }}"
+      terminology__ms_drg_weights_los:
+        +post-hook: "{{ load_seed('tuva-public-resources/versioned_terminology/0.10.6','ms_drg_weights_los.csv',compression=true,null_marker=true) }}"      
       terminology__ms_drg:
         +post-hook: "{{ load_seed('tuva-public-resources/versioned_terminology/0.10.5','ms_drg.csv',compression=true,null_marker=true) }}"
       terminology__ndc:

--- a/seeds/terminology/terminology__ms_drg_weights_los.csv
+++ b/seeds/terminology/terminology__ms_drg_weights_los.csv
@@ -1,0 +1,1 @@
+ms_drg,fy_2024_final_post_acute_drg,fy_2024_final_special_pay_drg,mdc,type,ms_drg_title,drg_weight_raw,drg_weight,geometric_mean_los,arithmetic_mean_los

--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -597,25 +597,25 @@ seeds:
         - data_profiling
         - claims_preprocessing
       column_types:
-        ms_drg : |
+        ms_drg: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        fy_2024_final_post_acute_drg : |
+        fy_2024_final_post_acute_drg: |
           {%- if target.type in ("bigquery", "databricks") -%} boolean {%- else -%} boolean {%- endif -%}
-        fy_2024_final_special_pay_drg : |
+        fy_2024_final_special_pay_drg: |
           {%- if target.type in ("bigquery", "databricks") -%} boolean {%- else -%} boolean {%- endif -%}
-        mdc : |
+        mdc: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        type : |
+        type: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        ms_drg_title : |
+        ms_drg_title: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
-        drg_weight_raw : |
+        drg_weight_raw: |
           {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,4) {%- endif -%}
-        drg_weight : |
+        drg_weight: |
           {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,4) {%- endif -%}
-        geometric_mean_los : |
+        geometric_mean_los: |
           {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,2) {%- endif -%}
-        arithmetic_mean_los : |
+        arithmetic_mean_los: |
           {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,2) {%- endif -%}
     columns:
       - name: ms_drg

--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -586,6 +586,59 @@ seeds:
       - name: medicare_status_description
         description: 'A description of the Medicare status.'
 
+  - name: terminology__ms_drg_weights_los
+    description: 'Seed containing Medicare Severity Diagnosis Related Groups (MS-DRG) weights and benchmark length of stay values from CMS.'
+    config:
+      schema: |
+        {%- if  var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_terminology{% else %}terminology{%- endif -%}
+      alias: ms_drg_weights_los
+      tags:
+        - terminology
+        - data_profiling
+        - claims_preprocessing
+      column_types:
+        ms_drg : |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
+        fy_2024_final_post_acute_drg : |
+          {%- if target.type in ("bigquery", "databricks") -%} boolean {%- else -%} boolean {%- endif -%}
+        fy_2024_final_special_pay_drg : |
+          {%- if target.type in ("bigquery", "databricks") -%} boolean {%- else -%} boolean {%- endif -%}
+        mdc : |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
+        type : |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
+        ms_drg_title : |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
+        drg_weight_raw : |
+          {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,4) {%- endif -%}
+        drg_weight : |
+          {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,4) {%- endif -%}
+        geometric_mean_los : |
+          {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,2) {%- endif -%}
+        arithmetic_mean_los : |
+          {%- if target.type in ("bigquery", "databricks") -%} float {%- else -%} numeric(18,2) {%- endif -%}
+    columns:
+      - name: ms_drg
+        description: 'The Medicare Severity Diagnosis Related Group (MS-DRG) code.'
+      - name: fy_2024_final_post_acute_drg
+        description: 'Indicates if this is a FY 2024 final post-acute DRG.'
+      - name: fy_2024_final_special_pay_drg
+        description: 'Indicates if this is a FY 2024 final special pay DRG.'
+      - name: mdc
+        description: 'The Major Diagnostic Category (MDC) code associated with the MS-DRG.'
+      - name: type
+        description: 'The type of the DRG.'
+      - name: ms_drg_title
+        description: 'The title of the Medicare Severity Diagnosis Related Group (MS-DRG).'
+      - name: drg_weight_raw
+        description: 'The raw DRG weight.'
+      - name: drg_weight
+        description: 'The adjusted DRG weight.'
+      - name: geometric_mean_los
+        description: 'The geometric mean length of stay for this DRG.'
+      - name: arithmetic_mean_los
+        description: 'The arithmetic mean length of stay for this DRG.'
+
   - name: terminology__ms_drg
     description: 'Seed containing Medicare Severity Diagnosis Related Groups (MS-DRG) codes and descriptions.'
     config:


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
Adding new seed file to terminology for DRG weights and CMS benchmark length of stay.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
Ran locally

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [x] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`