### PR TITLE
BUG FIX: CMS Chronic Conditions staging references

### DIFF
--- a/models/chronic_conditions/cms_chronic_conditions_models.yml
+++ b/models/chronic_conditions/cms_chronic_conditions_models.yml
@@ -460,14 +460,14 @@ models:
         - chronic_conditions
       materialized: ephemeral
 
-  - name: cms_chronic_conditions__stg_medical_claim
+  - name: cms_chronic_conditions__stg_core__medical_claim
     config:
       tags:
         - cms_chronic_conditions
         - chronic_conditions
       materialized: ephemeral
 
-  - name: cms_chronic_conditions__stg_pharmacy_claim
+  - name: cms_chronic_conditions__stg_core__pharmacy_claim
     config:
       tags:
         - cms_chronic_conditions

--- a/models/chronic_conditions/intermediate/chronic_conditions__cms_chronic_conditions_all.sql
+++ b/models/chronic_conditions/intermediate/chronic_conditions__cms_chronic_conditions_all.sql
@@ -31,7 +31,7 @@ with chronic_conditions as (
         , 'MS-DRG' as code_type
         , ms_drg_code as code
         , data_source
-    from {{ ref('cms_chronic_conditions__stg_medical_claim') }}
+    from {{ ref('cms_chronic_conditions__stg_core__medical_claim') }}
 
 )
 

--- a/models/chronic_conditions/intermediate/chronic_conditions__cms_chronic_conditions_hiv_aids.sql
+++ b/models/chronic_conditions/intermediate/chronic_conditions__cms_chronic_conditions_hiv_aids.sql
@@ -34,7 +34,7 @@ with chronic_conditions as (
         , 'MS-DRG' as code_type
         , ms_drg_code as code
         , data_source
-    from {{ ref('cms_chronic_conditions__stg_medical_claim') }}
+    from {{ ref('cms_chronic_conditions__stg_core__medical_claim') }}
 
 )
 

--- a/models/chronic_conditions/intermediate/chronic_conditions__cms_chronic_conditions_oud.sql
+++ b/models/chronic_conditions/intermediate/chronic_conditions__cms_chronic_conditions_oud.sql
@@ -46,7 +46,7 @@ with chronic_conditions as (
         , paid_date as start_date
         , replace(ndc_code,'.','') as code
         , data_source
-    from {{ ref('cms_chronic_conditions__stg_pharmacy_claim') }}
+    from {{ ref('cms_chronic_conditions__stg_core__pharmacy_claim') }}
 
 )
 

--- a/models/chronic_conditions/staging/cms_chronic_conditions__stg_core__medical_claim.sql
+++ b/models/chronic_conditions/staging/cms_chronic_conditions__stg_core__medical_claim.sql
@@ -10,4 +10,4 @@ select
     , ms_drg_code
     , data_source
     , '{{ var('tuva_last_run')}}' as tuva_last_run
-from {{ ref('medical_claim') }}
+from {{ ref('core__medical_claim') }}

--- a/models/chronic_conditions/staging/cms_chronic_conditions__stg_core__pharmacy_claim.sql
+++ b/models/chronic_conditions/staging/cms_chronic_conditions__stg_core__pharmacy_claim.sql
@@ -10,4 +10,4 @@ select
     , ndc_code
     , data_source
     , '{{ var('tuva_last_run')}}' as tuva_last_run
-from {{ ref('pharmacy_claim') }}
+from {{ ref('core__pharmacy_claim') }}


### PR DESCRIPTION
## Describe your changes
This data mart was referencing the Input Layer medical and pharmacy models rather than Core. This was causing issues in new marts when trying to just seed terminology and not run any data marts.


## How has this been tested?
Ran `dbt build --full-refresh` with no errors.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGp1dGRjZW1naDJrYzJnem5uejQwMnptcjF2ZjFkbHJ1NjdsendreiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Zf9oMBBf3eRTW/giphy.gif)


## Loom link
