### PR TITLE
Update _integration_tests__models.yml to use input_layer schema

### DIFF
--- a/integration_tests/models/_integration_tests__models.yml
+++ b/integration_tests/models/_integration_tests__models.yml
@@ -6,8 +6,8 @@ models:
     description: Created from seed or source data depending on test_data_override variable.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_claims
-        {% else %}_tuva_claims{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       tags: claims
       materialized: table
 
@@ -15,8 +15,8 @@ models:
     description: Created from seed or source data depending on test_data_override variable.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_claims
-        {% else %}_tuva_claims{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       tags: claims
       materialized: table
 
@@ -24,8 +24,8 @@ models:
     description: Created from seed or source data depending on test_data_override variable.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_claims
-        {% else %}_tuva_claims{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       tags: claims
       materialized: table
 
@@ -34,70 +34,70 @@ models:
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: encounter
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: lab_result
     description: Created from seed or source data depending on test_data_override variable.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: location
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: medication
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: observation
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: patient
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: practitioner
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table
 
   - name: procedure
     description: Created using empty table logic.
     config:
       schema: |
-        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}_tuva_clinical
-        {% else %}_tuva_clinical{%- endif -%}
+        {%- if var('tuva_schema_prefix',None) != None -%}_{{var('tuva_schema_prefix')}}input_layer
+        {% else %}input_layer{%- endif -%}
       materialized: table


### PR DESCRIPTION
Replace _tuva_claims and _tuva_clinical schemas with an input_layer schema for input layer tables inside integration_tests.

## Describe your changes
Please include a summary of any changes.


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
