### PR TITLE
removed column admit_age

### DIFF
--- a/models/claims_preprocessing/acute_inpatient/final/acute_inpatient__summary.sql
+++ b/models/claims_preprocessing/acute_inpatient/final/acute_inpatient__summary.sql
@@ -89,7 +89,6 @@ select
 , a.encounter_start_date
 , a.encounter_end_date
 , a.patient_id
-, {{ dbt.datediff("birth_date","encounter_end_date","day")}}/365 as admit_age
 , e.gender
 , e.race
 , c.diagnosis_code_type as primary_diagnosis_code_type

--- a/models/claims_preprocessing/emergency_department/final/emergency_department__summary.sql
+++ b/models/claims_preprocessing/emergency_department/final/emergency_department__summary.sql
@@ -90,7 +90,6 @@ select
     , a.encounter_start_date
     , a.encounter_end_date
     , a.patient_id
-    , {{ dbt.datediff("birth_date","encounter_end_date","day")}}/365 as admit_age
     , e.gender
     , e.race
     , c.diagnosis_code_type as primary_diagnosis_code_type


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

Removed the column admit_age from emergency_department__summary and acute_inpatient__summary.  Due to the way it was being calculated, it created two values causing duplicates.  Column is not used downstream which is why it was removed instead of edited the logic.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
CI testing

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
N/A

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
https://www.loom.com/share/98fe3c8ba6944c65a07c36eff7d6050e?sid=e7c364f2-f551-4cc9-85d5-8cf7739cd66d