### PR TITLE
fix the space in the generated schema name template

### DIFF
--- a/models/pharmacy/pharmacy_models.yml
+++ b/models/pharmacy/pharmacy_models.yml
@@ -8,7 +8,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: brand_generic_opportunity
@@ -63,7 +63,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: generic_available_list
@@ -115,7 +115,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: pharmacy_claim_expanded
@@ -209,7 +209,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: _int_brand_with_generic_available
@@ -224,7 +224,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: _int_claims_current_cost
@@ -239,7 +239,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: _int_generic_cost
@@ -254,7 +254,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: _int_generic_cost_by_ndc
@@ -271,7 +271,7 @@ models:
       schema: |
         {%- if var('tuva_schema_prefix', None) != None -%}
           {{var('tuva_schema_prefix')}}_pharmacy
-        {% else %}
+        {%- else -%}
           pharmacy
         {%- endif -%}
       alias: stg_pharmacy_claim


### PR DESCRIPTION
## Describe your changes
By default, the schema name for the pharmacy models is generated as 
```
"
    pharmacy__...."
```
Normally its not an issue but when integrating with dagster or external tools that have validations on schema names, this throws an error that the schema name is invalid. 

## How has this been tested?
Executed the build and deployed the datamart in postgres. 


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
* any test cases you might need to integrate this into the code base


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [x] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
