### PR TITLE
noticed a bug with institutional procedures, this fixes it

### DIFF
--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_code_final.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_code_final.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) | as_bool
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
    )
 }}
 
@@ -30,7 +31,7 @@ select
     , max(case when lower(column_name) = 'procedure_code_22' then normalized_code else null end) as procedure_code_22
     , max(case when lower(column_name) = 'procedure_code_23' then normalized_code else null end) as procedure_code_23
     , max(case when lower(column_name) = 'procedure_code_24' then normalized_code else null end) as procedure_code_24
-    , max(case when lower(column_name) = 'procedure_code_14' then normalized_code else null end) as procedure_code_25
+    , max(case when lower(column_name) = 'procedure_code_25' then normalized_code else null end) as procedure_code_25
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 from {{ ref('normalized_input__int_procedure_code_voting') }}
 where (occurrence_row_count = 1

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_code_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_code_normalize.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) | as_bool
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
    )
 }}
 
@@ -272,7 +273,7 @@ with pivot_procedure as(
         , data_source
         , procedure_code_type
         , 'procedure_code_23'  as procedure_column
-        ,  procedure_code_24  as procedure_code
+        ,  procedure_code_23  as procedure_code
     from {{ ref('normalized_input__stg_medical_claim') }}
 
     union all

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_date_final.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_date_final.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) | as_bool
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
    )
 }}
 
@@ -30,7 +31,7 @@ select
     , max(case when lower(column_name) = 'procedure_date_22' then normalized_code else null end) as procedure_date_22
     , max(case when lower(column_name) = 'procedure_date_23' then normalized_code else null end) as procedure_date_23
     , max(case when lower(column_name) = 'procedure_date_24' then normalized_code else null end) as procedure_date_24
-    , max(case when lower(column_name) = 'procedure_date_14' then normalized_code else null end) as procedure_date_25
+    , max(case when lower(column_name) = 'procedure_date_25' then normalized_code else null end) as procedure_date_25
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 from {{ ref('normalized_input__int_procedure_date_voting') }}
 where (occurrence_row_count = 1

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_date_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_date_normalize.sql
@@ -250,7 +250,7 @@ with pivot_procedure as(
         , claim_type
         , data_source
         , 'procedure_date_23'  as procedure_column
-        ,  procedure_date_24  as procedure_date
+        ,  procedure_date_23  as procedure_date
     from {{ ref('normalized_input__stg_medical_claim') }}
 
     union all

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_date_voting.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_procedure_date_voting.sql
@@ -1,5 +1,6 @@
 {{ config(
-     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) | as_bool
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
    )
 }}
 
@@ -10,7 +11,7 @@ with distinct_count as(
         , procedure_column
         , count(*) as distinct_count
         , '{{ var('tuva_last_run')}}' as tuva_last_run
-    from {{ ref('normalized_input__int_procedure_code_normalize') }}
+    from {{ ref('normalized_input__int_procedure_date_normalize') }}
     group by
         claim_id
         , data_source

--- a/models/core/staging/core__stg_claims_procedure.sql
+++ b/models/core/staging/core__stg_claims_procedure.sql
@@ -12,8 +12,7 @@ with unpivot_cte as (
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , claim_line_number as procedure_sequence_id
   , patient_id as patient_id
   , coalesce(admission_date
            , claim_start_date
@@ -40,8 +39,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 1 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_1 as procedure_date
   , procedure_code_type as source_code_type
@@ -64,8 +62,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 2 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_2 as procedure_date
   , procedure_code_type as source_code_type
@@ -88,8 +85,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 3 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_3 as procedure_date
   , procedure_code_type as source_code_type
@@ -112,8 +108,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 4 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_4 as procedure_date
   , procedure_code_type as source_code_type
@@ -136,8 +131,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 5 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_5 as procedure_date
   , procedure_code_type as source_code_type
@@ -160,8 +154,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 6 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_6 as procedure_date
   , procedure_code_type as source_code_type
@@ -184,8 +177,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 7 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_7 as procedure_date
   , procedure_code_type as source_code_type
@@ -208,8 +200,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 8 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_8 as procedure_date
   , procedure_code_type as source_code_type
@@ -232,8 +223,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 9 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_9 as procedure_date
   , procedure_code_type as source_code_type
@@ -256,8 +246,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 10 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_10 as procedure_date
   , procedure_code_type as source_code_type
@@ -280,8 +269,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 11 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_11 as procedure_date
   , procedure_code_type as source_code_type
@@ -304,8 +292,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 12 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_12 as procedure_date
   , procedure_code_type as source_code_type
@@ -328,8 +315,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 13 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_13 as procedure_date
   , procedure_code_type as source_code_type
@@ -352,8 +338,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 14 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_14 as procedure_date
   , procedure_code_type as source_code_type
@@ -376,8 +361,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 15 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_15 as procedure_date
   , procedure_code_type as source_code_type
@@ -400,8 +384,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 16 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_16 as procedure_date
   , procedure_code_type as source_code_type
@@ -424,8 +407,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 17 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_17 as procedure_date
   , procedure_code_type as source_code_type
@@ -448,8 +430,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 18 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_18 as procedure_date
   , procedure_code_type as source_code_type
@@ -472,8 +453,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 19 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_19 as procedure_date
   , procedure_code_type as source_code_type
@@ -496,8 +476,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 20 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_20 as procedure_date
   , procedure_code_type as source_code_type
@@ -520,8 +499,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 21 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_21 as procedure_date
   , procedure_code_type as source_code_type
@@ -544,8 +522,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 22 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_22 as procedure_date
   , procedure_code_type as source_code_type
@@ -568,8 +545,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 23 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_23 as procedure_date
   , procedure_code_type as source_code_type
@@ -592,8 +568,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 24 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_24 as procedure_date
   , procedure_code_type as source_code_type
@@ -616,8 +591,7 @@ union distinct
 
 select
     claim_id as claim_id
-   ,claim_line_number as claim_line_number
-
+  , 25 as procedure_sequence_id
   , patient_id as patient_id
   , procedure_date_25 as procedure_date
   , procedure_code_type as source_code_type
@@ -640,6 +614,8 @@ select distinct
         "unpivot_cte.data_source",
         "'_'",
         "unpivot_cte.claim_id",
+        "'_'",
+        "unpivot_cte.procedure_sequence_id",
         "'_'",
         "unpivot_cte.source_code",
         "case when unpivot_cte.modifier_1 is not null then CONCAT('_', unpivot_cte.modifier_1) else '' end",


### PR DESCRIPTION
## Describe your changes
There was a bug in the code preventing all institutional procedure codes from passing into core. Root of the issue was found in procedure date voting. There was a join that would always return null. In debugging I found a few proc number typos. And additionally found the need to add procedure sequence number to the procedure id field.

## How has this been tested?
I ran the changes in a slightly older tuva version on our data and verified that the missing institutional procedure codes are now available in procedures table

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
