### PR TITLE
New Quality Measure: Medication Adherence for Diabetes

### DIFF
--- a/models/quality_measures/final/quality_measures__summary_long.sql
+++ b/models/quality_measures/final/quality_measures__summary_long.sql
@@ -22,6 +22,7 @@ with union_measures as (
             , ref('quality_measures__int_cqm48_long')
             , ref('quality_measures__int_cqm130_long')
             , ref('quality_measures__int_nqf0420_long')
+            , ref('quality_measures__int_adh_diabetes_long')
         ]
 
     ) }}

--- a/models/quality_measures/final/quality_measures__summary_wide.sql
+++ b/models/quality_measures/final/quality_measures__summary_wide.sql
@@ -150,6 +150,16 @@ with measures_long as (
 
 )
 
+, adh_diabetes as (
+
+    select
+          patient_id
+        , performance_flag
+    from measures_long
+    where measure_id = 'ADH-Diabetes'
+
+)
+
 , joined as (
 
     select
@@ -167,6 +177,7 @@ with measures_long as (
         , max(cqm_48.performance_flag) as cqm_48
         , max(cqm_130.performance_flag) as cqm_130
         , max(nqf_0420.performance_flag) as nqf_0420
+        , max(adh_diabetes.performance_flag) as adh_diabetes
     from measures_long
         left join nqf_2372
             on measures_long.patient_id = nqf_2372.patient_id
@@ -194,6 +205,8 @@ with measures_long as (
             on measures_long.patient_id = cqm_130.patient_id
         left join nqf_0420
             on measures_long.patient_id = nqf_0420.patient_id
+        left join adh_diabetes
+            on measures_long.patient_id = adh_diabetes.patient_id
     group by measures_long.patient_id
 
 )
@@ -215,6 +228,7 @@ with measures_long as (
         , cast(cqm_48 as integer) as cqm_48
         , cast(cqm_130 as integer) as cqm_130
         , cast(nqf_0420 as integer) as nqf_0420
+        , cast(adh_diabetes as integer) as adh_diabetes
     from joined
 
 )
@@ -234,5 +248,6 @@ select
     , cqm_48
     , cqm_130
     , nqf_0420
+    , adh_diabetes
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 from add_data_types

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes__performance_period.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes__performance_period.sql
@@ -1,0 +1,70 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False))))
+ | as_bool
+   )
+}}
+
+{%- set measure_id -%}
+(select id
+from {{ ref('quality_measures__measures') }}
+where id = 'ADH-Diabetes')
+{%- endset -%}
+
+{%- set measure_name -%}
+(select name
+from {{ ref('quality_measures__measures') }}
+where id = 'ADH-Diabetes')
+{%- endset -%}
+
+{%- set measure_version -%}
+(select version
+from {{ ref('quality_measures__measures') }}
+where id = 'ADH-Diabetes')
+{%- endset -%}
+
+/*
+    set performance period end to the end of the current calendar year
+    or use the quality_measures_period_end variable if provided
+*/
+
+with period_end as (
+
+    select
+        {% if var('quality_measures_period_end',False) == False -%}
+        {{ last_day(dbt.current_timestamp(), 'year') }}
+        {% else -%}
+        cast('{{ var('quality_measures_period_end') }}' as date)
+        {%- endif %}
+         as performance_period_end
+         
+)
+
+/*
+    set performance period begin to a year and a day prior
+    for a complete calendar year
+*/
+, period_begin as (
+
+    select
+          performance_period_end
+        , {{ dbt.dateadd (
+              datepart = "day"
+            , interval = +1
+            , from_date_or_timestamp =
+                dbt.dateadd (
+                      datepart = "year"
+                    , interval = -1
+                    , from_date_or_timestamp = "performance_period_end"
+            )
+          ) }} as performance_period_begin
+    from period_end
+
+)
+
+select
+      cast({{ measure_id }} as {{ dbt.type_string() }}) as measure_id
+    , cast({{ measure_name }} as {{ dbt.type_string() }}) as measure_name
+    , cast({{ measure_version }} as {{ dbt.type_string() }}) as measure_version
+    , cast(performance_period_begin as date) as performance_period_begin
+    , cast(performance_period_end as date) as performance_period_end
+from period_begin

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_denominator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_denominator.sql
@@ -89,7 +89,7 @@ with diabetics_codes as (
             as days_in_treatment_period
         /*  
             Performance Period end minus dispensing date results in 
-            first_date non-inclusive difference, so to include both of these days
+            second_date non-inclusive difference, so to include both of these days
             1 day is added
         */
     from rx_first_fill

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_denominator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_denominator.sql
@@ -1,0 +1,225 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+with diabetics_codes as (
+
+    select
+          code
+        , code_system
+    from {{ ref('quality_measures__value_sets') }}
+    where lower(concept_name) in (
+          'pqa diabetes medications'
+        )
+
+)
+
+, rx_diabetes as (
+
+    select
+        patient_id
+      , dispensing_date
+      , ndc_code
+      , days_supply
+    from {{ ref('quality_measures__stg_pharmacy_claim') }} as pharmacy_claims
+    inner join diabetics_codes
+        on pharmacy_claims.ndc_code = diabetics_codes.code
+            and lower(diabetics_codes.code_system) = 'ndc'
+
+)
+
+, rx_diabetes_in_measurement_period as (
+
+    select
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , days_supply
+        , performance_period_end -- to use in latter cte for days in treatment period calculation
+    from rx_diabetes
+    inner join {{ ref('quality_measures__int_adh_diabetes__performance_period') }} pp
+        on dispensing_date between pp.performance_period_begin and pp.performance_period_end
+
+)
+
+/* 
+    These patients need to pass two checks
+    - First medication fill date should be at least 91 days before the end of measurement period
+    - Should have at least two distinct Date of Service (FillDate) for rx
+*/
+
+, rx_fill_order as (
+
+    select
+          patient_id
+        , dispensing_date
+        , performance_period_end
+        , dense_rank() over (
+            partition by 
+                  patient_id
+                , performance_period_end
+            order by dispensing_date
+        ) as rn
+    from rx_diabetes_in_measurement_period
+
+)
+
+, rx_first_fill as (
+
+    select
+          patient_id
+        , dispensing_date
+        , performance_period_end
+    from rx_fill_order
+    where rn = 1
+          
+)
+
+, timely_fill_check as (
+
+    select
+          patient_id
+        , ( 1 + {{ dbt.datediff (
+                                  datepart = 'day'
+                                , first_date = 'dispensing_date'
+                                , second_date = 'performance_period_end'
+                            )
+            }} )
+            as days_in_treatment_period
+        /*  
+            Performance Period end minus dispensing date results in 
+            first_date non-inclusive difference, so to include both of these days
+            1 day is added
+        */
+    from rx_first_fill
+
+)
+
+, first_check_passed_patients as (
+
+    select
+          patient_id
+        , days_in_treatment_period
+    from timely_fill_check
+    where days_in_treatment_period > 90
+
+)
+
+, second_check_passed_patients as (
+
+    select
+          patient_id
+    from rx_fill_order
+    where rn = 2
+
+)
+
+, qualifying_patients as (
+
+    select
+          first_check_passed_patients.patient_id
+        , first_check_passed_patients.days_in_treatment_period
+    from first_check_passed_patients
+    inner join second_check_passed_patients
+        on first_check_passed_patients.patient_id = second_check_passed_patients.patient_id 
+
+)
+
+, qualifying_patients_with_age as (
+    
+    select
+          patients.patient_id
+        , floor({{ datediff('birth_date', 'pp.performance_period_begin', 'hour') }} / 8760.0) as age
+        , days_in_treatment_period
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+    from {{ ref('quality_measures__stg_core__patient') }} patients
+    inner join qualifying_patients
+        on patients.patient_id = qualifying_patients.patient_id
+    cross join {{ ref('quality_measures__int_adh_diabetes__performance_period') }} pp
+    where patients.death_date is null
+
+)
+/*
+    Extracting related fields like dispensing_date, ndc_code and days_supply of qualified patients
+    to avoid redundant computations in numerator model
+*/
+
+, qualifying_patients_all_claim_info as (
+
+    select
+          qualifying_patients_with_age.patient_id
+        , qualifying_patients_with_age.age
+        , rx_diabetes_in_measurement_period.dispensing_date
+        , rx_diabetes_in_measurement_period.ndc_code
+        , rx_diabetes_in_measurement_period.days_supply
+        , qualifying_patients_with_age.days_in_treatment_period
+        , qualifying_patients_with_age.performance_period_begin
+        , qualifying_patients_with_age.performance_period_end
+        , qualifying_patients_with_age.measure_id
+        , qualifying_patients_with_age.measure_name
+        , qualifying_patients_with_age.measure_version
+    from qualifying_patients_with_age
+    inner join rx_diabetes_in_measurement_period
+        on qualifying_patients_with_age.patient_id = rx_diabetes_in_measurement_period.patient_id
+
+)
+
+, denominator as (
+
+    select
+          patient_id
+        , age
+        , dispensing_date
+        , ndc_code
+        , days_supply
+        , days_in_treatment_period
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , 1 as denominator_flag
+    from qualifying_patients_all_claim_info
+    where age >= 18
+
+)
+
+, add_data_types as (
+
+    select
+          cast(patient_id as {{ dbt.type_string() }}) as patient_id
+        , cast(age as integer) as age
+        , cast(dispensing_date as date) as dispensing_date
+        , cast(ndc_code as {{ dbt.type_string() }}) as ndc_code
+        , cast(days_supply as integer) as days_supply
+        , cast(days_in_treatment_period as integer) as days_in_treatment_period
+        , cast(performance_period_begin as date) as performance_period_begin
+        , cast(performance_period_end as date) as performance_period_end
+        , cast(measure_id as {{ dbt.type_string() }}) as measure_id
+        , cast(measure_name as {{ dbt.type_string() }}) as measure_name
+        , cast(measure_version as {{ dbt.type_string() }}) as measure_version
+        , cast(denominator_flag as integer) as denominator_flag
+    from denominator
+
+)
+
+select
+      patient_id
+    , age
+    , dispensing_date
+    , ndc_code
+    , days_supply
+    , days_in_treatment_period
+    , performance_period_begin
+    , performance_period_end
+    , measure_id
+    , measure_name
+    , measure_version
+    , denominator_flag
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from add_data_types

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_denominator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_denominator.sql
@@ -60,7 +60,7 @@ with diabetics_codes as (
                   patient_id
                 , performance_period_end
             order by dispensing_date
-        ) as rn
+        ) as dr
     from rx_diabetes_in_measurement_period
 
 )
@@ -72,7 +72,7 @@ with diabetics_codes as (
         , dispensing_date
         , performance_period_end
     from rx_fill_order
-    where rn = 1
+    where dr = 1
           
 )
 
@@ -111,7 +111,7 @@ with diabetics_codes as (
     select
           patient_id
     from rx_fill_order
-    where rn = 2
+    where dr = 2
 
 )
 

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_exclusions.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_exclusions.sql
@@ -1,0 +1,178 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+{%- set performance_period_begin -%}
+(
+
+  select 
+    performance_period_begin
+  from {{ ref('quality_measures__int_adh_diabetes__performance_period') }}
+
+)
+{%- endset -%}
+
+{%- set performance_period_end -%}
+(
+
+  select 
+    performance_period_end
+  from {{ ref('quality_measures__int_adh_diabetes__performance_period') }}
+
+)
+{%- endset -%}
+
+with denominator as (
+    
+    select
+        patient_id
+    from {{ ref('quality_measures__int_adh_diabetes_denominator') }}
+
+)
+
+, exclusion_codes as (
+
+    select
+        code
+      , code_system
+      , concept_name
+    from {{ ref('quality_measures__value_sets') }}
+    where lower(concept_name) in (
+          'pqa esrd'
+        , 'pqa insulin medications'
+    )
+
+)
+
+, hospice_palliative as (
+
+    select
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+    from {{ ref('quality_measures__int_shared_exclusions_hospice_palliative') }}
+    where exclusion_date between {{ performance_period_begin }} and {{ performance_period_end }}
+
+)
+
+, valid_hospice as (
+
+    select
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+    from hospice_palliative
+    where lower(exclusion_reason) in (
+            'hospice encounter'
+          , 'hospice care ambulatory'
+          , 'hospice diagnosis'
+    )
+
+)
+
+, conditions as (
+
+    select
+          patient_id
+        , recorded_date
+        , claim_id
+        , coalesce (
+              normalized_code_type
+            , case
+                when lower(source_code_type) = 'snomed' then 'snomed-ct'
+                else lower(source_code_type)
+              end
+          ) as code_type
+        , coalesce (
+              normalized_code
+            , source_code
+          ) as code
+    from {{ ref('quality_measures__stg_core__condition') }}
+    where recorded_date between {{ performance_period_begin }} and {{ performance_period_end }}
+
+)
+
+, condition_exclusions as (
+
+      select
+          conditions.patient_id
+        , conditions.recorded_date as exclusion_date
+        , exclusion_codes.concept_name as exclusion_reason
+    from conditions
+    inner join exclusion_codes
+      on conditions.code = exclusion_codes.code
+        and conditions.code_type = exclusion_codes.code_system
+
+)
+
+, pharmacy_exclusions as (
+
+    select
+        patient_id
+      , dispensing_date as exclusion_date
+      , concept_name as exclusion_reason
+    from {{ ref('quality_measures__stg_pharmacy_claim') }} as pharmacy_claims
+    inner join exclusion_codes
+      on pharmacy_claims.ndc_code = exclusion_codes.code
+        and exclusion_codes.code_system = 'ndc'
+
+)
+
+, exclusion_patients as (
+
+    select
+        patient_id
+      , exclusion_date
+      , exclusion_reason
+    from valid_hospice
+
+    union all
+
+    select
+        patient_id
+      , exclusion_date
+      , exclusion_reason
+    from condition_exclusions
+
+    union all
+
+    select
+        patient_id
+      , exclusion_date
+      , exclusion_reason
+    from pharmacy_exclusions
+
+)
+
+, combined_exclusions as (
+
+    select
+        exclusion_patients.patient_id
+      , exclusion_patients.exclusion_date
+      , exclusion_patients.exclusion_reason
+    from exclusion_patients
+    inner join denominator
+      on exclusion_patients.patient_id = denominator.patient_id
+
+)
+
+, add_data_types as (
+
+    select
+        distinct
+          cast(patient_id as {{ dbt.type_string() }}) as patient_id
+        , cast(exclusion_date as date) as exclusion_date
+        , cast(exclusion_reason as {{ dbt.type_string() }}) as exclusion_reason
+        , cast(1 as integer) as exclusion_flag
+    from combined_exclusions
+
+)
+
+select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+    , exclusion_flag
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from add_data_types

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_long.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_long.sql
@@ -1,0 +1,152 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+with denominator as (
+
+    select
+          patient_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from {{ ref('quality_measures__int_adh_diabetes_denominator') }}
+
+)
+
+, numerator as (
+
+    select
+          patient_id
+        , evidence_date
+        , evidence_value
+    from {{ ref('quality_measures__int_adh_diabetes_numerator') }}
+
+)
+
+, exclusions as (
+
+    select
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+    from {{ ref('quality_measures__int_adh_diabetes_exclusions') }}
+
+)
+
+, measure_flags as (
+
+    select
+          denominator.patient_id
+        , case
+            when denominator.patient_id is not null
+            then 1
+            else null
+          end as denominator_flag
+        , case
+            when numerator.patient_id is not null and denominator.patient_id is not null
+            then 1
+            when denominator.patient_id is not null
+            then 0
+            else null
+          end as numerator_flag
+        , case
+            when exclusions.patient_id is not null and denominator.patient_id is not null
+            then 1
+            when denominator.patient_id is not null
+            then 0
+            else null
+          end as exclusion_flag
+        , numerator.evidence_date
+        , numerator.evidence_value
+        , exclusions.exclusion_date
+        , exclusions.exclusion_reason
+        , denominator.performance_period_begin
+        , denominator.performance_period_end
+        , denominator.measure_id
+        , denominator.measure_name
+        , denominator.measure_version
+        , (row_number() over(
+            partition by
+                  denominator.patient_id
+                , denominator.performance_period_begin
+                , denominator.performance_period_end
+                , denominator.measure_id
+                , denominator.measure_name
+              order by
+                  case when numerator.evidence_date is null then 1 else 0 end,
+                  numerator.evidence_date desc
+                , case when exclusions.exclusion_date is null then 1 else 0 end,
+                  exclusions.exclusion_date desc
+          )) as rn
+    from denominator
+        left join numerator
+            on denominator.patient_id = numerator.patient_id
+        left join exclusions
+            on denominator.patient_id = exclusions.patient_id
+
+)
+
+/*
+    Deduplicate measure rows by latest evidence date or exclusion date
+*/
+, deduped as (
+
+    select
+          patient_id
+        , denominator_flag
+        , numerator_flag
+        , exclusion_flag
+        , evidence_date
+        , evidence_value
+        , exclusion_date
+        , exclusion_reason
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+    from measure_flags
+    where rn = 1
+
+)
+
+, add_data_types as (
+
+    select
+          cast(patient_id as {{ dbt.type_string() }}) as patient_id
+        , cast(denominator_flag as integer) as denominator_flag
+        , cast(numerator_flag as integer) as numerator_flag
+        , cast(exclusion_flag as integer) as exclusion_flag
+        , cast(evidence_date as date) as evidence_date
+        , cast(evidence_value as {{ dbt.type_string() }}) as evidence_value
+        , cast(exclusion_date as date) as exclusion_date
+        , cast(exclusion_reason as {{ dbt.type_string() }}) as exclusion_reason
+        , cast(performance_period_begin as date) as performance_period_begin
+        , cast(performance_period_end as date) as performance_period_end
+        , cast(measure_id as {{ dbt.type_string() }}) as measure_id
+        , cast(measure_name as {{ dbt.type_string() }}) as measure_name
+        , cast(measure_version as {{ dbt.type_string() }}) as measure_version
+    from deduped
+
+)
+
+select
+      patient_id
+    , denominator_flag
+    , numerator_flag
+    , exclusion_flag
+    , evidence_date
+    , evidence_value
+    , exclusion_date
+    , exclusion_reason
+    , performance_period_begin
+    , performance_period_end
+    , measure_id
+    , measure_name
+    , measure_version
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from add_data_types

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
@@ -325,4 +325,4 @@ select
     , adherence
     , numerator_flag
     , '{{ var('tuva_last_run')}}' as tuva_last_run
-from numerator
+from add_data_types

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
@@ -71,7 +71,11 @@ with denominator as (
         , ndc_code
         , dispensing_date
         , days_supply
-        , sum(med_change_flag) over (partition by patient_id order by dr) as group_id
+        , sum(med_change_flag) over (
+              partition by patient_id 
+              order by dr 
+              rows between unbounded preceding and current row
+          ) as group_id
     from grouped_meds
 
 )

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
@@ -284,7 +284,7 @@ with denominator as (
 
     select
           final_covered_days.patient_id
-        , round(cast(actual_covered_days / days_in_treatment_period as {{ dbt.type_numeric() }}), 2) as adherence
+        , round(cast(actual_covered_days / days_in_treatment_period as {{ dbt.type_numeric() }}), 4) as adherence
         , dispensing_date as evidence_date
         , days_supply as evidence_value
     from final_covered_days

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
@@ -314,7 +314,7 @@ with denominator as (
 
     select
           patient_id
-        , adherence
+        , adherence * 100 as adherence --percent conversion
         , evidence_date
         , evidence_value
         , 1 as numerator_flag

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
@@ -1,0 +1,328 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+with denominator as (
+
+    select
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , days_supply
+        , days_in_treatment_period
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+    from {{ ref('quality_measures__int_adh_diabetes_denominator') }}
+
+)
+
+, performance_end as (
+
+    select
+      performance_period_end
+    from {{ ref('quality_measures__int_adh_diabetes__performance_period') }}
+
+)
+
+, cte2 as (
+
+    select
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , days_supply
+        , dense_rank() over (partition by patient_id order by dispensing_date) as rn
+        , lag(ndc_code) over (partition by patient_id order by dispensing_date) as previous_ndc
+    from denominator
+
+)
+
+, grouped_meds as (
+
+    select
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , days_supply
+        , rn
+        , case
+            when (ndc_code != previous_ndc) or previous_ndc is null then 1
+            else 0
+          end as med_change_flag --to increment group when medication changes
+    from cte2
+
+)
+
+, final_groups as (
+
+    select
+          patient_id
+        , ndc_code
+        , dispensing_date
+        , days_supply
+        , sum(med_change_flag) over (partition by patient_id order by rn) as group_id
+    from grouped_meds
+
+)
+
+, fills as (
+
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , {{ dbt.dateadd (
+              datepart = "day"
+            , interval = -1
+            , from_date_or_timestamp =
+                dbt.dateadd (
+                      datepart = "day"
+                    , interval = "days_supply"
+                    , from_date_or_timestamp = "dispensing_date"
+            )
+          ) }} as theoretical_end_date
+    from final_groups
+
+)
+
+, adjusted_fillsv1 as (
+    
+    /* Adjust start dates based on the previous fill's end date + 1,
+    or use the current rx_fill_date */
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , theoretical_end_date
+        , lag(theoretical_end_date)
+          over (partition by 
+                patient_id
+              , group_id  
+            order by
+                dispensing_date
+          ) as previous_end_date
+    from fills
+
+)
+
+, adjusted_fills as (
+    
+    /* Adjust start dates based on the previous fill's end date + 1,
+    or use the current rx_fill_date */
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , theoretical_end_date
+        , coalesce(
+            greatest(
+                  dispensing_date
+                , {{ dbt.dateadd (
+                      datepart = "day"
+                    , interval = +1
+                    , from_date_or_timestamp = "previous_end_date"
+                  ) }}
+                )
+            , dispensing_date
+        ) as adjusted_start_date
+    from adjusted_fillsv1
+
+)
+
+, final_fills as (
+
+    select
+        patient_id
+      , group_id
+      , dispensing_date
+      , days_supply
+      , adjusted_start_date
+      , least(
+            {{ dbt.dateadd (
+                datepart = "day"
+              , interval = -1
+              , from_date_or_timestamp =
+                  dbt.dateadd (
+                        datepart = "day"
+                      , interval = "days_supply"
+                      , from_date_or_timestamp = "adjusted_start_date"
+              )
+            ) }}
+          , performance_period_end
+      ) as final_end_date
+    from adjusted_fills
+    inner join performance_end
+      on adjusted_fills.adjusted_start_date <= performance_end.performance_period_end
+
+)
+
+, final_final_fills as (
+
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , adjusted_start_date
+        , final_end_date
+        , min(adjusted_start_date) over(partition by patient_id, group_id) as first_disp_date
+        , max(adjusted_start_date) over(partition by patient_id, group_id) as last_disp_date
+    from final_fills
+
+)
+
+, last_med_end_groupwise as (
+
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , adjusted_start_date
+        , final_end_date
+        , first_disp_date
+        , last_disp_date
+        , max(
+            case
+              when adjusted_start_date = last_disp_date
+              then days_supply
+              else null
+            end) over (partition by patient_id, group_id) as last_days_supply
+    from final_final_fills
+
+)
+
+, covered_days as (
+    
+    select
+          patient_id
+        , group_id
+        , first_disp_date
+        , last_disp_date
+        , last_days_supply
+        , sum( 1 + {{ dbt.datediff (
+                                  datepart = 'day'
+                                , first_date = 'adjusted_start_date'
+                                , second_date = 'final_end_date'
+                            )
+            }} ) as covered_days
+    from last_med_end_groupwise
+    group by 
+          patient_id
+        , group_id
+        , first_disp_date
+        , last_disp_date
+        , last_days_supply
+
+)
+
+, final_with_lag as (
+
+    select
+          patient_id
+        , group_id
+        , first_disp_date
+        , last_disp_date
+        , covered_days
+        , lag(last_disp_date) over(partition by patient_id order by first_disp_date) as lag_date
+        , lag(last_days_supply) over(partition by patient_id order by first_disp_date) as lag_days_supply
+    from covered_days
+
+)
+
+, overlap_days as (
+
+    select
+          patient_id
+        , group_id
+        , first_disp_date
+        , last_disp_date
+        , covered_days
+        , lag_date
+        , case
+            when first_disp_date < 
+                {{ dbt.dateadd (
+                    datepart = "day"
+                  , interval = "lag_days_supply"
+                  , from_date_or_timestamp = "lag_date" 
+                ) }}
+            then
+                {{ dbt.datediff (
+                                  datepart = 'day'
+                                , first_date = "first_disp_date"
+                                , second_date = 
+                                              dbt.dateadd (
+                                                datepart = "day"
+                                              , interval = "lag_days_supply"
+                                              , from_date_or_timestamp = "lag_date" 
+                                            )
+                ) }}
+            else 0
+          end as overlap
+    from final_with_lag
+
+)
+
+, final_covered_days as (
+
+    select 
+          patient_id
+        , sum(covered_days) - sum(overlap) as actual_covered_days
+    from overlap_days
+    group by patient_id
+
+)  
+
+, relevant_patients_from_deno as (
+
+    select
+          final_covered_days.patient_id
+        , round(cast(actual_covered_days / days_in_treatment_period as {{ dbt.type_numeric() }}), 2) as adherence
+        , dispensing_date as evidence_date
+        , days_supply as evidence_value
+    from final_covered_days
+    inner join denominator
+      on final_covered_days.patient_id = denominator.patient_id
+        
+)
+
+, numerator as (
+
+    select
+          patient_id
+        , adherence
+        , evidence_date
+        , evidence_value
+        , 1 as numerator_flag
+    from relevant_patients_from_deno
+    where adherence >= 0.8
+
+)
+
+, add_data_types as (
+
+    select
+          cast(patient_id as {{ dbt.type_string() }}) as patient_id
+        , cast(evidence_date as date) as evidence_date
+        , cast(evidence_value as {{ dbt.type_string() }}) as evidence_value
+        , cast(adherence as {{ dbt.type_numeric() }}) as adherence
+        , cast(numerator_flag as integer) as numerator_flag
+    from numerator
+
+)
+
+select
+      patient_id
+    , evidence_date
+    , evidence_value
+    , adherence
+    , numerator_flag
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from numerator

--- a/models/quality_measures/quality_measures_models.yml
+++ b/models/quality_measures/quality_measures_models.yml
@@ -2598,7 +2598,7 @@ models:
           Observed evidence value for the patients in the numerator.
       - name: adherence
         description: >
-          The degree to which the person behaviour corresponds with taking a medicine optimally.
+          The degree to which the person behaviour corresponds with taking a medicine optimally in percentage.
       - name: numerator_flag
         description: >
           The numerator reflects the subset of patients in the denominator 
@@ -2778,6 +2778,7 @@ models:
       - name: patient_id
       - name: dispensing_date
       - name: ndc_code
+      - name: days_supply
       - name: paid_date
       - name: tuva_last_run
 

--- a/models/quality_measures/quality_measures_models.yml
+++ b/models/quality_measures/quality_measures_models.yml
@@ -182,6 +182,10 @@ models:
         description: >
           Performance flag for NQF0420, Pain Assessment and Follow-Up. 
           A null indicates that the measure was not applicable for the patient.
+      - name: adh_diabetes
+        description: >
+          Performance flag for ADH-Diabetes, Medication Adherence for Diabetes Medications. 
+          A null indicates that the measure was not applicable for the patient.
       - name: tuva_last_run
         description: The date and timestamp of the dbt run.
 
@@ -2437,6 +2441,164 @@ models:
       - name: evidence_value
         description: >
           Observed evidence value for the patients in the numerator.
+      - name: numerator_flag
+        description: >
+          The numerator reflects the subset of patients in the denominator 
+          for whom a particular service has been provided or for whom a 
+          particular outcome has been achieved.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+### Medication Adherence for Diabetes Medications
+  - name: quality_measures__int_adh_diabetes__performance_period
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_diabetes__performance_period
+      tags: quality_measures
+      materialized: view
+    description: >
+      Performance Period definition for Medication Adherence for Diabetes Medications.
+
+  - name: quality_measures__int_adh_diabetes_denominator
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_diabetes_denominator
+      tags: quality_measures
+      materialized: table
+    description: >
+      Denominator logic for the reporting version of ADH-Diabetes, Medication Adherence for Diabetes Medications.
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: age
+        description: Patient's age during latest encounter in the performance period.
+      - name: dispensing_date
+        description: Date the prescription was filled.
+      - name: ndc_code
+        description: National drug code on the claim.
+      - name: days_supply
+        description: Number of days the filled medication lasts for.
+      - name: days_in_treatment_period
+        description: Number of days from first dispensing_date to performance_period_end in the performance or measurement period.
+      - name: performance_period_begin
+        description: Beginning date of the performance or measurement period.
+      - name: performance_period_end
+        description: Ending date of the performance or measurement period.
+      - name: measure_id
+        description: Unique measure identification number.
+      - name: measure_name
+        description: Name of the measure.
+      - name: measure_version
+        description: Version of the measure.
+      - name: denominator_flag
+        description: >
+          The denominator is associated with a given patient population that 
+          may be counted as eligible to meet a measure’s inclusion requirements.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+  - name: quality_measures__int_adh_diabetes_exclusions
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_diabetes_exclusions
+      tags: quality_measures
+      materialized: table
+    description: >
+      Combined exclusion logic for the reporting version of ADH-Diabetes, Medication Adherence for Diabetes Medications.
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: exclusion_date
+        description: >
+          Date of event or service that excludes patient from the measure.
+      - name: exclusion_reason
+        description: >
+          Reason (usually the value set concept name) that excludes patient 
+          from the measure.
+      - name: exclusion_flag
+        description: >
+          Specifications of those characteristics that would cause groups of 
+          individuals to be removed from the numerator and/or denominator of 
+          a measure although they experience the denominator index event.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+  - name: quality_measures__int_adh_diabetes_long
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_diabetes_long
+      tags: quality_measures
+      materialized: table
+    description: >
+      Final preparation of the reporting version of ADH-Diabetes, Medication Adherence for Diabetes Medications before combining with other measures.
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: denominator_flag
+        description: >
+          The denominator is associated with a given patient population that 
+          may be counted as eligible to meet a measure’s inclusion requirements.
+      - name: numerator_flag
+        description: >
+          The numerator reflects the subset of patients in the denominator 
+          for whom a particular service has been provided or for whom a 
+          particular outcome has been achieved.
+      - name: exclusion_flag
+        description: >
+          Specifications of those characteristics that would cause groups of 
+          individuals to be removed from the numerator and/or denominator of 
+          a measure although they experience the denominator index event.
+      - name: evidence_date
+        description: >
+          Date of event or service that places patient in the numerator.
+      - name: evidence_value
+        description: >
+          Observed evidence value for the patients in the numerator.
+      - name: exclusion_date
+        description: >
+          Date of event or service that excludes patient from the measure.
+      - name: exclusion_reason
+        description: >
+          Reason (usually the value set concept name) that excludes patient 
+          from the measure.
+      - name: performance_period_begin
+        description: Beginning date of the performance or measurement period.
+      - name: performance_period_end
+        description: Ending date of the performance or measurement period.
+      - name: measure_id
+        description: Unique measure identification number.
+      - name: measure_name
+        description: Name of the measure.
+      - name: measure_version
+        description: Version of the measure.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+  - name: quality_measures__int_adh_diabetes_numerator
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_diabetes_numerator
+      tags: quality_measures
+      materialized: table
+    description: >
+      Numerator logic for the reporting version of ADH-Diabetes, Medication Adherence for Diabetes Medications.
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: evidence_date
+        description: >
+          Date of event or service that places patient in the numerator.
+      - name: evidence_value
+        description: >
+          Observed evidence value for the patients in the numerator.
+      - name: adherence
+        description: >
+          The degree to which the person behaviour corresponds with taking a medicine optimally.
       - name: numerator_flag
         description: >
           The numerator reflects the subset of patients in the denominator 

--- a/models/quality_measures/staging/quality_measures__stg_pharmacy_claim.sql
+++ b/models/quality_measures/staging/quality_measures__stg_pharmacy_claim.sql
@@ -8,6 +8,7 @@
 select
       patient_id
     , dispensing_date
+    , days_supply
     , ndc_code
     , paid_date
     , '{{ var('tuva_last_run')}}' as tuva_last_run
@@ -18,6 +19,7 @@ from {{ ref('core__pharmacy_claim') }}
 select
       patient_id
     , dispensing_date
+    , days_supply
     , ndc_code
     , paid_date
     , '{{ var('tuva_last_run')}}' as tuva_last_run
@@ -29,6 +31,7 @@ from {{ ref('core__pharmacy_claim') }}
     select top 0
       cast(null as {{ dbt.type_string() }} ) as patient_id
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as dispensing_date
+    , cast(days_supply as integer) as days_supply
     , cast(null as {{ dbt.type_string() }} ) as ndc_code
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as paid_date
     , cast(null as {{ dbt.type_timestamp() }} ) as tuva_last_run
@@ -36,6 +39,7 @@ from {{ ref('core__pharmacy_claim') }}
     select
       cast(null as {{ dbt.type_string() }} ) as patient_id
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as dispensing_date
+    , cast(days_supply as integer) as days_supply
     , cast(null as {{ dbt.type_string() }} ) as ndc_code
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as paid_date
     , cast(null as {{ dbt.type_timestamp() }} ) as tuva_last_run

--- a/models/quality_measures/staging/quality_measures__stg_pharmacy_claim.sql
+++ b/models/quality_measures/staging/quality_measures__stg_pharmacy_claim.sql
@@ -8,8 +8,8 @@
 select
       patient_id
     , dispensing_date
-    , days_supply
     , ndc_code
+    , days_supply
     , paid_date
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 from {{ ref('core__pharmacy_claim') }}
@@ -19,8 +19,8 @@ from {{ ref('core__pharmacy_claim') }}
 select
       patient_id
     , dispensing_date
-    , days_supply
     , ndc_code
+    , days_supply
     , paid_date
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 from {{ ref('core__pharmacy_claim') }}
@@ -31,16 +31,16 @@ from {{ ref('core__pharmacy_claim') }}
     select top 0
       cast(null as {{ dbt.type_string() }} ) as patient_id
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as dispensing_date
-    , cast(days_supply as integer) as days_supply
     , cast(null as {{ dbt.type_string() }} ) as ndc_code
+    , cast(null as {{ dbt.type_int() }} ) as days_supply
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as paid_date
     , cast(null as {{ dbt.type_timestamp() }} ) as tuva_last_run
 {% else %}
     select
       cast(null as {{ dbt.type_string() }} ) as patient_id
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as dispensing_date
-    , cast(days_supply as integer) as days_supply
     , cast(null as {{ dbt.type_string() }} ) as ndc_code
+    , cast(null as {{ dbt.type_int() }} ) as days_supply
     , {{ try_to_cast_date('null', 'YYYY-MM-DD') }} as paid_date
     , cast(null as {{ dbt.type_timestamp() }} ) as tuva_last_run
     limit 0


### PR DESCRIPTION
## Describe your changes
Implemented Quality Measure ADH-Diabetes: Medication Adherence for Diabetes according to the [specification document](https://www.cms.gov/files/document/2024-star-ratings-technical-notes.pdf#page=98).


## How has this been tested?
Ran `dbt build` against Snowflake and BigQuery.
Additionally, [a validation document](https://docs.google.com/spreadsheets/d/1vwQDJIyt5I0LODv3SfBrMK9gX1ZcLzXMS3m3Fav785Y/edit?usp=sharing) has been prepared to manually test models output in `tuva_synthetic` db


## Reviewer focus
Since `days_supply` field is null across `pharmacy_claim` table in synthetic data, logic has been drafted with assumption that multiple refills of same prescription are not filled simultaneously, but around/after the end of existing fill. Please verify on real data.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [x] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [x] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [x] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDJoNWRnaGRrd3VudGZjdnhlMjV2N2RjcWZ0djU3ZzVneGNlN29nciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jPMqASVsBxhZP0ldYS/giphy.gif)


## Loom link
