### PR TITLE
added safe cast for obs+lab result eval

### DIFF
--- a/models/quality_measures/intermediate/cqm236_controlling_blood_pressure/quality_measures__int_cqm236_numerator.sql
+++ b/models/quality_measures/intermediate/cqm236_controlling_blood_pressure/quality_measures__int_cqm236_numerator.sql
@@ -60,6 +60,7 @@ with controlled_bp_codes as (
               '99473' -- Self-measured blood pressure using a device validated for clinical accuracy; patient education/training and device calibration
             , '99474' -- Separate self-measurements of two readings one minute apart, twice daily over a 30-day period (minimum of 12 readings), collection of data reported by the patient and/or caregiver to the physician or other qualified health care professional, with report of average systolic and diastolic pressures and subsequent communication of a treatment plan to the patient
         )
+        and {{ dbt.safe_cast("result", api.Column.translate_type("numeric")) }} is not null
 
 )
 
@@ -77,6 +78,7 @@ with controlled_bp_codes as (
     ,'8462-4') --diastolic
     and
     normalized_code_type = 'loinc'
+    and {{ dbt.safe_cast("result", api.Column.translate_type("numeric")) }} is not null
 
 )
 


### PR DESCRIPTION
## Describe your changes
added a safe cast on the result column for labs and observations.  For BP readings, the results column is being evaluated `< <integer>`, which throws an error if result is text, such as `not given`


## How has this been tested?
Run in client env

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [x] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [x] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [x] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXBhcmh1NmE3ZWp5M2ZndGJnZXBranMwdWk5cHJzNWRqOHo3OG9vMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/AfOBdq0rumImNlukVz/giphy-downsized-large.gif)


## Loom link
