### PR TITLE
Fix limit logic in financial_pmpm__stg_provider_attribution

### DIFF
--- a/models/financial_pmpm/staging/financial_pmpm__stg_provider_attribution.sql
+++ b/models/financial_pmpm/staging/financial_pmpm__stg_provider_attribution.sql
@@ -5,58 +5,58 @@
 
 {% if var('provider_attribution_enabled',False) == true -%}
 
-
 select
-         cast(patient_id as {{ dbt.type_string() }} ) as patient_id
-       , cast(year_month as {{ dbt.type_string() }} ) as year_month
-       , cast(payer as {{ dbt.type_string() }} ) as payer
-       , {{ quote_column('plan') }}
-       , cast(data_source as {{ dbt.type_string() }} ) as data_source
-       
-       , cast(payer_attributed_provider as {{ dbt.type_string() }} )
-                   as payer_attributed_provider
-       , cast(payer_attributed_provider_practice as {{ dbt.type_string() }} )
-                   as payer_attributed_provider_practice
-       , cast(payer_attributed_provider_organization as {{ dbt.type_string() }} )
-                   as payer_attributed_provider_organization
-       , cast(payer_attributed_provider_lob as {{ dbt.type_string() }} )
-                   as payer_attributed_provider_lob
-
-       , cast(custom_attributed_provider as {{ dbt.type_string() }} )
-                   as custom_attributed_provider
-       , cast(custom_attributed_provider_practice as {{ dbt.type_string() }} )
-                   as custom_attributed_provider_practice
-       , cast(custom_attributed_provider_organization as {{ dbt.type_string() }} )
-                   as custom_attributed_provider_organization
-       , cast(custom_attributed_provider_lob as {{ dbt.type_string() }} )
-                   as custom_attributed_provider_lob
-
-       , '{{ var('tuva_last_run')}}' as tuva_last_run
-       
+      cast(patient_id as {{ dbt.type_string() }} ) as patient_id
+    , cast(year_month as {{ dbt.type_string() }} ) as year_month
+    , cast(payer as {{ dbt.type_string() }} ) as payer
+    , {{ quote_column('plan') }}
+    , cast(data_source as {{ dbt.type_string() }} ) as data_source
+    , cast(payer_attributed_provider as {{ dbt.type_string() }} ) as payer_attributed_provider
+    , cast(payer_attributed_provider_practice as {{ dbt.type_string() }} ) as payer_attributed_provider_practice
+    , cast(payer_attributed_provider_organization as {{ dbt.type_string() }} ) as payer_attributed_provider_organization
+    , cast(payer_attributed_provider_lob as {{ dbt.type_string() }} ) as payer_attributed_provider_lob
+    , cast(custom_attributed_provider as {{ dbt.type_string() }} ) as custom_attributed_provider
+    , cast(custom_attributed_provider_practice as {{ dbt.type_string() }} ) as custom_attributed_provider_practice
+    , cast(custom_attributed_provider_organization as {{ dbt.type_string() }} ) as custom_attributed_provider_organization
+    , cast(custom_attributed_provider_lob as {{ dbt.type_string() }} ) as custom_attributed_provider_lob
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
 from {{ ref('provider_attribution') }}
 
+{% elif var('provider_attribution_enabled',False) ==  false -%}
 
-
-{%- else %}
-
-
+{% if target.type == 'fabric' %}
+select top 0
+      cast(null as {{ dbt.type_string() }} ) patient_id
+    , cast(null as {{ dbt.type_string() }} ) as year_month
+    , cast(null as {{ dbt.type_string() }} ) as payer
+    , cast(null as {{ dbt.type_string() }} ) as {{ quote_column('plan') }}
+    , cast(null as {{ dbt.type_string() }} ) as data_source
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_practice
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_organization
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_lob
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_practice
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_organization
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_lob
+    , cast(null as {{ dbt.type_string() }} ) as tuva_last_run
+{% else %}
 select
-         cast(null as {{ dbt.type_string() }} ) patient_id
-       , cast(null as {{ dbt.type_string() }} ) as year_month
-       , cast(null as {{ dbt.type_string() }} ) as payer
-       , cast(null as {{ dbt.type_string() }} ) as {{ quote_column('plan') }}
-       , cast(null as {{ dbt.type_string() }} ) as data_source
-       
-       , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider
-       , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_practice
-       , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_organization
-       , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_lob
-       , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider
-       , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_practice
-       , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_organization
-       , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_lob
-       , cast(null as {{ dbt.type_string() }} ) as tuva_last_run
-
+      cast(null as {{ dbt.type_string() }} ) patient_id
+    , cast(null as {{ dbt.type_string() }} ) as year_month
+    , cast(null as {{ dbt.type_string() }} ) as payer
+    , cast(null as {{ dbt.type_string() }} ) as {{ quote_column('plan') }}
+    , cast(null as {{ dbt.type_string() }} ) as data_source
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_practice
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_organization
+    , cast(null as {{ dbt.type_string() }} ) as payer_attributed_provider_lob
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_practice
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_organization
+    , cast(null as {{ dbt.type_string() }} ) as custom_attributed_provider_lob
+    , cast(null as {{ dbt.type_string() }} ) as tuva_last_run
 limit 0
+{%- endif %}
 
-{%- endif %} 
+{%- endif %}


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

Added "limit" logic for Fabric adapter to `financial_pmpm__stg_provider_attribution`.


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

Tested various combinations of vars.

`"clinical_enabled":true,"claims_enabled":true`
`"claims_enabled":true,"provider_attribution_enabled":true`
`"claims_enabled":true`
`"clinical_enabled":true`
`"provider_attribution_enabled":true`

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
