### PR TITLE
New Quality Measure: Medication Adherence for Cholesterol

### DIFF
--- a/models/quality_measures/final/quality_measures__summary_long.sql
+++ b/models/quality_measures/final/quality_measures__summary_long.sql
@@ -25,6 +25,7 @@ with union_measures as (
             , ref('quality_measures__int_adh_diabetes_long')
             , ref('quality_measures__int_adhras_long')
             , ref('quality_measures__int_supd_long')
+            , ref('quality_measures__int_adh_statins_long')
         ]
 
     ) }}

--- a/models/quality_measures/final/quality_measures__summary_wide.sql
+++ b/models/quality_measures/final/quality_measures__summary_wide.sql
@@ -180,6 +180,16 @@ with measures_long as (
 
 )
 
+, adh_statins as (
+
+    select
+          patient_id
+        , performance_flag
+    from measures_long
+    where measure_id = 'ADH-Statins'
+
+)
+
 , joined as (
 
     select
@@ -200,6 +210,7 @@ with measures_long as (
         , max(adh_diabetes.performance_flag) as adh_diabetes
         , max(adh_ras.performance_flag) as adh_ras
         , max(supd.performance_flag) as supd
+        , max(adh_statins.performance_flag) as adh_statins
     from measures_long
         left join nqf_2372
             on measures_long.patient_id = nqf_2372.patient_id
@@ -233,6 +244,8 @@ with measures_long as (
             on measures_long.patient_id = adh_ras.patient_id
         left join supd
             on measures_long.patient_id = supd.patient_id
+        left join adh_statins
+            on measures_long.patient_id = adh_statins.patient_id
     group by measures_long.patient_id
 
 )
@@ -257,6 +270,7 @@ with measures_long as (
         , cast(adh_diabetes as integer) as adh_diabetes
         , cast(adh_ras as integer) as adh_ras
         , cast(supd as integer) as supd
+        , cast(adh_statins as integer) as adh_statins
     from joined
 
 )
@@ -279,5 +293,6 @@ select
     , adh_diabetes
     , adh_ras
     , supd
+    , adh_statins
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 from add_data_types

--- a/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins__performance_period.sql
+++ b/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins__performance_period.sql
@@ -1,0 +1,82 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False))))
+     | as_bool
+   )
+}}
+
+{%- set measure_id -%}
+
+(
+  select id
+  from {{ ref('quality_measures__measures') }}
+  where id = 'ADH-Statins'
+)
+
+{%- endset -%}
+
+{%- set measure_name -%}
+
+(
+  select name
+  from {{ ref('quality_measures__measures') }}
+  where id = 'ADH-Statins'
+)
+
+{%- endset -%}
+
+{%- set measure_version -%}
+
+(
+  select version
+  from {{ ref('quality_measures__measures') }}
+  where id = 'ADH-Statins'
+)
+
+{%- endset -%}
+
+/*
+    set performance period end to the end of the current calendar year
+    or use the quality_measures_period_end variable if provided
+*/
+
+with period_end as (
+
+    select
+        {% if var('quality_measures_period_end',False) == False -%}
+        {{ last_day(dbt.current_timestamp(), 'year') }}
+        {% else -%}
+        cast('{{ var('quality_measures_period_end') }}' as date)
+        {%- endif %}
+         as performance_period_end
+
+)
+
+/*
+    set performance period begin to following day of 1 year prior
+*/
+
+, period_begin as (
+
+    select
+          performance_period_end
+        , {{ dbt.dateadd (
+              datepart = "day"
+            , interval = +1
+            , from_date_or_timestamp =
+                dbt.dateadd (
+                      datepart = "year"
+                    , interval = -1
+                    , from_date_or_timestamp = "performance_period_end"
+            )
+          ) }} as performance_period_begin
+    from period_end
+
+)
+
+select
+      cast({{ measure_id }} as {{ dbt.type_string() }}) as measure_id
+    , cast({{ measure_name }} as {{ dbt.type_string() }}) as measure_name
+    , cast({{ measure_version }} as {{ dbt.type_string() }}) as measure_version
+    , cast(performance_period_begin as date) as performance_period_begin
+    , cast(performance_period_end as date) as performance_period_end
+from period_begin

--- a/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_denominator.sql
+++ b/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_denominator.sql
@@ -1,0 +1,223 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False))))
+     | as_bool
+   )
+}}
+
+with performance_period as (
+
+    select
+          measure_id
+        , measure_name
+        , measure_version
+        , performance_period_end
+        , performance_period_begin
+    from {{ ref('quality_measures__int_adh_statins__performance_period') }}
+
+)
+
+, visit_codes as (
+
+    select
+          code
+        , code_system
+    from {{ ref('quality_measures__value_sets') }}
+    where lower(concept_name) = 'pqa statin medications'
+
+)
+
+, pharmacy_claim  as (
+
+    select 
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , days_supply
+    from {{ ref('quality_measures__stg_pharmacy_claim') }}
+
+)
+
+, patient_with_claim as (
+
+    select
+          pharmacy_claim.patient_id
+        , dispensing_date
+        , days_supply
+        , ndc_code
+    from pharmacy_claim 
+    inner join visit_codes
+        on pharmacy_claim.ndc_code = visit_codes.code
+    
+)
+
+, patient_within_performance_period as (
+
+    select
+          patient_id
+        , dispensing_date
+        , days_supply
+        , ndc_code
+        , performance_period_begin
+        , performance_period_end
+    from patient_with_claim as claim_patient
+    inner join performance_period as pp
+        on claim_patient.dispensing_date between pp.performance_period_begin and pp.performance_period_end
+
+)
+
+/* 
+    These patients need to pass two checks
+    - First medication fill date should be at least 91 days before the end of measurement period
+    - Should have at least two distinct Date of Service (FillDate) for rx
+*/
+
+, patient_with_rank as (
+
+    select
+          patient_id
+        , dispensing_date
+        , days_supply
+        , ndc_code
+        , dense_rank() over (partition by patient_id order by dispensing_date) as dense_rank
+    from patient_within_performance_period
+
+)
+
+, patient_with_first_dispensing_date as (
+
+    select
+          patient_id
+        , dispensing_date as first_dispensing_date
+    from patient_with_rank
+    where dense_rank = 1
+
+)
+
+
+/*
+treatment period days is abbreviated as tpd
+*/
+
+, patient_with_tpd as (
+
+    select
+          patients1.patient_id
+        , patients1.dispensing_date
+        , patients2.first_dispensing_date
+        , patients1.days_supply
+        , {{ datediff('first_dispensing_date', 'performance_period_end', 'day') }} as tpd
+    from patient_within_performance_period as patients1
+    inner join patient_with_first_dispensing_date as patients2
+        on patients1.patient_id = patients2.patient_id
+
+)
+
+, first_check_patient as (
+
+    select
+          patient_id
+        , dispensing_date
+        , first_dispensing_date
+        , days_supply
+    from patient_with_tpd
+    where tpd > 89
+    
+)
+
+, second_check_patient as (
+
+    select
+          patient_id
+        , ndc_code
+    from patient_with_rank
+    where dense_rank = 2
+
+)
+
+, both_check_patient as (
+
+    select
+          valid_patients1.patient_id
+        , valid_patients1.dispensing_date
+        , valid_patients1.first_dispensing_date
+        , valid_patients1.days_supply
+        , valid_patients2.ndc_code
+    from first_check_patient as valid_patients1
+    inner join second_check_patient as valid_patients2
+        on valid_patients1.patient_id = valid_patients2.patient_id
+     
+)
+
+, patient_with_age as (
+
+    select
+          valid_patients1.patient_id
+        , floor({{ datediff('birth_date', 'pp.performance_period_begin', 'hour') }} / 8760.0) as age
+        , dispensing_date
+        , first_dispensing_date
+        , days_supply
+        , ndc_code
+        , pp.performance_period_begin
+        , pp.performance_period_end
+        , pp.measure_id
+        , pp.measure_name
+        , pp.measure_version
+    from {{ ref('quality_measures__stg_core__patient') }} as patient
+    inner join both_check_patient as valid_patients1
+        on patient.patient_id = valid_patients1.patient_id
+    cross join performance_period as pp
+    where patient.death_date is null
+
+)
+
+, qualifying_patients as (
+
+    select
+          patient_id
+        , dispensing_date
+        , first_dispensing_date
+        , days_supply
+        , ndc_code
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , 1 as denominator_flag
+    from patient_with_age 
+    where age > 17
+
+)
+
+, add_data_types as (
+
+    select
+          cast(patient_id as {{ dbt.type_string() }}) as patient_id
+        , cast(dispensing_date as date) as dispensing_date
+        , cast(first_dispensing_date as date) as first_dispensing_date
+        , cast(days_supply as integer) as days_supply
+        , cast(ndc_code as {{ dbt.type_string() }}) as ndc_code
+        , cast(performance_period_begin as date) as performance_period_begin
+        , cast(performance_period_end as date) as performance_period_end
+        , cast(measure_id as {{ dbt.type_string() }}) as measure_id
+        , cast(measure_name as {{ dbt.type_string() }}) as measure_name
+        , cast(measure_version as {{ dbt.type_string() }}) as measure_version
+        , cast(denominator_flag as integer) as denominator_flag
+    from qualifying_patients
+
+)
+
+select 
+      patient_id
+    , dispensing_date
+    , first_dispensing_date
+    , days_supply
+    , ndc_code
+    , performance_period_begin
+    , performance_period_end
+    , measure_id
+    , measure_name
+    , measure_version
+    , denominator_flag
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from add_data_types

--- a/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_exclusions.sql
+++ b/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_exclusions.sql
@@ -1,0 +1,133 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+{%- set performance_period_begin -%}
+(
+  select 
+    performance_period_begin
+  from {{ ref('quality_measures__int_adh_statins__performance_period') }}
+
+)
+{%- endset -%}
+
+{%- set performance_period_end -%}
+(
+  select 
+    performance_period_end
+  from {{ ref('quality_measures__int_adh_statins__performance_period') }}
+
+)
+{%- endset -%}
+
+with denominator as (
+
+    select
+          patient_id
+    from {{ ref('quality_measures__int_adh_statins_denominator')}}
+
+)
+
+, hospice_palliative as (
+
+    select
+        patient_id
+      , exclusion_date
+      , exclusion_reason
+    from {{ ref('quality_measures__int_shared_exclusions_hospice_palliative') }}
+    where exclusion_date between {{ performance_period_begin }} and {{ performance_period_end }}
+
+)
+
+, valid_hospice as (
+
+    select
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+    from hospice_palliative
+    where lower(exclusion_reason) in (
+            'hospice encounter'
+          , 'hospice care ambulatory'
+          , 'hospice diagnosis'
+    )
+
+)
+
+, esrd_codes as (
+
+    select
+            code
+          , code_system
+          , concept_name
+    from {{ ref('quality_measures__value_sets') }}
+    where concept_name in (
+            'PQA ESRD'
+        )
+
+)
+
+, valid_esrd as (
+
+    select
+          condition.patient_id
+        , condition.recorded_date as exclusion_date
+        , esrd_codes.concept_name as exclusion_reason
+    from {{ ref('quality_measures__stg_core__condition') }} as condition
+    inner join esrd_codes 
+      on coalesce(condition.normalized_code, condition.source_code) = esrd_codes.code 
+        and coalesce(condition.normalized_code_type, condition.source_code_type) = esrd_codes.code_system
+    where condition.recorded_date between {{ performance_period_begin }} and {{ performance_period_end }}
+
+)
+
+, exclusions as (
+
+    select 
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+    from valid_hospice
+
+    union all
+
+    select 
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+    from valid_esrd
+
+)
+
+, measure_exclusions as (
+
+    select 
+          exclusions.patient_id
+        , exclusion_date
+        , exclusion_reason
+    from exclusions
+    inner join denominator
+      on exclusions.patient_id = denominator.patient_id
+
+)
+
+, add_data_types as (
+
+    select
+        distinct
+            cast(patient_id as {{ dbt.type_string() }}) as patient_id
+          , cast(exclusion_date as date) as exclusion_date
+          , cast(exclusion_reason as {{ dbt.type_string() }}) as exclusion_reason
+          , 1 as exclusion_flag
+    from measure_exclusions
+
+)
+
+select
+      patient_id
+    , exclusion_date
+    , exclusion_reason
+    , exclusion_flag
+    , '{{ var('tuva_last_run')}}' as tuva_last_run 
+from add_data_types

--- a/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_long.sql
+++ b/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_long.sql
@@ -1,0 +1,149 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+with denominator as (
+
+    select
+          patient_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from {{ ref('quality_measures__int_adh_statins_denominator') }}
+
+)
+
+, numerator as (
+
+    select
+          patient_id
+        , evidence_date
+        , evidence_value
+    from {{ ref('quality_measures__int_adh_statins_numerator') }}
+
+)
+
+, exclusions as (
+
+    select
+          patient_id
+        , exclusion_date
+        , exclusion_reason
+    from {{ ref('quality_measures__int_adh_statins_exclusions') }}
+
+)
+
+, measure_flags as (
+
+    select
+          denominator.patient_id
+        , case
+            when denominator.patient_id is not null
+            then 1
+            else null
+          end as denominator_flag
+        , case
+            when numerator.patient_id is not null and denominator.patient_id is not null
+            then 1
+            when denominator.patient_id is not null
+            then 0
+            else null
+          end as numerator_flag
+        , case
+            when exclusions.patient_id is not null and denominator.patient_id is not null
+            then 1
+            when denominator.patient_id is not null
+            then 0
+            else null
+          end as exclusion_flag
+        , numerator.evidence_date
+        , numerator.evidence_value
+        , exclusions.exclusion_date
+        , exclusions.exclusion_reason
+        , denominator.performance_period_begin
+        , denominator.performance_period_end
+        , denominator.measure_id
+        , denominator.measure_name
+        , denominator.measure_version
+        , (row_number() over(
+            partition by
+                  denominator.patient_id
+                , denominator.performance_period_begin
+                , denominator.performance_period_end
+                , denominator.measure_id
+                , denominator.measure_name
+              order by
+                  case when numerator.evidence_date is null then 1 else 0 end,
+                  numerator.evidence_date desc
+                , case when exclusions.exclusion_date is null then 1 else 0 end,
+                  exclusions.exclusion_date desc
+          )) as rn
+    from denominator
+        left join numerator
+            on denominator.patient_id = numerator.patient_id
+        left join exclusions
+            on denominator.patient_id = exclusions.patient_id
+
+)
+
+, deduped as (
+
+    select
+          patient_id
+        , denominator_flag
+        , numerator_flag
+        , exclusion_flag
+        , evidence_date
+        , evidence_value
+        , exclusion_date
+        , exclusion_reason
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+    from measure_flags
+    where rn = 1
+
+)
+
+, add_data_types as (
+
+    select
+          cast(patient_id as {{ dbt.type_string() }}) as patient_id
+        , cast(denominator_flag as integer) as denominator_flag
+        , cast(numerator_flag as integer) as numerator_flag
+        , cast(exclusion_flag as integer) as exclusion_flag
+        , cast(evidence_date as date) as evidence_date
+        , cast(evidence_value as {{ dbt.type_string() }}) as evidence_value
+        , cast(exclusion_date as date) as exclusion_date
+        , cast(exclusion_reason as {{ dbt.type_string() }}) as exclusion_reason
+        , cast(performance_period_begin as date) as performance_period_begin
+        , cast(performance_period_end as date) as performance_period_end
+        , cast(measure_id as {{ dbt.type_string() }}) as measure_id
+        , cast(measure_name as {{ dbt.type_string() }}) as measure_name
+        , cast(measure_version as {{ dbt.type_string() }}) as measure_version
+    from deduped
+
+)
+
+select
+      patient_id
+    , denominator_flag
+    , numerator_flag
+    , exclusion_flag
+    , evidence_date
+    , evidence_value
+    , exclusion_date
+    , exclusion_reason
+    , performance_period_begin
+    , performance_period_end
+    , measure_id
+    , measure_name
+    , measure_version
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from add_data_types

--- a/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_numerator.sql
+++ b/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_numerator.sql
@@ -9,7 +9,7 @@ with denominator as (
           patient_id
         , dispensing_date
         , first_dispensing_date
-        ,30 as days_supply
+        , days_supply
         , ndc_code
         , performance_period_begin
         , performance_period_end

--- a/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_numerator.sql
+++ b/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_numerator.sql
@@ -1,0 +1,366 @@
+{{ config(
+     enabled = var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) | as_bool
+   )
+}}
+
+with denominator as (
+
+    select
+          patient_id
+        , dispensing_date
+        , first_dispensing_date
+        ,30 as days_supply
+        , ndc_code
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+    from {{ ref('quality_measures__int_adh_statins_denominator') }}
+
+)
+
+, performance_end as (
+
+    select
+      performance_period_end
+    from {{ ref('quality_measures__int_adh_statins__performance_period') }}
+
+)
+
+/*
+The below 3 cte identifies periods of continuous medication use for each patient by:
+1. Assigning a row number and tracking the previous medication per patient.
+2. Flagging when a medication change occurs.
+3. Grouping consecutive periods of the same medication by assigning a group ID.
+*/
+
+, ranked_patient as (
+
+    select
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , days_supply
+        , dense_rank() over (partition by patient_id order by dispensing_date) as dense_rank
+        , lag(ndc_code) over (partition by patient_id order by dispensing_date) as previous_ndc
+    from denominator
+
+)
+
+, grouped_meds as (
+
+    select
+          patient_id
+        , dispensing_date
+        , ndc_code
+        , days_supply
+        , dense_rank
+        , case
+            when (ndc_code != previous_ndc) or previous_ndc is null then 1
+            else 0
+          end as med_change_flag --to increment group when medication changes
+    from ranked_patient
+
+)
+
+, final_groups as (
+
+    select
+          patient_id
+        , ndc_code
+        , dispensing_date
+        , days_supply
+        , sum(med_change_flag) over (
+              partition by patient_id 
+              order by dense_rank 
+              rows between unbounded preceding and current row
+          ) as group_id
+    from grouped_meds
+
+)
+
+/*
+This cte theoretical_end_dates to final_fills calculates adjusted medication fill dates, 
+groups fills by continuous periods of use and ensures accurate start and end dates based 
+on previous fills and the performance period.
+*/
+
+, theoretical_end_dates as (
+
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , {{ dbt.dateadd (
+              datepart = "day"
+            , interval = -1
+            , from_date_or_timestamp =
+                dbt.dateadd (
+                      datepart = "day"
+                    , interval = "days_supply"
+                    , from_date_or_timestamp = "dispensing_date"
+            )
+          ) }} as theoretical_end_date
+    from final_groups
+
+)
+
+/* 
+Adjust start dates based on the previous fill's end date + 1,
+or use the current rx_fill_date 
+*/
+
+, previous_fill_end_dates as (
+    
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , theoretical_end_date
+        , lag(theoretical_end_date)
+          over (partition by 
+                patient_id
+              , group_id  
+            order by
+                dispensing_date
+          ) as previous_fill_end_date
+    from theoretical_end_dates
+
+)
+
+, adjusted_fill_dates as (
+    
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , theoretical_end_date
+        , coalesce(
+            greatest(
+                  dispensing_date
+                , {{ dbt.dateadd (
+                      datepart = "day"
+                    , interval = +1
+                    , from_date_or_timestamp = "previous_fill_end_date"
+                  ) }}
+                )
+            , dispensing_date
+        ) as adjusted_fill_date
+    from previous_fill_end_dates
+
+)
+
+
+, actual_end_dates as (
+
+    select
+        patient_id
+      , group_id
+      , dispensing_date
+      , days_supply
+      , adjusted_fill_date
+      , least(
+            {{ dbt.dateadd (
+                datepart = "day"
+              , interval = -1
+              , from_date_or_timestamp =
+                  dbt.dateadd (
+                        datepart = "day"
+                      , interval = "days_supply"
+                      , from_date_or_timestamp = "adjusted_fill_date"
+              )
+            ) }}
+          , performance_period_end
+      ) as actual_end_date
+    from adjusted_fill_dates
+    inner join performance_end
+      on adjusted_fill_dates.adjusted_fill_date <= performance_end.performance_period_end
+
+)
+
+, grouped_fill_ranges as (
+
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , adjusted_fill_date
+        , actual_end_date
+        , min(adjusted_fill_date) over(partition by patient_id, group_id) as group_first
+        , max(adjusted_fill_date) over(partition by patient_id, group_id) as group_last
+    from actual_end_dates
+
+)
+
+, final_fills as (
+
+    select
+          patient_id
+        , group_id
+        , dispensing_date
+        , days_supply
+        , adjusted_fill_date
+        , actual_end_date
+        , group_first
+        , group_last
+        , max(
+            case
+              when adjusted_fill_date = group_last
+              then days_supply
+              else 0
+            end) over (partition by patient_id, group_id) as group_last_days_supply
+    from grouped_fill_ranges
+
+)
+
+/*
+1. Calculates the total covered days per every medication group per patient
+2. Then, calculates the overlap between groups of medication per patient.
+3. Then, calculates the actual total covered days for each patient.
+*/
+
+, covered_days_per_groups as (
+    
+    select
+          patient_id
+        , group_id
+        , group_first
+        , group_last
+        , group_last_days_supply
+        , sum( 1 + {{ dbt.datediff (
+                                  datepart = 'day'
+                                , first_date = 'adjusted_fill_date'
+                                , second_date = 'actual_end_date'
+                            )
+            }} ) as covered_days_per_group
+    from final_fills
+    group by 
+          patient_id
+        , group_id
+        , group_first
+        , group_last
+        , group_last_days_supply
+
+)
+
+, with_lag as (
+
+    select
+          patient_id
+        , group_id
+        , group_first
+        , group_last
+        , covered_days_per_group
+        , lag(group_last) over(partition by patient_id order by group_first) as lag_date
+        , lag(group_last_days_supply) over(partition by patient_id order by group_first) as lag_days_supply
+    from covered_days_per_groups
+
+)
+
+, overlap_days as (
+
+    select
+          patient_id
+        , group_id
+        , group_first
+        , group_last
+        , covered_days_per_group
+        , lag_date
+        , case
+            when group_first < 
+                {{ dbt.dateadd (
+                    datepart = "day"
+                  , interval = "lag_days_supply"
+                  , from_date_or_timestamp = "lag_date" 
+                ) }}
+            then
+                {{ dbt.datediff (
+                                  datepart = 'day'
+                                , first_date = "group_first"
+                                , second_date = 
+                                              dbt.dateadd (
+                                                datepart = "day"
+                                              , interval = "lag_days_supply"
+                                              , from_date_or_timestamp = "lag_date" 
+                                            )
+                ) }}
+            else 0
+          end as overlap
+    from with_lag
+
+)
+
+
+, final_covered_days as (
+
+    select 
+          patient_id
+        , sum(covered_days_per_group) - sum(overlap) as actual_covered_days
+    from overlap_days
+    group by patient_id
+
+)
+
+, patient_with_treatment_period_days as (
+    select
+          patient_id
+        , {{ datediff('first_dispensing_date', 'performance_period_end', 'day') }} as treatment_period_days
+    from denominator
+
+)
+
+, patient_with_pdc as (
+
+    select
+          final_covered_days.patient_id
+        , round(cast(actual_covered_days * 100 / treatment_period_days as {{ dbt.type_numeric() }}), 4) as adherence
+    from final_covered_days
+    inner join patient_with_treatment_period_days 
+        on final_covered_days.patient_id = patient_with_treatment_period_days.patient_id
+
+)
+
+/*
+Selects only the patient whose pdc is greater than 80%.
+*/
+
+, valid_patients as (
+
+    select 
+          patient_with_pdc.patient_id
+        , adherence
+        , denominator.dispensing_date as evidence_date
+        , denominator.days_supply as evidence_value
+        , 1 as numerator_flag
+    from patient_with_pdc 
+    inner join denominator
+        on patient_with_pdc.patient_id = denominator.patient_id 
+    where patient_with_pdc.adherence >= 80.00 
+
+)
+
+, add_data_types as (
+
+    select
+          cast(patient_id as {{ dbt.type_string() }}) as patient_id
+        , cast(evidence_date as date) as evidence_date
+        , cast(evidence_value as {{ dbt.type_string() }}) as evidence_value
+        , cast(adherence as {{ dbt.type_numeric() }}) as adherence
+        , cast(numerator_flag as integer) as numerator_flag
+    from valid_patients
+
+)
+
+select
+      patient_id
+    , evidence_date
+    , evidence_value
+    , adherence
+    , numerator_flag
+    , '{{ var('tuva_last_run')}}' as tuva_last_run
+from add_data_types

--- a/models/quality_measures/quality_measures_models.yml
+++ b/models/quality_measures/quality_measures_models.yml
@@ -190,6 +190,14 @@ models:
         description: >
           Performance flag for ADH-RAS, Medication Adherence for Hypertension. 
           A null indicates that the measure was not applicable for the patient.
+      - name: supd
+        description: >
+          Performance flag for SUPD, Statin Use in Persons with Diabetes.
+          A null indicates that the measure was not applicable for the patient.
+      - name: adh_statins
+        description: >
+          Performance flag for ADH-Statins, Medication Adherence for Cholesterol. 
+          A null indicates that the measure was not applicable for the patient.
       - name: tuva_last_run
         description: The date and timestamp of the dbt run.
 
@@ -2906,6 +2914,162 @@ models:
       - name: evidence_value
         description: >
           Observed evidence value for the patients in the numerator.
+      - name: numerator_flag
+        description: >
+          The numerator reflects the subset of patients in the denominator 
+          for whom a particular service has been provided or for whom a 
+          particular outcome has been achieved.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+### Medication Adherence for Cholesterol
+  - name: quality_measures__int_adh_statins__performance_period
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_statins__performance_period
+      tags: quality_measures
+      materialized: view
+    description: >
+      Performance Period definition for Medication Adherence for Cholesterol
+
+  - name: quality_measures__int_adh_statins_denominator
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_statins_denominator
+      tags: quality_measures
+      materialized: table
+    description: >
+      Denominator logic for the reporting version of ADH-Statins, Medication Adherence for Cholesterol
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: dispensing_date
+        description: Date the prescription was filled.
+      - name: first_dispensing_date
+        description: Date the first prescription was filled.
+      - name: days_supply
+        description: Number of days supply.
+      - name: ndc_code
+        description: National drug code on the claim.
+      - name: performance_period_begin
+        description: Beginning date of the performance or measurement period.
+      - name: performance_period_end
+        description: Ending date of the performance or measurement period.
+      - name: measure_id
+        description: Unique measure identification number.
+      - name: measure_name
+        description: Name of the measure.
+      - name: measure_version
+        description: Version of the measure.
+      - name: denominator_flag
+        description: >
+          The denominator is associated with a given patient population that 
+          may be counted as eligible to meet a measure’s inclusion requirements.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+  - name: quality_measures__int_adh_statins_exclusions
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_statins_exclusions
+      tags: quality_measures
+      materialized: table
+    description: >
+      Combined exclusion logic for the reporting version of ADH-Statins, Medication Adherence for Cholesterol
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: exclusion_date
+        description: >
+          Date of event or service that excludes patient from the measure.
+      - name: exclusion_reason
+        description: >
+          Reason (usually the value set concept name) that excludes patient 
+          from the measure.
+      - name: exclusion_flag
+        description: >
+          Specifications of those characteristics that would cause groups of 
+          individuals to be removed from the numerator and/or denominator of 
+          a measure although they experience the denominator index event.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+  - name: quality_measures__int_adh_statins_long
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_statins_long
+      tags: quality_measures
+      materialized: table
+    description: >
+      Final preparation of the reporting version of ADH-Statins, Medication Adherence for Cholesterol before combining with other measures.
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: denominator_flag
+        description: >
+          The denominator is associated with a given patient population that 
+          may be counted as eligible to meet a measure’s inclusion requirements.
+      - name: numerator_flag
+        description: >
+          The numerator reflects the subset of patients in the denominator 
+          for whom a particular service has been provided or for whom a 
+          particular outcome has been achieved.
+      - name: exclusion_flag
+        description: >
+          Specifications of those characteristics that would cause groups of 
+          individuals to be removed from the numerator and/or denominator of 
+          a measure although they experience the denominator index event.
+      - name: evidence_date
+        description: >
+          Date of event or service that places patient in the numerator.
+      - name: evidence_value
+        description: >
+          Observed evidence value for the patients in the numerator.
+      - name: exclusion_date
+        description: >
+          Date of event or service that excludes patient from the measure.
+      - name: exclusion_reason
+        description: >
+          Reason (usually the value set concept name) that excludes patient 
+          from the measure.
+      - name: performance_period_begin
+        description: Beginning date of the performance or measurement period.
+      - name: performance_period_end
+        description: Ending date of the performance or measurement period.
+      - name: measure_id
+        description: Unique measure identification number.
+      - name: measure_name
+        description: Name of the measure.
+      - name: measure_version
+        description: Version of the measure.
+      - name: tuva_last_run
+        description: The date and timestamp of the dbt run.
+
+  - name: quality_measures__int_adh_statins_numerator
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_quality_measures{% else %}quality_measures{%- endif -%}
+      alias: _int_adh_statins_numerator
+      tags: quality_measures
+      materialized: table
+    description: >
+      Numerator logic for the reporting version of ADH-Statins, Medication Adherence for Cholesterol
+    columns:
+      - name: patient_id
+        description: Unique patient_id for each person.
+      - name: evidence_date
+        description: >
+          Date of event or service that places patient in the numerator.
+      - name: evidence_value
+        description: >
+          Observed evidence value for the patients in the numerator.
+      - name: adherence
+        description: >
+          The extent to which a person's behaviour corresponds with taking a medicine optimally.
       - name: numerator_flag
         description: >
           The numerator reflects the subset of patients in the denominator 


### PR DESCRIPTION
## Describe your changes
Implemented Medication Adherence for Cholesterol (ADH-Statins) based on [CMS Star Documentation](https://www.cms.gov/files/document/2024-star-ratings-technical-notes.pdf#page=104).

## How has this been tested?
dbt build has been run for Snowflake and BigQuery. In addition to this, [validation document](https://docs.google.com/spreadsheets/d/1nO5dqnBgi9RWwwPjC3oPT9fdk_ruMhWPostGt9NOMYY/edit?usp=sharing) has been prepared on top of tuva_synthetic for each model.

## Reviewer focus
Since days_supply field is null across pharmacy_claim table in synthetic data, logic has been drafted with assumption that multiple refills of same prescription are not filled simultaneously, but around/after the end of existing fill. Please verify on real data.

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [x] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [x] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [x] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)