### PR TITLE
Update safe_cast to try_cast for duckdb

### DIFF
--- a/models/claims_preprocessing/service_category/intermediate/service_category__office_based_surgery_professional.sql
+++ b/models/claims_preprocessing/service_category/intermediate/service_category__office_based_surgery_professional.sql
@@ -7,7 +7,11 @@
 with numeric_hcpcs as (
     select *
     from {{ ref('service_category__stg_medical_claim') }} as med
-    where {{ safe_cast('hcpcs_code', 'int')}} is not null
+    {% if target.type == 'duckdb' %}
+        where try_cast('hcpcs_code' as integer) is not null
+    {% else %}
+        where {{ safe_cast('hcpcs_code', 'int')}} is not null
+    {% endif %}
 )
 
 

--- a/models/hcc_suspecting/intermediate/hcc_suspecting__int_observation_suspects.sql
+++ b/models/hcc_suspecting/intermediate/hcc_suspecting__int_observation_suspects.sql
@@ -34,7 +34,7 @@ with conditions as (
     select
           patient_id
         , observation_date
-        {% if target.type == 'fabric' %}
+        {% if target.type == 'fabric' or target.type == 'duckdb' %}
          , TRY_CAST(result AS {{ dbt.type_numeric() }}) AS result
         {% else %}
         , CAST(result AS {{ dbt.type_numeric() }}) AS result

--- a/models/quality_measures/intermediate/cqm236_controlling_blood_pressure/quality_measures__int_cqm236_numerator.sql
+++ b/models/quality_measures/intermediate/cqm236_controlling_blood_pressure/quality_measures__int_cqm236_numerator.sql
@@ -60,25 +60,33 @@ with controlled_bp_codes as (
               '99473' -- Self-measured blood pressure using a device validated for clinical accuracy; patient education/training and device calibration
             , '99474' -- Separate self-measurements of two readings one minute apart, twice daily over a 30-day period (minimum of 12 readings), collection of data reported by the patient and/or caregiver to the physician or other qualified health care professional, with report of average systolic and diastolic pressures and subsequent communication of a treatment plan to the patient
         )
-        and {{ dbt.safe_cast("result", api.Column.translate_type("numeric")) }} is not null
+        {% if  target.type == 'duckdb' %}
+            and try_cast('result' as numeric) is not null
+        {% else %}
+            and {{ dbt.safe_cast("result", api.Column.translate_type("numeric")) }} is not null
+        {% endif %}
 
 )
 
 , labs as (
 
-    select 
+    select
           patient_id
         , result_date
         , collection_date
         , result
         , normalized_code
     from {{ref('quality_measures__stg_core__lab_result')}}
-    where normalized_code in 
+    where normalized_code in
     ('8480-6' --systolic
     ,'8462-4') --diastolic
     and
     normalized_code_type = 'loinc'
-    and {{ dbt.safe_cast("result", api.Column.translate_type("numeric")) }} is not null
+    {% if  target.type == 'duckdb' %}
+        and try_cast('result' as numeric) is not null
+    {% else %}
+        and {{ dbt.safe_cast("result", api.Column.translate_type("numeric")) }} is not null
+    {% endif %}
 
 )
 
@@ -104,7 +112,7 @@ with controlled_bp_codes as (
 )
 
 , all_medical_claims as (
-    
+
     select
           patient_id
         , claim_start_date
@@ -149,7 +157,7 @@ with controlled_bp_codes as (
     from controlled_bp_procedures
 
     union all
-    
+
     select
           patient_id
         , evidence_date
@@ -199,9 +207,9 @@ with controlled_bp_codes as (
     from controlled_bp_within_range_proc_claims
     left join encounters
         on controlled_bp_within_range_proc_claims.patient_id = encounters.patient_id
-        and controlled_bp_within_range_proc_claims.evidence_date between 
-            encounters.encounter_start_date and encounters.encounter_end_date 
-    
+        and controlled_bp_within_range_proc_claims.evidence_date between
+            encounters.encounter_start_date and encounters.encounter_end_date
+
 )
 
 , valid_procedures_and_claims as (
@@ -278,7 +286,7 @@ with controlled_bp_codes as (
     from observations
     inner join denominator
         on observations.patient_id = denominator.patient_id
-        and observations.observation_date between 
+        and observations.observation_date between
             denominator.performance_period_begin and denominator.performance_period_end
 
 )
@@ -298,7 +306,7 @@ with controlled_bp_codes as (
     from labs
     inner join denominator
         on labs.patient_id = denominator.patient_id
-        and coalesce(labs.result_date,labs.collection_date) between 
+        and coalesce(labs.result_date,labs.collection_date) between
             denominator.performance_period_begin and denominator.performance_period_end
 
 )
@@ -327,7 +335,7 @@ with controlled_bp_codes as (
     from observations_within_range
     left join encounters
         on observations_within_range.patient_id = encounters.patient_id
-        and observations_within_range.observation_date between 
+        and observations_within_range.observation_date between
             encounters.encounter_start_date and encounters.encounter_end_date
 
 )
@@ -357,7 +365,7 @@ with controlled_bp_codes as (
         on labs_within_range.patient_id = encounters.patient_id
         and labs_within_range.observation_date between
             encounters.encounter_start_date and encounters.encounter_end_date
-            
+
 )
 
 , obs_and_labs as (
@@ -368,7 +376,7 @@ with controlled_bp_codes as (
         {% if target.type == 'fabric' %}
             , try_cast(result as {{ dbt.type_float() }}) as bp_reading
         {% else %}
-        , cast(result as {{ dbt.type_float() }}) as bp_reading
+            , cast(result as {{ dbt.type_float() }}) as bp_reading
         {% endif %}
         , normalized_description
         , measure_id


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

On duckdb safe_cast() is interpreted as cast(). This causes failures in certain data marts. Updated those failing to use try_cast() instead of safe_cast()


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

Using tuva_demo ran `dbt build` locally on duckdb. 


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExdXJmdnI3cnBhamkxb2MwYWJra3YwMDhuZDN1NW8zd3BoZzRkeWljcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/krewXUB6LBja/giphy.webp)


## Loom link
