### PR TITLE
fix unit quantity data type to be numeric

### DIFF
--- a/models/claims_preprocessing/normalized_input/final/normalized_input__medical_claim.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__medical_claim.sql
@@ -35,7 +35,7 @@ select
     , cast(coalesce(apr.normalized_description, undetermined.apr_drg_description) as {{ dbt.type_string() }} ) as apr_drg_description
 	, cast(coalesce(rev.normalized_code, undetermined.revenue_center_code) as {{ dbt.type_string() }} ) as revenue_center_code
     , cast(coalesce(rev.normalized_description, undetermined.revenue_center_description) as {{ dbt.type_string() }} ) as revenue_center_description
-	, cast(med.service_unit_quantity as {{ dbt.type_string() }} ) as service_unit_quantity
+	, cast(med.service_unit_quantity as {{ dbt.type_numeric() }} ) as service_unit_quantity
 	, cast(med.hcpcs_code as {{ dbt.type_string() }} ) as hcpcs_code
 	, cast(med.hcpcs_modifier_1 as {{ dbt.type_string() }} ) as hcpcs_modifier_1
 	, cast(med.hcpcs_modifier_2 as {{ dbt.type_string() }} ) as hcpcs_modifier_2


### PR DESCRIPTION
which is consistent with other dbt models downstream

## Describe your changes
Please include a summary of any changes.
service unit is cast as string in one model and downstream is numeric. failing to convert in fabric. changing to numeric to be consistent. 

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
