### PR TITLE
Add person_id to snapshot models

### DIFF
--- a/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
@@ -11,7 +11,7 @@
     , "tags": "cms_hcc"
     , "strategy": "timestamp"
     , "updated_at": "tuva_last_run"
-    , "unique_key": "patient_id||model_version||payment_year||tuva_last_run"
+    , "unique_key": "person_id||model_version||payment_year||tuva_last_run"
     , "enabled": var('snapshots_enabled',False) == true and var('cms_hcc_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) == true | as_bool
   })
 }}

--- a/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
@@ -11,7 +11,7 @@
     , "tags": "cms_hcc"
     , "strategy": "timestamp"
     , "updated_at": "tuva_last_run"
-    , "unique_key": "patient_id||payment_year||tuva_last_run"
+    , "unique_key": "person_id||payment_year||tuva_last_run"
     , "enabled": var('snapshots_enabled',False) == true and var('cms_hcc_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) == true | as_bool
   })
 }}

--- a/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
+++ b/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
@@ -11,7 +11,7 @@
     , "tags": "quality_measures"
     , "strategy": "timestamp"
     , "updated_at": "tuva_last_run"
-    , "unique_key": "patient_id||denominator_flag||numerator_flag||exclusion_flag||evidence_date||exclusion_date||exclusion_reason||performance_period_begin||performance_period_end||measure_id||measure_name||measure_version||tuva_last_run"
+    , "unique_key": "person_id||denominator_flag||numerator_flag||exclusion_flag||evidence_date||exclusion_date||exclusion_reason||performance_period_begin||performance_period_end||measure_id||measure_name||measure_version||tuva_last_run"
     , "enabled": var('snapshots_enabled',False) == true and var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) == true | as_bool
   })
 }}


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

Resolves #701 

Replaced `patient_id` with `person_id` in snapshot models for CMS HCC and Quality Measures.


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

Ran `dbt build --full-refresh` with the variable `snapshots_enabled: true`.

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3I2bHU5cmc5Y2c0bHFmNzN5b2Exd3dsaXh6ZnZtMXd1a2NoMzJxeSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Q9GnMCzYtQXpQXL9Lm/giphy.gif)


## Loom link
