### PR TITLE
fixing grain of core location and practitioner

### DIFF
--- a/models/core/staging/core__stg_claims_location.sql
+++ b/models/core/staging/core__stg_claims_location.sql
@@ -6,7 +6,7 @@
 }}
 
 with all_providers_in_claims_dataset as (
-select distinct facility_id as npi, data_source
+select distinct facility_id as npi
 from {{ ref('core__stg_claims_medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -15,7 +15,7 @@ union
 union distinct
 {% endif %}
 
-select distinct rendering_id as npi, data_source
+select distinct rendering_id as npi
 from {{ ref('core__stg_claims_medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -24,7 +24,7 @@ union
 union distinct
 {% endif %}
 
-select distinct billing_id as npi, data_source
+select distinct billing_id as npi
 from {{ ref('core__stg_claims_medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -33,7 +33,7 @@ union
 union distinct
 {% endif %}
 
-select distinct prescribing_provider_id as npi, data_source
+select distinct prescribing_provider_id as npi
 from {{ ref('core__stg_claims_pharmacy_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -42,13 +42,13 @@ union
 union distinct
 {% endif %}
 
-select distinct dispensing_provider_id as npi, data_source
+select distinct dispensing_provider_id as npi
 from {{ ref('core__stg_claims_pharmacy_claim') }}
 ),
 
 
 provider as (
-select aa.*, bb.data_source
+select aa.*
 from {{ ref('terminology__provider') }} aa
 inner join all_providers_in_claims_dataset bb
 on aa.npi = bb.npi
@@ -69,6 +69,6 @@ select
     , cast(practice_zip_code as {{ dbt.type_string() }} ) as zip_code
     , cast(null as {{ dbt.type_float() }} ) as latitude
     , cast(null as {{ dbt.type_float() }} ) as longitude
-    , cast(data_source as {{ dbt.type_string() }} ) as data_source
+    , cast(null as {{ dbt.type_string() }} ) as data_source
     , cast( '{{ var('tuva_last_run')}}' as {{ dbt.type_timestamp() }} ) as tuva_last_run
-from provider
+from provider 

--- a/models/core/staging/core__stg_claims_practitioner.sql
+++ b/models/core/staging/core__stg_claims_practitioner.sql
@@ -12,7 +12,7 @@
 
 
 with all_providers_in_claims_dataset as (
-select distinct facility_id as npi, data_source
+select distinct facility_id as npi
 from {{ ref('core__stg_claims_medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -21,7 +21,7 @@ union
 union distinct
 {% endif %}
 
-select distinct rendering_id as npi, data_source
+select distinct rendering_id as npi
 from {{ ref('core__stg_claims_medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -30,7 +30,7 @@ union
 union distinct
 {% endif %}
 
-select distinct billing_id as npi, data_source
+select distinct billing_id as npi
 from {{ ref('core__stg_claims_medical_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -39,7 +39,7 @@ union
 union distinct
 {% endif %}
 
-select distinct prescribing_provider_id as npi, data_source
+select distinct prescribing_provider_id as npi
 from {{ ref('core__stg_claims_pharmacy_claim') }}
 
 {% if target.type == 'fabric' %}
@@ -48,13 +48,13 @@ union
 union distinct
 {% endif %}
 
-select distinct dispensing_provider_id as npi, data_source
+select distinct dispensing_provider_id as npi
 from {{ ref('core__stg_claims_pharmacy_claim') }}
 ),
 
 
 provider as (
-select aa.*, bb.data_source
+select aa.*
 from {{ ref('terminology__provider') }} aa
 inner join all_providers_in_claims_dataset bb
 on aa.npi = bb.npi
@@ -71,6 +71,6 @@ select
     , cast(parent_organization_name as {{ dbt.type_string() }} ) as practice_affiliation
     , cast(primary_specialty_description as {{ dbt.type_string() }} ) as specialty
     , cast(null as {{ dbt.type_string() }} ) as sub_specialty
-    , cast(data_source as {{ dbt.type_string() }} ) as data_source
+    , cast(null as {{ dbt.type_string() }} ) as data_source
     , cast('{{ var('tuva_last_run')}}' as {{ dbt.type_timestamp() }} ) as tuva_last_run
 from provider


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
removing datasource from unique grain to ensure uniqueness of table key
if same npi is in multiple sources, they show up in multiple rows and join can no longer be done on just practitioner/location_id

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
