### PR TITLE
Input testing flag

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -39,6 +39,9 @@ vars:
     #tuva_seeds_s3_key_prefix: "tuva/seeds/example/prefix"
     custom_bucket_name: tuva-public-resources
 
+    ## DQI data testing on input layer
+    enable_input_layer_testing: true
+
 on-run-end:
   - "{{ log_warning_for_seeds() }}"
 

--- a/models/input_layer/input_layer__condition.yml
+++ b/models/input_layer/input_layer__condition.yml
@@ -14,7 +14,7 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
@@ -27,137 +27,137 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: claim_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: recorded_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: onset_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: resolved_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: status
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: condition_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: condition_rank
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: present_on_admit_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: present_on_admit_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__condition.yml
+++ b/models/input_layer/input_layer__condition.yml
@@ -18,9 +18,11 @@ models:
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: patient_id
     description: ''
     tests:

--- a/models/input_layer/input_layer__eligibility.yml
+++ b/models/input_layer/input_layer__eligibility.yml
@@ -13,7 +13,7 @@ models:
           - data_source
         config:
           severity: warn
-          enabled: "{{ (target.type != 'fabric') | as_bool }}"
+          enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   config:
     schema: |
       {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_input_layer{% else %}input_layer{%- endif -%}
@@ -26,217 +26,218 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: member_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: subscriber_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: gender
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: race
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: birth_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: death_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: death_flag
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: enrollment_start_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: enrollment_end_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: payer
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: payer_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: plan
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: original_reason_entitlement_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: dual_status_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: medicare_status_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: group_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: group_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: first_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: last_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: social_security_number
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: subscriber_relation
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: address
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: city
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: state
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: zip_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: phone
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__encounter.yml
+++ b/models/input_layer/input_layer__encounter.yml
@@ -14,206 +14,208 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: person_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: patient_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_start_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_end_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: length_of_stay
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: admit_source_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: admit_source_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: admit_type_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: admit_type_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: discharge_disposition_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: discharge_disposition_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: attending_provider_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: attending_provider_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: facility_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: facility_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: primary_diagnosis_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: primary_diagnosis_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: primary_diagnosis_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: drg_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: drg_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: drg_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: paid_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: allowed_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: charge_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__lab_result.yml
+++ b/models/input_layer/input_layer__lab_result.yml
@@ -14,213 +14,215 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: person_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: patient_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: accession_number
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_component
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_component
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: status
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: result
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: result_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: collection_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_units
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_units
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_reference_range_low
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_reference_range_high
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_reference_range_low
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_reference_range_high
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_abnormal_flag
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_abnormal_flag
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: specimen
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ordering_practitioner_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__location.yml
+++ b/models/input_layer/input_layer__location.yml
@@ -14,87 +14,89 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: npi
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: facility_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: parent_organization
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: address
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: city
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: state
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: zip_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: latitude
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: longitude
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -9,13 +9,13 @@ models:
           - claim_line_number
         config:
           severity: warn
-          enabled: "{{ (target.type != 'fabric') | as_bool }}"
+          enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
 #     A claim cannot be both professional and institutional within the same claim id.
     - dbt_expectations.expect_select_column_values_to_be_unique_within_record:
         column_list: ['claim_id', 'claim_type']
         config:
           severity: warn
-          enabled: "{{ (target.type != 'fabric') | as_bool }}"
+          enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   config:
     schema: |
       {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_input_layer{% else %}input_layer{%- endif -%}
@@ -28,1085 +28,1092 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: claim_line_number
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: claim_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - accepted_values:
           values: ['professional', 'institutional', 'undetermined']
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: person_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: member_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: payer
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: plan
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: claim_start_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: claim_end_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: claim_line_start_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: claim_line_end_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: admission_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: discharge_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: admit_source_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - dbt_expectations.expect_column_value_lengths_to_equal:
           value: 1
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: admit_type_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: discharge_disposition_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: place_of_service_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - dbt_expectations.expect_column_value_lengths_to_equal:
           value: 2
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: bill_type_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - dbt_expectations.expect_column_value_lengths_to_be_between:
           min_value: 3
           max_value: 4
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: drg_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - accepted_values:
           values: ['ms-drg', 'apr-drg']
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: drg_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - dbt_expectations.expect_column_value_lengths_to_equal:
           value: 3
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: revenue_center_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - dbt_expectations.expect_column_value_lengths_to_be_between:
           min_value: 3
           max_value: 4
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: service_unit_quantity
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: hcpcs_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: hcpcs_modifier_1
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: hcpcs_modifier_2
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: hcpcs_modifier_3
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: hcpcs_modifier_4
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: hcpcs_modifier_5
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: rendering_npi
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: rendering_tin
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: billing_npi
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: billing_tin
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: facility_npi
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: paid_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: paid_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: allowed_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: charge_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: coinsurance_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: copayment_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: deductible_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: total_cost_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - accepted_values:
           values: ['icd-10-cm', 'icd-9-cm']
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: diagnosis_code_1
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_2
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_3
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_4
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_5
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_6
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_7
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_8
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_9
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_10
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_11
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_12
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_13
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_14
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_15
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_16
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_17
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_18
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_19
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_20
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_21
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_22
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_23
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_24
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_code_25
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_1
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_2
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_3
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_4
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_5
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_6
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_7
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_8
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_9
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_10
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_11
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_12
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_13
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_14
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_15
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_16
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_17
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_18
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_19
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_20
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_21
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_22
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_23
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_24
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: diagnosis_poa_25
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - accepted_values:
           values: ['icd-10-pcs', 'icd-9-pcs', 'hcpcs_level_2']
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: procedure_code_1
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_2
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_3
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_4
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_5
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_6
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_7
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_8
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_9
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_10
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_11
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_12
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_13
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_14
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_15
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_16
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_17
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_18
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_19
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_20
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_21
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_22
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_23
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_24
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_code_25
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_1
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_2
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_3
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_4
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_5
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_6
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_7
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_8
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_9
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_10
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_11
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_12
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_13
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_14
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_15
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_16
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_17
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_18
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_19
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_20
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_21
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_22
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_23
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_24
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date_25
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: in_network_flag
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__medication.yml
+++ b/models/input_layer/input_layer__medication.yml
@@ -14,171 +14,173 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: person_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: patient_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: dispensing_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: prescribing_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ndc_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ndc_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: rxnorm_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: rxnorm_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: atc_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: atc_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: route
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: strength
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: quantity
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: quantity_unit
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: days_supply
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: practitioner_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__observation.yml
+++ b/models/input_layer/input_layer__observation.yml
@@ -14,164 +14,166 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: person_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: patient_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: panel_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: observation_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: observation_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: result
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_units
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_units
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_reference_range_low
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_reference_range_high
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_reference_range_low
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_reference_range_high
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__patient.yml
+++ b/models/input_layer/input_layer__patient.yml
@@ -9,6 +9,7 @@ models:
           - patient_id
         config:
           severity: warn
+          enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   config:
     schema: |
       {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_input_layer{% else %}input_layer{%- endif -%}
@@ -21,150 +22,152 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: patient_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: first_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: last_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: sex
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: race
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: birth_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: death_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: death_flag
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: social_security_number
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: address
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: city
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: state
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: zip_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: county
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: latitude
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: longitude
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: phone
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__pharmacy_claim.yml
+++ b/models/input_layer/input_layer__pharmacy_claim.yml
@@ -9,6 +9,7 @@ models:
           - claim_line_number
         config:
           severity: warn
+          enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   config:
     schema: |
       {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_input_layer{% else %}input_layer{%- endif -%}
@@ -21,178 +22,180 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: claim_line_number
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: person_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: member_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: payer
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: plan
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: prescribing_provider_npi
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: dispensing_provider_npi
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: dispensing_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ndc_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: quantity
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: days_supply
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: refills
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: paid_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: paid_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: allowed_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: charge_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: coinsurance_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: copayment_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: deductible_amount
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: in_network_flag
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__practitioner.yml
+++ b/models/input_layer/input_layer__practitioner.yml
@@ -14,59 +14,61 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: npi
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: first_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: last_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: practice_affiliation
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: specialty
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: sub_specialty
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__procedure.yml
+++ b/models/input_layer/input_layer__procedure.yml
@@ -14,150 +14,152 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - unique:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: person_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: patient_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: encounter_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: claim_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: procedure_date
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: source_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code_type
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_code
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: normalized_description
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: modifier_1
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: modifier_2
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: modifier_3
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: modifier_4
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: modifier_5
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: practitioner_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: file_name
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: ingest_datetime
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"

--- a/models/input_layer/input_layer__provider_attribution.yml
+++ b/models/input_layer/input_layer__provider_attribution.yml
@@ -8,6 +8,8 @@ models:
           - person_id
           - year_month
           - data_source
+        config:
+          severity: warn
   config:
     schema: |
       {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_input_layer{% else %}input_layer{%- endif -%}

--- a/models/input_layer/input_layer__provider_attribution.yml
+++ b/models/input_layer/input_layer__provider_attribution.yml
@@ -10,6 +10,7 @@ models:
           - data_source
         config:
           severity: warn
+          enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   config:
     schema: |
       {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_input_layer{% else %}input_layer{%- endif -%}
@@ -22,104 +23,107 @@ models:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: patient_id
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: year_month
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: payer
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: plan
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: data_source
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - not_null:
           config:
             severity: warn
+            enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
   - name: payer_attributed_provider
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: payer_attributed_provider_practice
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: payer_attributed_provider_organization
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: payer_attributed_provider_lob
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: custom_attributed_provider
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: custom_attributed_provider_practice
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: custom_attributed_provider_organization
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
   - name: custom_attributed_provider_lob
     description: ''
     tests:
       - dbt_expectations.expect_column_to_exist:
           config:
             severity: warn
-            enabled: "{{ (target.type != 'fabric') | as_bool }}"
+            enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
Flag to enable / disable input / dqi testing.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
```
dbt test -s tag:input_layer --vars "{enable_input_layer_testing: false}"
19:24:45  Running with dbt=1.9.2
19:24:45  Registered adapter: snowflake=1.9.1
19:24:45  Unable to do partial parsing because saved manifest not found. Starting full parse.
19:24:53  Found 860 models, 97 seeds, 3 operations, 73 data tests, 1603 macros
19:24:53  Nothing to do. Try checking your model configs and model specification args
```

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
Making sure flags are on all variables.

## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [NA] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`

