### PR TITLE
Add (again) date filter to patient factors

### DIFF
--- a/models/cms_hcc/final/cms_hcc__patient_risk_factors.sql
+++ b/models/cms_hcc/final/cms_hcc__patient_risk_factors.sql
@@ -16,3 +16,8 @@ select
     , payment_year
     , '{{ var('tuva_last_run')}}' as tuva_last_run
 from {{ ref('cms_hcc__patient_risk_factors_monthly') }}
+where collection_end_date = (
+        select max(collection_end_date)
+        from {{ ref('cms_hcc__patient_risk_factors_monthly') }}
+        where payment_year = {{ var('cms_hcc_payment_year') }}
+    )


### PR DESCRIPTION
## Describe your changes
Added back date filter to patient risk factors, mirroring patient risk scores. The code comes from  [PR #627](https://github.com/tuva-health/tuva/pull/627), but disappeared in [PR #685](https://github.com/tuva-health/tuva/pull/685).

## How has this been tested?
Ran locally, verified results are filtered correctly compared to patient risk factors monthly and the payment year. 

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
I'd recommend to review the two previous PRs that created then removed the change.

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
