### PR TITLE
738 disable previous data quality by default

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,15 +6,6 @@ require-dbt-version: ">=1.5.0"
 profile: default
 
 models:
-  the_tuva_project:
-    data_quality:
-      ## Legacy data quality models
-      final:
-        +enabled: "{{ var('enable_legacy_data_quality', false) }}"
-      intermediate:
-        +enabled: "{{ var('enable_legacy_data_quality', false) }}"
-      stage:
-        +enabled: "{{ var('enable_legacy_data_quality', false) }}"
   ## see docs: https://docs.elementary-data.com/
   elementary:
     ## elementary models will be created in the schema '<your_schema>_elementary'

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,6 +6,14 @@ require-dbt-version: ">=1.5.0"
 profile: default
 
 models:
+  data_quality:
+    ## Legacy data quality models
+    final:
+      +enabled: "{{ var('enable_legacy_data_quality', false) }}"
+    intermediate:
+      +enabled: "{{ var('enable_legacy_data_quality', false) }}"
+    stage:
+      +enabled: "{{ var('enable_legacy_data_quality', false) }}"
   ## see docs: https://docs.elementary-data.com/
   elementary:
     ## elementary models will be created in the schema '<your_schema>_elementary'
@@ -54,6 +62,9 @@ vars:
 
     ## DQI data testing on input layer
     enable_input_layer_testing: true
+
+    ## Set this variable to true if you want legacy data quality models to build
+    enable_legacy_data_quality: false
 
 on-run-end:
   - "{{ log_warning_for_seeds() }}"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,14 +6,15 @@ require-dbt-version: ">=1.5.0"
 profile: default
 
 models:
-  data_quality:
-    ## Legacy data quality models
-    final:
-      +enabled: "{{ var('enable_legacy_data_quality', false) }}"
-    intermediate:
-      +enabled: "{{ var('enable_legacy_data_quality', false) }}"
-    stage:
-      +enabled: "{{ var('enable_legacy_data_quality', false) }}"
+  the_tuva_project:
+    data_quality:
+      ## Legacy data quality models
+      final:
+        +enabled: "{{ var('enable_legacy_data_quality', false) }}"
+      intermediate:
+        +enabled: "{{ var('enable_legacy_data_quality', false) }}"
+      stage:
+        +enabled: "{{ var('enable_legacy_data_quality', false) }}"
   ## see docs: https://docs.elementary-data.com/
   elementary:
     ## elementary models will be created in the schema '<your_schema>_elementary'

--- a/models/data_quality/final/data_quality__analytics_checks_summary.sql
+++ b/models/data_quality/final/data_quality__analytics_checks_summary.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with unioned_data as (

--- a/models/data_quality/final/data_quality__analytics_populated.sql
+++ b/models/data_quality/final/data_quality__analytics_populated.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with tuva_chronic_condition_long as (

--- a/models/data_quality/final/data_quality__analytics_reference_summary.sql
+++ b/models/data_quality/final/data_quality__analytics_reference_summary.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with unioned_data as (

--- a/models/data_quality/final/data_quality__claim_date_trends.sql
+++ b/models/data_quality/final/data_quality__claim_date_trends.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('data_quality_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with date_stage as(
 

--- a/models/data_quality/final/data_quality__core_populated.sql
+++ b/models/data_quality/final/data_quality__core_populated.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with medical as (

--- a/models/data_quality/final/data_quality__data_loss.sql
+++ b/models/data_quality/final/data_quality__data_loss.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with input_medical as (

--- a/models/data_quality/final/data_quality__data_quality_test_summary.sql
+++ b/models/data_quality/final/data_quality__data_quality_test_summary.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with unioned_data as (

--- a/models/data_quality/final/data_quality__eligibility_trend.sql
+++ b/models/data_quality/final/data_quality__eligibility_trend.sql
@@ -1,8 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False))
- | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with eligibility_spans as(
     select distinct

--- a/models/data_quality/final/data_quality__encounters_cost_and_utilization_trend.sql
+++ b/models/data_quality/final/data_quality__encounters_cost_and_utilization_trend.sql
@@ -1,6 +1,6 @@
 {{ config(
-    enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with member_months as (
     select

--- a/models/data_quality/final/data_quality__medical_claim_volume_and_dollars.sql
+++ b/models/data_quality/final/data_quality__medical_claim_volume_and_dollars.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with range_cte as (
   select

--- a/models/data_quality/final/data_quality__pharmacy_claim_volume_and_dollars.sql
+++ b/models/data_quality/final/data_quality__pharmacy_claim_volume_and_dollars.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 select
     c.year_month_int as year_month

--- a/models/data_quality/final/data_quality__service_category_pmpm_trend.sql
+++ b/models/data_quality/final/data_quality__service_category_pmpm_trend.sql
@@ -1,4 +1,6 @@
-{{ config(enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool) }}
+{{ config(
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with member_months as (
     select

--- a/models/data_quality/intermediate/data_quality__acute_inpatient.sql
+++ b/models/data_quality/intermediate/data_quality__acute_inpatient.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with cte as (

--- a/models/data_quality/intermediate/data_quality__acute_inpatient_prevalence.sql
+++ b/models/data_quality/intermediate/data_quality__acute_inpatient_prevalence.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with total_cte as (

--- a/models/data_quality/intermediate/data_quality__acute_inpatient_reference.sql
+++ b/models/data_quality/intermediate/data_quality__acute_inpatient_reference.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with cte as (

--- a/models/data_quality/intermediate/data_quality__chronic_conditions_none.sql
+++ b/models/data_quality/intermediate/data_quality__chronic_conditions_none.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with chronic_conditions as 

--- a/models/data_quality/intermediate/data_quality__chronic_conditions_prevalence.sql
+++ b/models/data_quality/intermediate/data_quality__chronic_conditions_prevalence.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with condition_counts as (

--- a/models/data_quality/intermediate/data_quality__claim_percent.sql
+++ b/models/data_quality/intermediate/data_quality__claim_percent.sql
@@ -1,6 +1,6 @@
 {{ config(
-    enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 
 with cte as 

--- a/models/data_quality/intermediate/data_quality__cms_hcc.sql
+++ b/models/data_quality/intermediate/data_quality__cms_hcc.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with cte as (

--- a/models/data_quality/intermediate/data_quality__cms_hcc_reference.sql
+++ b/models/data_quality/intermediate/data_quality__cms_hcc_reference.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with cte as (

--- a/models/data_quality/intermediate/data_quality__dx_and_px.sql
+++ b/models/data_quality/intermediate/data_quality__dx_and_px.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('data_quality_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with unpivot_diagnosis as(
         {{ dbt_utils.unpivot(

--- a/models/data_quality/intermediate/data_quality__ed_classification.sql
+++ b/models/data_quality/intermediate/data_quality__ed_classification.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('data_quality_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with cte as (
   select 

--- a/models/data_quality/intermediate/data_quality__ed_classification_reference.sql
+++ b/models/data_quality/intermediate/data_quality__ed_classification_reference.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with total_cte as 

--- a/models/data_quality/intermediate/data_quality__eligibility_date_checks.sql
+++ b/models/data_quality/intermediate/data_quality__eligibility_date_checks.sql
@@ -1,8 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False))
- | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with eligibility_spans as(
     select distinct

--- a/models/data_quality/intermediate/data_quality__eligibility_demographics.sql
+++ b/models/data_quality/intermediate/data_quality__eligibility_demographics.sql
@@ -1,8 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False))
- | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 
 with eligibility_spans as(

--- a/models/data_quality/intermediate/data_quality__eligibility_missing_payer.sql
+++ b/models/data_quality/intermediate/data_quality__eligibility_missing_payer.sql
@@ -1,8 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False))
- | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with eligibility_spans as(
     select distinct

--- a/models/data_quality/intermediate/data_quality__eligibility_missing_person_id.sql
+++ b/models/data_quality/intermediate/data_quality__eligibility_missing_person_id.sql
@@ -1,8 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False))
- | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 
 with eligibility_spans as(

--- a/models/data_quality/intermediate/data_quality__encounters_cost_and_utilization.sql
+++ b/models/data_quality/intermediate/data_quality__encounters_cost_and_utilization.sql
@@ -1,6 +1,6 @@
 {{ config(
-    enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with member_months as (
     select 

--- a/models/data_quality/intermediate/data_quality__encounters_missing_groups.sql
+++ b/models/data_quality/intermediate/data_quality__encounters_missing_groups.sql
@@ -1,6 +1,6 @@
 {{ config(
-    enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with expected_groups as (
     select 'inpatient' as encounter_group

--- a/models/data_quality/intermediate/data_quality__encounters_missing_groups_union.sql
+++ b/models/data_quality/intermediate/data_quality__encounters_missing_groups_union.sql
@@ -1,6 +1,6 @@
 {{ config(
-    enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 select
     'number of missing encounter groups' as data_quality_check

--- a/models/data_quality/intermediate/data_quality__financial_pmpm.sql
+++ b/models/data_quality/intermediate/data_quality__financial_pmpm.sql
@@ -1,6 +1,6 @@
 {{ config(
-    enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with cte as (
 select distinct cast(year_month_int as {{ dbt.type_string() }} ) as year_month

--- a/models/data_quality/intermediate/data_quality__medical_claim_claim_line_fields.sql
+++ b/models/data_quality/intermediate/data_quality__medical_claim_claim_line_fields.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with medical_claim as (
   select

--- a/models/data_quality/intermediate/data_quality__medical_claim_date_checks.sql
+++ b/models/data_quality/intermediate/data_quality__medical_claim_date_checks.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False)) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with medical_claim as (
     select m.claim_id,

--- a/models/data_quality/intermediate/data_quality__medical_claim_inst_header_fields.sql
+++ b/models/data_quality/intermediate/data_quality__medical_claim_inst_header_fields.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with inst_header as (
   select

--- a/models/data_quality/intermediate/data_quality__medical_claim_person_id.sql
+++ b/models/data_quality/intermediate/data_quality__medical_claim_person_id.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with medical as (
   select

--- a/models/data_quality/intermediate/data_quality__medical_claim_provider_npi.sql
+++ b/models/data_quality/intermediate/data_quality__medical_claim_provider_npi.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with medical_claim as (
     select

--- a/models/data_quality/intermediate/data_quality__pharmacy_claim_date_checks.sql
+++ b/models/data_quality/intermediate/data_quality__pharmacy_claim_date_checks.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with pharmacy_claim as (
   select

--- a/models/data_quality/intermediate/data_quality__pharmacy_claim_ndc.sql
+++ b/models/data_quality/intermediate/data_quality__pharmacy_claim_ndc.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with pharmacy_claim as (
   select

--- a/models/data_quality/intermediate/data_quality__pharmacy_claim_npi.sql
+++ b/models/data_quality/intermediate/data_quality__pharmacy_claim_npi.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with pharmacy_claim as (
     select

--- a/models/data_quality/intermediate/data_quality__pharmacy_claim_person_id.sql
+++ b/models/data_quality/intermediate/data_quality__pharmacy_claim_person_id.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with pharmacy as (
   select

--- a/models/data_quality/intermediate/data_quality__pharmacy_claim_prescription_details.sql
+++ b/models/data_quality/intermediate/data_quality__pharmacy_claim_prescription_details.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with pharmacy_claim as (
   select

--- a/models/data_quality/intermediate/data_quality__primary_key_check.sql
+++ b/models/data_quality/intermediate/data_quality__primary_key_check.sql
@@ -1,6 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
-) }}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with pharmacy as (
   select

--- a/models/data_quality/intermediate/data_quality__quality_measures.sql
+++ b/models/data_quality/intermediate/data_quality__quality_measures.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with cte as (

--- a/models/data_quality/intermediate/data_quality__quality_measures_reference.sql
+++ b/models/data_quality/intermediate/data_quality__quality_measures_reference.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with cte as (

--- a/models/data_quality/intermediate/data_quality__readmissions.sql
+++ b/models/data_quality/intermediate/data_quality__readmissions.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 

--- a/models/data_quality/intermediate/data_quality__readmissions_reference.sql
+++ b/models/data_quality/intermediate/data_quality__readmissions_reference.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled', var('tuva_marts_enabled', False)) | as_bool
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
 )}}
 
 with cte as (

--- a/models/data_quality/intermediate/data_quality__service_categories_pmpm.sql
+++ b/models/data_quality/intermediate/data_quality__service_categories_pmpm.sql
@@ -1,4 +1,6 @@
-{{ config(enabled = var('claims_enabled', var('tuva_marts_enabled', false)) | as_bool) }}
+{{ config(
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with member_months as (
     select

--- a/models/data_quality/stage/data_quality__eligibility_dq_stage.sql
+++ b/models/data_quality/stage/data_quality__eligibility_dq_stage.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False)) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+)}}
 
 with month_start_and_end_dates as (
   select

--- a/models/data_quality/stage/data_quality__inpatient_dq_stage.sql
+++ b/models/data_quality/stage/data_quality__inpatient_dq_stage.sql
@@ -1,7 +1,6 @@
 {{ config(
-     enabled = var('claims_preprocessing_enabled', var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
-   )
-}}
+     enabled = (var('enable_legacy_data_quality', False) and var('claims_preprocessing_enabled', var('claims_enabled', var('tuva_marts_enabled', False)))) | as_bool
+)}}
 
 with drg_requirement as (
   select distinct


### PR DESCRIPTION
## Review https://github.com/tuva-health/tuva/pull/737 first as the diff will clear up a lot once that PR is addressed.

## Describe your changes
Introducing a variable of `enable_legacy_data_quality` that is set to false be default. Can be overwritten in custom configurations.


## How has this been tested?
Tested in local dev envs

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output