### PR TITLE
separating models for fabric query fix

### DIFF
--- a/models/claims_preprocessing/encounters/encounter_models.yml
+++ b/models/claims_preprocessing/encounters/encounter_models.yml
@@ -3526,6 +3526,16 @@ models:
       - claims_preprocessing
       - encounters
 
+  - name: office_visits__int_detail_values
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_claims_preprocessing
+        {%- else -%}claims_preprocessing{%- endif -%}
+      materialized: table
+      tags:
+      - claims_preprocessing
+      - encounters
+
   - name: office_visits__int_office_visits_encounter_ranking
     config:
       schema: |

--- a/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
@@ -3,77 +3,9 @@
    )
 }}
 
-with encounter_date as (
-  select distinct old_encounter_id
-  ,start_date as encounter_start_date
-  ,'office visit surgery' as encounter_type
-  from {{ ref('office_visits__int_office_visits_surgery') }}
 
-  union all
 
-select distinct old_encounter_id
-  ,start_date as encounter_start_date
-  ,'office visit injections' as encounter_type
-  from {{ ref('office_visits__int_office_visits_injections') }}
-
-  union all 
-
-select distinct old_encounter_id
-  ,start_date as encounter_start_date
-  ,'office visit radiology' as encounter_type
-  from {{ ref('office_visits__int_office_visits_radiology') }}
-
-  union all
-
-select distinct old_encounter_id
-  ,start_date as encounter_start_date
-  ,'office visit - other' as encounter_type
-  from {{ ref('office_visits__int_office_visits') }}
-
-  union all 
-
-select distinct old_encounter_id
-  ,start_date as encounter_start_date
-  ,'office visit' as encounter_type
-  from {{ ref('office_visits__int_office_visits_em') }}
-
-  union all 
-
-select distinct old_encounter_id
-  ,start_date as encounter_start_date
-  ,'telehealth' as encounter_type
-  from {{ ref('office_visits__int_office_visits_telehealth') }}
-
-  union all 
-
-select distinct old_encounter_id
-  ,start_date as encounter_start_date
-  ,'office visit pt/ot/st' as encounter_type
-  from {{ ref('office_visits__int_office_visits') }}
-)
-
-,detail_values as (
-    select stg.*
-    ,cli.encounter_id
-    ,cli.old_encounter_id
-      ,cli.encounter_type
-    ,cli.encounter_group
-    ,d.encounter_start_date 
-    , row_number() over (partition by cli.encounter_id order by stg.claim_type, stg.start_date) as encounter_row_number --institutional then professional
-    from  {{ ref('encounters__stg_medical_claim') }} stg
-    inner join {{ ref('encounters__combined_claim_line_crosswalk') }} cli on stg.claim_id = cli.claim_id  
-    and
-    stg.claim_line_number = cli.claim_line_number
-    and
-    cli.encounter_group = 'office based'
-    and
-    cli.claim_line_attribution_number = 1
-    inner join encounter_date d on cli.old_encounter_id = d.old_encounter_id
-    and
-    d.encounter_type = cli.encounter_type
-)
-
-, patient as (
+ with patient as (
     select 
         patient_data_source_id
         , birth_date
@@ -94,7 +26,7 @@ select distinct old_encounter_id
     , count(distinct claim_id) as claim_count
     , count(distinct(case when claim_type = 'institutional' then claim_id else null end))  as inst_claim_count
     , count(distinct(case when claim_type = 'professional' then claim_id else null end))  as prof_claim_count
-from detail_values
+from {{ ref('office_visits__int_detail_values') }}
 group by encounter_id
 ,encounter_type 
 ,encounter_group
@@ -108,7 +40,7 @@ group by encounter_id
   , diagnosis_code_type
   , row_number() over (partition by encounter_id order by sum(paid_amount) desc ) as paid_order
   , sum(paid_amount) as paid_amount
-  from detail_values
+  from {{ ref('office_visits__int_detail_values') }}
   where diagnosis_code_1 is not null
   group by diagnosis_code_1
   , encounter_id
@@ -121,7 +53,7 @@ group by encounter_id
   , facility_id
   , row_number() over (partition by encounter_id order by sum(paid_amount) desc ) as paid_order
   , sum(paid_amount) as paid_amount
-  from detail_values
+  from {{ ref('office_visits__int_detail_values') }}
   where facility_id is not null
   group by 
    encounter_id
@@ -134,7 +66,7 @@ group by encounter_id
   , billing_id
   , row_number() over (partition by encounter_id order by sum(paid_amount) desc ) as paid_order
   , sum(paid_amount) as paid_amount
-  from detail_values
+  from {{ ref('office_visits__int_detail_values') }}
   where billing_id is not null
   group by 
    encounter_id
@@ -149,7 +81,7 @@ group by encounter_id
   , ccs_category_description
   , row_number() over (partition by encounter_id order by sum(paid_amount) desc ) as paid_order
   , sum(paid_amount) as paid_amount
-  from detail_values
+  from {{ ref('office_visits__int_detail_values') }}
   where hcpcs_code is not null
   group by 
    encounter_id
@@ -169,7 +101,7 @@ group by encounter_id
        ,max(case when scr.service_category_2 = 'observation' then 1 else 0 end) as observation_flag
        ,max(case when scr.service_category_2 = 'pharmacy' then 1 
               else 0 end) as pharmacy_flag
-    from detail_values d
+    from {{ ref('office_visits__int_detail_values') }} d
     left join {{ ref('service_category__service_category_grouper') }} scr on d.claim_id = scr.claim_id 
     and
     scr.claim_line_number = d.claim_line_number
@@ -177,22 +109,21 @@ group by encounter_id
 )
 
 
-select   d.encounter_id
+select d.encounter_id
 , d.encounter_start_date
 , d.patient_data_source_id
-
-,tot.encounter_type
-,tot.encounter_group
+, tot.encounter_type
+, tot.encounter_group
 , {{ dbt.datediff("birth_date","d.encounter_start_date","day")}}/365 as admit_age
 , e.gender
 , e.race
 , hp.diagnosis_code_type as primary_diagnosis_code_type
 , hp.diagnosis_code_1 as primary_diagnosis_code
 , coalesce(icd10cm.long_description, icd9cm.long_description) as primary_diagnosis_description
-, hf.facility_id as facility_id
+, hf.facility_id as facility_ide
 , b.provider_organization_name as facility_name
 , phy.billing_id
-, {{ concat_custom(["b2.provider_first_name", "' '", "b2.provider_last_name"]) }} as provider_name
+, {{ dbt.concat(["b2.provider_first_name", "' '", "b2.provider_last_name"]) }} as provider_name
 , b2.primary_specialty_description as provider_specialty
 , sc.lab_flag
 , sc.dme_flag
@@ -209,7 +140,7 @@ select   d.encounter_id
 , tot.prof_claim_count
 , d.data_source
 , '{{ var('tuva_last_run')}}' as tuva_last_run
-from detail_values d
+from {{ ref('office_visits__int_detail_values') }} d
 inner join total_amounts tot on d.encounter_id = tot.encounter_id
 inner join service_category_flags sc on d.encounter_id = sc.encounter_id
 left join highest_paid_diagnosis hp on d.encounter_id = hp.encounter_id

--- a/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
@@ -120,7 +120,7 @@ select d.encounter_id
 , hp.diagnosis_code_type as primary_diagnosis_code_type
 , hp.diagnosis_code_1 as primary_diagnosis_code
 , coalesce(icd10cm.long_description, icd9cm.long_description) as primary_diagnosis_description
-, hf.facility_id as facility_ide
+, hf.facility_id as facility_id
 , b.provider_organization_name as facility_name
 , phy.billing_id
 , {{ concat_custom(["b2.provider_first_name", "' '", "b2.provider_last_name"]) }} as provider_name

--- a/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
+++ b/models/claims_preprocessing/encounters/final/office_visit__encounter_grain.sql
@@ -123,7 +123,7 @@ select d.encounter_id
 , hf.facility_id as facility_ide
 , b.provider_organization_name as facility_name
 , phy.billing_id
-, {{ dbt.concat(["b2.provider_first_name", "' '", "b2.provider_last_name"]) }} as provider_name
+, {{ concat_custom(["b2.provider_first_name", "' '", "b2.provider_last_name"]) }} as provider_name
 , b2.primary_specialty_description as provider_specialty
 , sc.lab_flag
 , sc.dme_flag

--- a/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_detail_values.sql
+++ b/models/claims_preprocessing/encounters/intermediate/office_visits/office_visits__int_detail_values.sql
@@ -1,0 +1,87 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled', var('claims_enabled', var('tuva_marts_enabled', False))) | as_bool
+   )
+}}
+with encounter_date as (
+  select distinct old_encounter_id
+  ,start_date as encounter_start_date
+  ,'office visit surgery' as encounter_type
+  from {{ ref('office_visits__int_office_visits_surgery') }}
+
+  union all
+
+select distinct old_encounter_id
+  ,start_date as encounter_start_date
+  ,'office visit injections' as encounter_type
+  from {{ ref('office_visits__int_office_visits_injections') }}
+
+  union all 
+
+select distinct old_encounter_id
+  ,start_date as encounter_start_date
+  ,'office visit radiology' as encounter_type
+  from {{ ref('office_visits__int_office_visits_radiology') }}
+
+  union all
+
+select distinct old_encounter_id
+  ,start_date as encounter_start_date
+  ,'office visit - other' as encounter_type
+  from {{ ref('office_visits__int_office_visits') }}
+
+  union all 
+
+select distinct old_encounter_id
+  ,start_date as encounter_start_date
+  ,'office visit' as encounter_type
+  from {{ ref('office_visits__int_office_visits_em') }}
+
+  union all 
+
+select distinct old_encounter_id
+  ,start_date as encounter_start_date
+  ,'telehealth' as encounter_type
+  from {{ ref('office_visits__int_office_visits_telehealth') }}
+
+  union all 
+
+select distinct old_encounter_id
+  ,start_date as encounter_start_date
+  ,'office visit pt/ot/st' as encounter_type
+  from {{ ref('office_visits__int_office_visits') }}
+)
+
+
+    select 
+      stg.paid_amount
+    , stg.allowed_amount
+    , stg.charge_amount
+    , stg.claim_id
+    , stg.claim_type
+    , stg.diagnosis_code_1
+    , stg.diagnosis_code_type
+    , stg.facility_id
+    , stg.billing_id
+    , stg.hcpcs_code
+    , stg.ccs_category
+    , stg.ccs_category_description
+    , stg.claim_line_number
+    , stg.patient_data_source_id
+    , stg.data_source
+    , cli.encounter_id
+    , cli.old_encounter_id
+    , cli.encounter_type
+    , cli.encounter_group
+    , d.encounter_start_date 
+    , row_number() over (partition by cli.encounter_id order by stg.claim_type, stg.start_date) as encounter_row_number --institutional then professional
+    from  {{ ref('encounters__stg_medical_claim') }} stg
+    inner join {{ ref('encounters__combined_claim_line_crosswalk') }} cli on stg.claim_id = cli.claim_id  
+    and
+    stg.claim_line_number = cli.claim_line_number
+    and
+    cli.encounter_group = 'office based'
+    and
+    cli.claim_line_attribution_number = 1
+    inner join encounter_date d on cli.old_encounter_id = d.old_encounter_id
+    and
+    d.encounter_type = cli.encounter_type


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
separating out office visit encounter model which was erroring out on fabric due to query plan 



## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
ran on fabric and this fixes the issue

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
