### PR TITLE
Disambiguate `tuva_last_run`, there are issues when input layer models provide this column

### DIFF
--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_claim_line_end_date.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_claim_line_end_date.sql
@@ -19,14 +19,14 @@ SELECT
     , m.claim_type as claim_type
     , 'CLAIM_LINE_END_DATE' AS field_name
     , case
-        when m.claim_line_end_date > tuva_last_run then 'invalid'
+        when m.claim_line_end_date > cte.tuva_last_run then 'invalid'
         when m.claim_line_end_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'invalid'
         when m.claim_line_end_date > m.claim_line_end_date then 'invalid'
         when m.claim_line_end_date is null then 'null'
         else 'valid'
     end as bucket_name
     , case
-        when m.claim_line_end_date > tuva_last_run then 'future'
+        when m.claim_line_end_date > cte.tuva_last_run then 'future'
         when m.claim_line_end_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'too old'
         when m.claim_line_end_date > m.claim_end_date then 'line date greater than claim date'
         else null

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_claim_line_start_date.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_claim_line_start_date.sql
@@ -18,14 +18,14 @@ SELECT
     , m.claim_type as claim_type
     , 'CLAIM_LINE_START_DATE' AS field_name
     , case
-        when m.claim_line_start_date > tuva_last_run then 'invalid'
+        when m.claim_line_start_date > cte.tuva_last_run then 'invalid'
         when m.claim_line_start_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp = "cte.tuva_last_run") }} then 'invalid'
         when m.claim_line_start_date < m.claim_start_date then 'invalid'
         when m.claim_line_start_date is null then 'null'
         else 'valid'
     end as bucket_name
     , case
-        when m.claim_line_start_date > tuva_last_run then 'future'
+        when m.claim_line_start_date > cte.tuva_last_run then 'future'
         when m.claim_line_start_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp = "cte.tuva_last_run" ) }} then 'too old'
         when m.claim_line_start_date < m.claim_start_date then 'line date less than than claim date'
         else null

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_paid_date.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_paid_date.sql
@@ -18,14 +18,14 @@ SELECT
     , m.claim_type as claim_type
     , 'PAID_DATE' AS field_name
     , case
-        when m.paid_date > tuva_last_run then 'invalid'
+        when m.paid_date > cte.tuva_last_run then 'invalid'
         when m.paid_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'invalid'
         when m.paid_date < m.claim_start_date then 'invalid'
         when m.paid_date is null then 'null'
         else 'valid'
     end as bucket_name
     , case
-        when m.paid_date > tuva_last_run then 'future'
+        when m.paid_date > cte.tuva_last_run then 'future'
         when m.paid_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'too old'
         when m.paid_date < m.claim_start_date then 'paid date before claim start date'
         else null

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/pharmacy/data_quality__pharmacy_dispensing_date.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/pharmacy/data_quality__pharmacy_dispensing_date.sql
@@ -16,13 +16,13 @@ SELECT
     , 'PHARMACY' AS claim_type
     , 'DISPENSING_DATE' AS field_name
     , case
-        when m.dispensing_date > tuva_last_run then 'invalid'
+        when m.dispensing_date > cte.tuva_last_run then 'invalid'
         when m.dispensing_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'invalid'
         when m.dispensing_date is null then 'null'
         else 'valid'
     end as bucket_name
     , case
-        when m.dispensing_date > tuva_last_run then 'future'
+        when m.dispensing_date > cte.tuva_last_run then 'future'
         when m.dispensing_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'too old'
         else null
         end as invalid_reason

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/pharmacy/data_quality__pharmacy_paid_date.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/pharmacy/data_quality__pharmacy_paid_date.sql
@@ -16,13 +16,13 @@ SELECT
     , 'PHARMACY' AS claim_type
     , 'PAID_DATE' AS field_name
     , case
-        when m.paid_date > tuva_last_run then 'invalid'
+        when m.paid_date > cte.tuva_last_run then 'invalid'
         when m.paid_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'invalid'
         when m.paid_date is null then 'null'
         else 'valid'
     end as bucket_name
     , case
-        when m.paid_date > tuva_last_run then 'future'
+        when m.paid_date > cte.tuva_last_run then 'future'
         when m.paid_date < {{ dbt.dateadd(datepart="year", interval=-10, from_date_or_timestamp="cte.tuva_last_run") }} then 'too old'
         else null
         end as invalid_reason


### PR DESCRIPTION
## Describe your changes

Disambiguate `tuva_last_run`, there are issues when input layer models provide this column

## How has this been tested?

By running the whole thing:
```
22:22:18  Finished running 15 incremental models, 1 project hook, 584 table models, 173 view models in 0 hours 7 minutes and 41.77 seconds (461.77s).
22:22:19
22:22:19  Completed successfully
22:22:19
22:22:19  Done. PASS=773 WARN=0 ERROR=0 SKIP=0 TOTAL=773
```

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
