### PR TITLE
Added check for readmissions enabled for mart review

### DIFF
--- a/models/data_quality/dqi/mart_review/final/mart_review__readmissions.sql
+++ b/models/data_quality/dqi/mart_review/final/mart_review__readmissions.sql
@@ -1,5 +1,5 @@
 {{ config(
-     enabled = var('claims_enabled',var('tuva_marts_enabled',False))
+     enabled = var('readmissions_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
  | as_bool
    )
 }}

--- a/models/readmissions/intermediate/readmissions__index_admission.sql
+++ b/models/readmissions/intermediate/readmissions__index_admission.sql
@@ -11,7 +11,7 @@
 -- for the HWR measure:
 --
 --     Time Requirement: The discharge data must be at least 30 days
---                       earlier than the last dischareg date available
+--                       earlier than the last discharge date available
 --                       in the dataset.
 -- 
 --     Discharge Requirements: The patient must not be discharged to another


### PR DESCRIPTION
## Describe your changes
- Added check for readmissions_enabled on the dqi - mart_review model for readmissions.
- Fixed a typo

## How has this been tested?
Disabled readmissions by adding `readmissions_enabled: false` to the `dbt_project.yml` file. Ran `dbt run`.

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [n/a] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [n/a] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [n/a] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [n/a] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [n/a] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
