### PR TITLE
Update README in `integration_tests`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ The easiest way to test your changes is to use the dbt project inside the packag
 1. Set the project subdirectory to “integration_tests” if using dbt cloud or change directory (`cd integration_tests`) if using CLI.
 2. Choose a data source:
    1. To use synthetic demo data:
-        -  Set test_data_override to true
+        -  Set use_synthetic_data to true
    3. To use your own data sources, update the vars in integration_tests/dbt_project.yml:
         - Set input_database and input_schema to your testing sources
 4. Run `dbt deps`.

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,13 +1,10 @@
 ## Using Integration Tests
 
-#### In CLI:
-- Open project in parent folder
-- Change terminal context to integration_tests folder
-- Make sure any parent package refs are sources and models in integration_tests
-- dbt deps before building and/or running
-
-#### In Cloud:
-- In account settings > projects > project, set **project subdirectory** to `integration_tests`
-- Make sure any parent package refs are sources and models in integration_tests
-- dbt deps before building and/or running
-- If it's not working, try switching to classic ide and back 
+1. Set the project subdirectory to “integration_tests” if using dbt cloud or change directory to "integration_tests" (`cd integration_tests`) if using CLI.
+2. Choose a data source:
+   1. To use synthetic demo data:
+        -  Set use_synthetic_data to true
+   3. To use your own data sources, update the vars in integration_tests/dbt_project.yml:
+        - Set input_database and input_schema to your testing sources
+4. Run `dbt deps`.
+5. Run `dbt build`.


### PR DESCRIPTION
## Describe your changes
Changes docs in `integration_tests` to mirror the "How to test the package" section from the Contributing guide. Previously it was difficult to understand the requirements for running tests from the `integration_tests` directory. Closes #780 


## How has this been tested?
Docs update


## Reviewer focus
Would we rather provide a link than instructions? to me it seems more intuitive to have insrtructions in the appropriate dir (`integration_tests`)


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
