### PR TITLE
Move member_month_key calculation to norm_input_elig. Adjust claims_e…

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -8,7 +8,7 @@ vars:
   error_empty_seeds: true
   ## Use this variable to run the project with synthetic data loaded as seeds
   # otherwise set to false and set the input vars below
-  use_synthetic_data: true
+  use_synthetic_data: false
 
   ## Update these vars to use your own data as input, do not comment out
   # enabled logic has been added to the sources config

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -8,7 +8,7 @@ vars:
   error_empty_seeds: true
   ## Use this variable to run the project with synthetic data loaded as seeds
   # otherwise set to false and set the input vars below
-  use_synthetic_data: false
+  use_synthetic_data: true
 
   ## Update these vars to use your own data as input, do not comment out
   # enabled logic has been added to the sources config

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -60,8 +60,8 @@ select distinct
     , claim.inferred_claim_start_year_month
     , claim.inferred_claim_start_column_used
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
-from {{ ref('core__member_months') }} as mm
-inner join claim_year_month as claim
+from claim_year_month as claim
+inner join {{ ref('normalized_input__eligibility') }} as mm
     on mm.person_id = claim.person_id
     and mm.member_id = claim.member_id
     and mm.payer = claim.payer

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -45,7 +45,6 @@ with claim_dates as (
             )
         ]) }} as inferred_claim_start_year_month
 from claim_dates
-
 )
 
 select distinct

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_rx_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_rx_claims_with_enrollment.sql
@@ -38,8 +38,8 @@ select distinct
     , mm.member_month_key
     , claim.paid_year_month
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
-from {{ ref('core__member_months') }} as mm
-inner join claim_dates as claim
+from claim_dates as claim
+inner join {{ ref('normalized_input__eligibility') }} as mm
     on mm.person_id = claim.person_id
     and mm.member_id = claim.member_id
     and mm.payer = claim.payer

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -72,7 +72,7 @@ with stg_eligibility as (
     and a.enrollment_end_date >= b.month_start_date
 )
 
-select 
+select
     m.member_month_key
   , a.person_id
   , a.member_id

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -6,40 +6,41 @@
 
 
 with stg_eligibility as (
-    select
-      cast(elig.person_id as {{ dbt.type_string() }}) as person_id
-      , cast(elig.member_id as {{ dbt.type_string() }}) as member_id
-      , cast(elig.subscriber_id as {{ dbt.type_string() }}) as subscriber_id
-      , cast(elig.gender as {{ dbt.type_string() }}) as gender
-      , cast(elig.race as {{ dbt.type_string() }}) as race
-      , cast(date_norm.normalized_birth_date as date) as birth_date
-      , cast(date_norm.normalized_death_date as date) as death_date
-      , cast(elig.death_flag as int) as death_flag
-      , cast(date_norm.normalized_enrollment_start_date as date) as enrollment_start_date
-      , cast(date_norm.normalized_enrollment_end_date as date) as enrollment_end_date
-      , cast(elig.payer as {{ dbt.type_string() }}) as payer
-      , cast(elig.payer_type as {{ dbt.type_string() }}) as payer_type
-      , cast(elig.{{ quote_column('plan') }} as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
-      , cast(elig.original_reason_entitlement_code as {{ dbt.type_string() }}) as original_reason_entitlement_code
-      , cast(elig.dual_status_code as {{ dbt.type_string() }}) as dual_status_code
-      , cast(elig.medicare_status_code as {{ dbt.type_string() }}) as medicare_status_code
-      , cast(elig.group_id as {{ dbt.type_string() }}) as group_id
-      , cast(elig.group_name as {{ dbt.type_string() }}) as group_name
-      , cast(elig.first_name as {{ dbt.type_string() }}) as first_name
-      , cast(elig.last_name as {{ dbt.type_string() }}) as last_name
-      , cast(elig.social_security_number as {{ dbt.type_string() }}) as social_security_number
-      , cast(elig.subscriber_relation as {{ dbt.type_string() }}) as subscriber_relation
-      , cast(elig.address as {{ dbt.type_string() }}) as address
-      , cast(elig.city as {{ dbt.type_string() }}) as city
-      , cast(elig.state as {{ dbt.type_string() }}) as state
-      , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
-      , cast(elig.phone as {{ dbt.type_string() }}) as phone
-      , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
-      , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
-    from {{ ref('normalized_input__stg_eligibility') }} as elig
-    left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
-      on elig.person_id_key = date_norm.person_id_key
+  select
+    cast(elig.person_id as {{ dbt.type_string() }}) as person_id
+    , cast(elig.member_id as {{ dbt.type_string() }}) as member_id
+    , cast(elig.subscriber_id as {{ dbt.type_string() }}) as subscriber_id
+    , cast(elig.gender as {{ dbt.type_string() }}) as gender
+    , cast(elig.race as {{ dbt.type_string() }}) as race
+    , cast(date_norm.normalized_birth_date as date) as birth_date
+    , cast(date_norm.normalized_death_date as date) as death_date
+    , cast(elig.death_flag as int) as death_flag
+    , cast(date_norm.normalized_enrollment_start_date as date) as enrollment_start_date
+    , cast(date_norm.normalized_enrollment_end_date as date) as enrollment_end_date
+    , cast(elig.payer as {{ dbt.type_string() }}) as payer
+    , cast(elig.payer_type as {{ dbt.type_string() }}) as payer_type
+    , cast(elig.{{ quote_column('plan') }} as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
+    , cast(elig.original_reason_entitlement_code as {{ dbt.type_string() }}) as original_reason_entitlement_code
+    , cast(elig.dual_status_code as {{ dbt.type_string() }}) as dual_status_code
+    , cast(elig.medicare_status_code as {{ dbt.type_string() }}) as medicare_status_code
+    , cast(elig.group_id as {{ dbt.type_string() }}) as group_id
+    , cast(elig.group_name as {{ dbt.type_string() }}) as group_name
+    , cast(elig.first_name as {{ dbt.type_string() }}) as first_name
+    , cast(elig.last_name as {{ dbt.type_string() }}) as last_name
+    , cast(elig.social_security_number as {{ dbt.type_string() }}) as social_security_number
+    , cast(elig.subscriber_relation as {{ dbt.type_string() }}) as subscriber_relation
+    , cast(elig.address as {{ dbt.type_string() }}) as address
+    , cast(elig.city as {{ dbt.type_string() }}) as city
+    , cast(elig.state as {{ dbt.type_string() }}) as state
+    , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
+    , cast(elig.phone as {{ dbt.type_string() }}) as phone
+    , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
+    , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
+  from {{ ref('normalized_input__stg_eligibility') }} as elig
+  left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
+    on elig.person_id_key = date_norm.person_id_key
 )
+
 , month_start_and_end_dates as (
   select
     {{ concat_custom(["year",
@@ -49,6 +50,7 @@ with stg_eligibility as (
   from {{ ref('reference_data__calendar') }}
   group by year, month, year_month
 )
+
 , member_month_calc as (
   select distinct
     dense_rank() over (
@@ -69,6 +71,7 @@ with stg_eligibility as (
     on a.enrollment_start_date <= b.month_end_date
     and a.enrollment_end_date >= b.month_start_date
 )
+
 select 
     m.member_month_key
   , a.person_id

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -5,36 +5,109 @@
 }}
 
 
-select
-    cast(elig.person_id as {{ dbt.type_string() }}) as person_id
-    , cast(elig.member_id as {{ dbt.type_string() }}) as member_id
-    , cast(elig.subscriber_id as {{ dbt.type_string() }}) as subscriber_id
-    , cast(elig.gender as {{ dbt.type_string() }}) as gender
-    , cast(elig.race as {{ dbt.type_string() }}) as race
-    , cast(date_norm.normalized_birth_date as date) as birth_date
-    , cast(date_norm.normalized_death_date as date) as death_date
-    , cast(elig.death_flag as int) as death_flag
-    , cast(date_norm.normalized_enrollment_start_date as date) as enrollment_start_date
-    , cast(date_norm.normalized_enrollment_end_date as date) as enrollment_end_date
-    , cast(elig.payer as {{ dbt.type_string() }}) as payer
-    , cast(elig.payer_type as {{ dbt.type_string() }}) as payer_type
-    , cast(elig.{{ quote_column('plan') }} as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
-    , cast(elig.original_reason_entitlement_code as {{ dbt.type_string() }}) as original_reason_entitlement_code
-    , cast(elig.dual_status_code as {{ dbt.type_string() }}) as dual_status_code
-    , cast(elig.medicare_status_code as {{ dbt.type_string() }}) as medicare_status_code
-    , cast(elig.group_id as {{ dbt.type_string() }}) as group_id
-    , cast(elig.group_name as {{ dbt.type_string() }}) as group_name
-    , cast(elig.first_name as {{ dbt.type_string() }}) as first_name
-    , cast(elig.last_name as {{ dbt.type_string() }}) as last_name
-    , cast(elig.social_security_number as {{ dbt.type_string() }}) as social_security_number
-    , cast(elig.subscriber_relation as {{ dbt.type_string() }}) as subscriber_relation
-    , cast(elig.address as {{ dbt.type_string() }}) as address
-    , cast(elig.city as {{ dbt.type_string() }}) as city
-    , cast(elig.state as {{ dbt.type_string() }}) as state
-    , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
-    , cast(elig.phone as {{ dbt.type_string() }}) as phone
-    , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
-    , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
-from {{ ref('normalized_input__stg_eligibility') }} as elig
-left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
-    on elig.person_id_key = date_norm.person_id_key
+with stg_eligibility as (
+    select
+      cast(elig.person_id as {{ dbt.type_string() }}) as person_id
+      , cast(elig.member_id as {{ dbt.type_string() }}) as member_id
+      , cast(elig.subscriber_id as {{ dbt.type_string() }}) as subscriber_id
+      , cast(elig.gender as {{ dbt.type_string() }}) as gender
+      , cast(elig.race as {{ dbt.type_string() }}) as race
+      , cast(date_norm.normalized_birth_date as date) as birth_date
+      , cast(date_norm.normalized_death_date as date) as death_date
+      , cast(elig.death_flag as int) as death_flag
+      , cast(date_norm.normalized_enrollment_start_date as date) as enrollment_start_date
+      , cast(date_norm.normalized_enrollment_end_date as date) as enrollment_end_date
+      , cast(elig.payer as {{ dbt.type_string() }}) as payer
+      , cast(elig.payer_type as {{ dbt.type_string() }}) as payer_type
+      , cast(elig.{{ quote_column('plan') }} as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
+      , cast(elig.original_reason_entitlement_code as {{ dbt.type_string() }}) as original_reason_entitlement_code
+      , cast(elig.dual_status_code as {{ dbt.type_string() }}) as dual_status_code
+      , cast(elig.medicare_status_code as {{ dbt.type_string() }}) as medicare_status_code
+      , cast(elig.group_id as {{ dbt.type_string() }}) as group_id
+      , cast(elig.group_name as {{ dbt.type_string() }}) as group_name
+      , cast(elig.first_name as {{ dbt.type_string() }}) as first_name
+      , cast(elig.last_name as {{ dbt.type_string() }}) as last_name
+      , cast(elig.social_security_number as {{ dbt.type_string() }}) as social_security_number
+      , cast(elig.subscriber_relation as {{ dbt.type_string() }}) as subscriber_relation
+      , cast(elig.address as {{ dbt.type_string() }}) as address
+      , cast(elig.city as {{ dbt.type_string() }}) as city
+      , cast(elig.state as {{ dbt.type_string() }}) as state
+      , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
+      , cast(elig.phone as {{ dbt.type_string() }}) as phone
+      , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
+      , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
+    from {{ ref('normalized_input__stg_eligibility') }} as elig
+    left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
+      on elig.person_id_key = date_norm.person_id_key
+)
+, month_start_and_end_dates as (
+  select
+    {{ concat_custom(["year",
+                  dbt.right(concat_custom(["'0'", "month"]), 2)]) }} as year_month
+    , min(full_date) as month_start_date
+    , max(full_date) as month_end_date
+  from {{ ref('reference_data__calendar') }}
+  group by year, month, year_month
+)
+, member_month_calc as (
+  select distinct
+    dense_rank() over (
+      order by
+        a.person_id
+      , b.year_month
+      , a.payer
+      , a.{{ quote_column('plan') }}
+      , a.data_source
+      ) as member_month_key
+    , a.person_id
+    , b.year_month
+    , a.payer
+    , a.{{ quote_column('plan') }}
+    , a.data_source
+  from stg_eligibility as a
+  inner join month_start_and_end_dates as b
+    on a.enrollment_start_date <= b.month_end_date
+    and a.enrollment_end_date >= b.month_start_date
+)
+select 
+    m.member_month_key
+  , a.person_id
+  , a.member_id
+  , a.subscriber_id
+  , a.gender
+  , a.race
+  , a.birth_date
+  , a.death_date
+  , a.death_flag
+  , a.enrollment_start_date
+  , a.enrollment_end_date
+  , a.payer
+  , a.payer_type
+  , a.{{ quote_column('plan') }}
+  , b.year_month
+  , a.original_reason_entitlement_code
+  , a.dual_status_code
+  , a.medicare_status_code
+  , a.group_id
+  , a.group_name
+  , a.first_name
+  , a.last_name
+  , a.social_security_number
+  , a.subscriber_relation
+  , a.address
+  , a.city
+  , a.state
+  , a.zip_code
+  , a.phone
+  , a.data_source
+  , a.tuva_last_run
+from stg_eligibility as a
+  inner join month_start_and_end_dates as b
+    on a.enrollment_start_date <= b.month_end_date
+    and a.enrollment_end_date >= b.month_start_date
+  inner join member_month_calc as m
+    on m.person_id = a.person_id
+    and m.payer = a.payer
+    and m.{{ quote_column('plan') }} = a.{{ quote_column('plan') }}
+    and m.data_source = a.data_source
+    and m.year_month = b.year_month

--- a/models/core/final/core__member_months.sql
+++ b/models/core/final/core__member_months.sql
@@ -44,6 +44,7 @@ with final_before_attribution_fields as (
   and a.{{ quote_column('plan') }} = b.{{ quote_column('plan') }}
   and a.data_source = b.data_source
 )
+
 select
     member_month_key
   , person_id

--- a/models/core/final/core__member_months.sql
+++ b/models/core/final/core__member_months.sql
@@ -3,70 +3,49 @@
    )
 }}
 
-with month_start_and_end_dates as (
-  select
-    {{ concat_custom(["year",
-                  dbt.right(concat_custom(["'0'", "month"]), 2)]) }} as year_month
-    , min(full_date) as month_start_date
-    , max(full_date) as month_end_date
-  from {{ ref('reference_data__calendar') }}
-  group by year, month, year_month
-)
-
-
-, final_before_attribution_fields as (
-select distinct
-    a.person_id
-  , a.member_id
-  , year_month
-  , a.payer
-  , a.{{ quote_column('plan') }}
-  , data_source
-  , '{{ var('tuva_last_run') }}' as tuva_last_run
-from {{ ref('core__eligibility') }} as a
-inner join month_start_and_end_dates as b
-  on a.enrollment_start_date <= b.month_end_date
-  and a.enrollment_end_date >= b.month_start_date
+with final_before_attribution_fields as (
+  select distinct
+      a.member_month_key
+    , a.person_id
+    , a.member_id
+    , a.year_month
+    , a.payer
+    , a.{{ quote_column('plan') }}
+    , data_source
+    , '{{ var('tuva_last_run') }}' as tuva_last_run
+  from {{ ref('normalized_input__eligibility') }} as a
 )
 
 , add_attribution_fields as (
-select
-    a.person_id
-  , a.member_id
-  , a.year_month
-  , a.payer
-  , a.{{ quote_column('plan') }}
-  , a.data_source
-  , a.tuva_last_run
+  select
+      a.member_month_key
+    , a.person_id
+    , a.member_id
+    , a.year_month
+    , a.payer
+    , a.{{ quote_column('plan') }}
+    , a.data_source
+    , a.tuva_last_run
 
-  , b.payer_attributed_provider
-  , b.payer_attributed_provider_practice
-  , b.payer_attributed_provider_organization
-  , b.payer_attributed_provider_lob
-  , b.custom_attributed_provider
-  , b.custom_attributed_provider_practice
-  , b.custom_attributed_provider_organization
-  , b.custom_attributed_provider_lob
-
-from final_before_attribution_fields as a
-left outer join {{ ref('financial_pmpm__stg_provider_attribution') }} as b
-on a.person_id = b.person_id
-and a.year_month = b.year_month
-and a.payer = b.payer
-and a.{{ quote_column('plan') }} = b.{{ quote_column('plan') }}
-and a.data_source = b.data_source
+    , b.payer_attributed_provider
+    , b.payer_attributed_provider_practice
+    , b.payer_attributed_provider_organization
+    , b.payer_attributed_provider_lob
+    , b.custom_attributed_provider
+    , b.custom_attributed_provider_practice
+    , b.custom_attributed_provider_organization
+    , b.custom_attributed_provider_lob
+    
+  from final_before_attribution_fields as a
+  left outer join {{ ref('financial_pmpm__stg_provider_attribution') }} as b
+  on a.person_id = b.person_id
+  and a.year_month = b.year_month
+  and a.payer = b.payer
+  and a.{{ quote_column('plan') }} = b.{{ quote_column('plan') }}
+  and a.data_source = b.data_source
 )
-
-, final_with_sk as (
 select
-    dense_rank() over (
-      order by
-        person_id
-      , year_month
-      , payer
-      , {{ quote_column('plan') }}
-      , data_source
-  ) as member_month_key
+    member_month_key
   , person_id
   , member_id
   , year_month
@@ -83,6 +62,3 @@ select
   , custom_attributed_provider_organization
   , custom_attributed_provider_lob
 from add_attribution_fields
-)
-
-select * from final_with_sk

--- a/models/core/final/core__member_months.sql
+++ b/models/core/final/core__member_months.sql
@@ -35,7 +35,7 @@ with final_before_attribution_fields as (
     , b.custom_attributed_provider_practice
     , b.custom_attributed_provider_organization
     , b.custom_attributed_provider_lob
-    
+
   from final_before_attribution_fields as a
   left outer join {{ ref('financial_pmpm__stg_provider_attribution') }} as b
   on a.person_id = b.person_id


### PR DESCRIPTION
…nrollment off core models. Optimize core mem_months.

## Describe your changes
Moved the `member_month_key` calculation upstream to `normalized_input__eligibility`.
Adjusted claims_enrollment models off of core models.
Adjusted `core__member_months` off of core models.

## How has this been tested?
Run entire dbt project to ensure models are not broken.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
