### PR TITLE
swapping coalesce for case

### DIFF
--- a/models/claims_preprocessing/normalized_input/final/normalized_input__pharmacy_claim.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__pharmacy_claim.sql
@@ -13,9 +13,28 @@ select
     , cast(payer as {{ dbt.type_string() }}) as payer
     , cast({{ quote_column('plan') }} as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
     , cast(prescribing_provider_npi as {{ dbt.type_string() }}) as prescribing_provider_id
-    , cast(coalesce({{ concat_custom(["pres.provider_last_name", "', '", "pres.provider_first_name"]) }}, pres.provider_organization_name) as {{ dbt.type_string() }}) as prescribing_provider_name
+    , case
+      when pres.entity_type_code = '1' then cast(
+        {{ concat_custom([
+             "pres.provider_last_name"
+           , "', '"
+           , "pres.provider_first_name"
+        ]) }} as {{ dbt.type_string() }})
+      when pres.entity_type_code = '2' then cast(pres.provider_organization_name as {{ dbt.type_string() }})
+      else null
+    end as prescribing_provider_name
     , cast(dispensing_provider_npi as {{ dbt.type_string() }}) as dispensing_provider_id
-    , cast(coalesce({{ concat_custom(["disp.provider_last_name", "', '", "disp.provider_first_name"]) }}, disp.provider_organization_name) as {{ dbt.type_string() }}) as dispensing_provider_name, cast(dispensing_date as date) as dispensing_date
+    , case
+      when disp.entity_type_code = '1' then cast(
+        {{ concat_custom([
+             "disp.provider_last_name"
+           , "', '"
+           , "disp.provider_first_name"
+        ]) }} as {{ dbt.type_string() }})
+      when disp.entity_type_code = '2' then cast(disp.provider_organization_name as {{ dbt.type_string() }})
+      else null
+    end as dispensing_provider_name
+    , cast(dispensing_date as date) as dispensing_date
     , cast(ndc_code as {{ dbt.type_string() }}) as ndc_code
     , cast(ndc.fda_description as {{ dbt.type_string() }}) as ndc_description
     , cast(quantity as int) as quantity


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
Old coalesce was coalescing a concatenation with a comma, so in sql dialects where a concat with a null doesn't null the result (Fabric), this always produced a comma which would be returned in the coalesce, instead of returning second item in coalesce which is the intent.

Replaced with more robust case statement that checks entity type of NPPES table and returns either name or org.


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
