### PR TITLE
Terminology  Update: 'Encounter type'

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -111,7 +111,7 @@ seeds:
       terminology__discharge_disposition:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.9','discharge_disposition.csv',compression=true,null_marker=true) }}"
       terminology__encounter_type:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.9','encounter_type.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.11','encounter_type.csv',compression=true,null_marker=true) }}"
       terminology__ethnicity:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.9','ethnicity.csv',compression=true,null_marker=true) }}"
       terminology__gender:

--- a/seeds/terminology/terminology__encounter_type.csv
+++ b/seeds/terminology/terminology__encounter_type.csv
@@ -1,1 +1,1 @@
-encounter_type
+encounter_group, encounter_type

--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -144,9 +144,13 @@ seeds:
         - terminology
         - claims_preprocessing
       column_types:
+        encounter_group : |
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
         encounter_type : |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(256) {%- endif -%}
     columns:
+      - name: encounter_group
+        description: 'The group of the encounter.'
       - name: encounter_type
         description: 'The type of the encounter.'
 


### PR DESCRIPTION
## Describe your changes
- new column _encounter_group_ added to the schema file of **encounter_type** terminology.

## How has this been tested?
- ran `dbt seed -s terminology__encounter_type` in Snowflake warehouse.

## Reviewer focus
Updated seed has been unloaded to the s3 bucket URI=

> s3://tuva-public-resources-snowflake/versioned_terminology/encounter_type.csv_0_0_0.csv.gz

Please sync the seed to your production bucket. @sarah-tuva


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
