### PR TITLE
Fix redshift actions to compile instead of build

### DIFF
--- a/.github/workflows/outside_contributor_dbt_v1.8.6.yml
+++ b/.github/workflows/outside_contributor_dbt_v1.8.6.yml
@@ -240,6 +240,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/bigquery
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -299,6 +300,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/bigquery
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -358,6 +360,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/bigquery
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -417,6 +420,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/bigquery
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -506,6 +510,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/fabric
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -550,6 +555,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/fabric
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -594,6 +600,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/fabric
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -638,6 +645,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/fabric
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -676,6 +684,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/redshift
         working-directory: ci_testing
+
       #Changed to seed then compile to speed up processing time
       - name: dbt-seed
         run: |
@@ -721,7 +730,7 @@ jobs:
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
-          dbt build --full-refresh --profiles-dir ./profiles/redshift --vars '{"input_database":"dev_ci_testing","input_schema":"input_layer","claims_enabled":true}'
+          dbt compile --profiles-dir ./profiles/redshift --vars '{"input_database":"dev_ci_testing","input_schema":"input_layer","claims_enabled":true}'
         working-directory: ci_testing
 
       - name: Get the result
@@ -755,6 +764,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/redshift
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -792,6 +802,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/redshift
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -829,6 +840,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/redshift
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -904,6 +916,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -941,6 +954,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -978,6 +992,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -1015,6 +1030,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
+
       #Changed to compile to save processing time
       - name: dbt-compile
         run: |

--- a/.github/workflows/tuva_internal_dbt_v1.8.6.yml
+++ b/.github/workflows/tuva_internal_dbt_v1.8.6.yml
@@ -151,8 +151,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -349,6 +347,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
+
       # Changed to compile to save processing time
       - name: dbt-compile
         run: |
@@ -424,7 +423,7 @@ jobs:
       # Changed to compile to save processing time
       - name: dbt-compile
         run: |
-          dbt build --full-refresh --profiles-dir ./profiles/snowflake --vars '{"input_database":"dev_ci_testing","input_schema":"input_layer","clinical_enabled":true}'
+          dbt compile --profiles-dir ./profiles/snowflake --vars '{"input_database":"dev_ci_testing","input_schema":"input_layer","clinical_enabled":true}'
         working-directory: ci_testing
 
       - name: Get the result
@@ -456,6 +455,7 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
+
       # Changed to compile to save processing time
       - name: dbt-compile
         run: |


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

* cleaned up some formatting 
* change redshift steps to dbt compile instead of build 

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
