### PR TITLE
Fix join clause in `data_quality__encounters_cost_and_utilization`

### DIFF
--- a/models/data_quality/intermediate/data_quality__encounters_cost_and_utilization.sql
+++ b/models/data_quality/intermediate/data_quality__encounters_cost_and_utilization.sql
@@ -3,8 +3,8 @@
 )}}
 
 with member_months as (
-    select 
-        cast(count(1) as {{ dbt.type_numeric() }}) as member_months 
+    select
+        cast(count(1) as {{ dbt.type_numeric() }}) as member_months
     from {{ ref('core__member_months') }}
 )
 ,pkpy as (
@@ -13,7 +13,7 @@ select
     , enc.encounter_group
     , cast(enc.encounter_type as {{dbt.type_string()}}) as analytics_measure
     , case when avg(mm.member_months) = 0 then 0
-           else count(enc.encounter_id)  / avg(mm.member_months ) * 12000 
+           else count(enc.encounter_id)  / avg(mm.member_months ) * 12000
       end as data_source_value
 from {{ ref('core__encounter') }} as enc
 cross join member_months as mm
@@ -27,7 +27,7 @@ select
     , enc.encounter_group
     , cast(enc.encounter_type as {{dbt.type_string()}}) as analytics_measure
     , case when count(enc.encounter_id) = 0 then 0
-           else sum(enc.paid_amount) / count(enc.encounter_id) 
+           else sum(enc.paid_amount) / count(enc.encounter_id)
       end as data_source_value
 from {{ ref('core__encounter') }} as enc
 cross join member_months as mm
@@ -48,4 +48,4 @@ select
     ,ref_data.analytics_value
     ,cast('{{ var('tuva_last_run')}}' as {{dbt.type_string()}}) as tuva_last_run
 from paid_per
-left join {{ ref('data_quality__reference_mart_analytics') }} ref_data on paid_per.analytics_concept = paid_per.analytics_concept and paid_per.analytics_measure = paid_per.analytics_measure
+left join {{ ref('data_quality__reference_mart_analytics') }} ref_data on paid_per.analytics_concept = ref_data.analytics_concept and paid_per.analytics_measure = ref_data.analytics_measure


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
Updates join clause in `data_quality__encounters_cost_and_utilization.sql` to use `ref_data` on right side of join.  


## How has this been tested?
Ran with `enable_legacy_data_quality = True`.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
