### PR TITLE
Provider attribution have patient id when disabled.

### DIFF
--- a/models/input_layer/input_layer__provider_attribution.sql
+++ b/models/input_layer/input_layer__provider_attribution.sql
@@ -13,7 +13,8 @@ from {{ ref('provider_attribution') }}
 
 {% if target.type == 'fabric' %}
 select top 0
-      cast(null as {{ dbt.type_string() }} ) person_id
+      cast(null as {{ dbt.type_string() }} ) as person_id
+    , cast(null as {{ dbt.type_string() }} ) as patient_id
     , cast(null as {{ dbt.type_string() }} ) as year_month
     , cast(null as {{ dbt.type_string() }} ) as payer
     , cast(null as {{ dbt.type_string() }} ) as {{ quote_column('plan') }}
@@ -29,7 +30,8 @@ select top 0
     , cast(null as {{ dbt.type_string() }} ) as tuva_last_run
 {% else %}
 select
-      cast(null as {{ dbt.type_string() }} ) person_id
+      cast(null as {{ dbt.type_string() }} ) as person_id
+    , cast(null as {{ dbt.type_string() }} ) as patient_id
     , cast(null as {{ dbt.type_string() }} ) as year_month
     , cast(null as {{ dbt.type_string() }} ) as payer
     , cast(null as {{ dbt.type_string() }} ) as {{ quote_column('plan') }}


### PR DESCRIPTION
https://thetuvaproject.slack.com/archives/C03DET9ETK3/p1746831452558529

## Describe your changes
Please include a summary of any changes.
Tuva demo project has patient_id in the columns of the provider attribution model. When disabled, should match columns expected.


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [NA] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`
