### PR TITLE
Terminology Update: Provider and Other Provider Taxonomy - May 2025

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -151,7 +151,7 @@ seeds:
       terminology__nitos:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.11','nitos.csv',compression=true,null_marker=true) }}"
       terminology__other_provider_taxonomy:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.14.11','other_provider_taxonomy.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.14.12','other_provider_taxonomy.csv',compression=true,null_marker=true) }}"
       terminology__payer_type:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.11','payer_type.csv',compression=true,null_marker=true) }}"
       terminology__place_of_service:
@@ -159,7 +159,7 @@ seeds:
       terminology__present_on_admission:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.11','present_on_admission.csv',compression=true,null_marker=true) }}"
       terminology__provider:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.14.11','provider.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.14.12','provider.csv',compression=true,null_marker=true) }}"
       terminology__race:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.11','race.csv',compression=true,null_marker=true) }}"
       terminology__revenue_center:


### PR DESCRIPTION
## Describe your changes
NPPES May data has been processed and seeds have been unloaded to S3.

## How has this been tested?
Ran `dbt seed`


## Reviewer focus
Please sync new seed before merging this PR from `s3://tuva-public-resources-snowflake/versioned_provider_data/` to `s3://tuva-public-resources/versioned_provider_data/0.14.12/` and kickoff CI tests.

@sarah-tuva 

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
