### PR TITLE
Regex for icd-10-cd modes now includes special code sets

### DIFF
--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -859,7 +859,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs', 'dqi_ed_classification', 'dqi_readmission']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -880,7 +880,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -901,7 +901,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -922,7 +922,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -943,7 +943,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -964,7 +964,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -985,7 +985,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1006,7 +1006,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1027,7 +1027,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1048,7 +1048,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1069,7 +1069,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1090,7 +1090,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1111,7 +1111,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1132,7 +1132,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1153,7 +1153,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1174,7 +1174,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1195,7 +1195,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1216,7 +1216,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1237,7 +1237,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1258,7 +1258,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1279,7 +1279,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1300,7 +1300,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1321,7 +1321,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1342,7 +1342,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]
@@ -1363,7 +1363,7 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex_list:
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ccsr', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs']
-              regex_list: ["^[A-TV-Z][0-9A-Z]{2,7}$", "^[A-TV-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
+              regex_list: ["^[A-Z][0-9A-Z]{2,7}$", "^[A-Z][0-9]{1,2}[.][0-9A-Z]{1,7}$",
                 "^[0-9]{3}([.][0-9]{1,2})?$", "^[0-9]{3,5}$", "^[VE][0-9]{3}([.][0-9]{1})?$",
                 "^[VE][0-9]{2,4}$"                    # ICD-9 V/E codes without period
 ]


### PR DESCRIPTION
## Describe your changes
icd-10-code validation now includes codes for special purposes.


## How has this been tested?
Regex now does not exclude the letter U

## Reviewer focus
Regex and if CI is passing


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
