### PR TITLE
Update test to accept case where there are 0 bill type codes over a claim ID

### DIFF
--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -455,7 +455,7 @@ models:
         tests:
           - dbt_expectations.expect_column_unique_value_count_to_be_between:
 # description: A claim should not have multiple bill type codes within the same claim id.
-              min_value: 1
+              min_value: 0
               max_value: 1
               tags: ['tuva_dqi_sev_1', 'dqi', 'dqi_cms_chronic_conditions']
               group_by: [claim_id]


### PR DESCRIPTION
## Describe your changes
Accept case where there are 0 bill type codes over claim ID. This would happen when there is no bill type code in the source data

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
CI and test update


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [NA] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [NA] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
