### PR TITLE
Updating multiple values tests to have a floor of 0 as not null tests should check for nulls

### DIFF
--- a/models/input_layer/input_layer__eligibility.yml
+++ b/models/input_layer/input_layer__eligibility.yml
@@ -122,7 +122,7 @@ models:
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_unique_value_count_to_be_between:
 # description: A person should not have multiple birthdays.
-              min_value: 1
+              min_value: 0
               max_value: 1
               tags: ['tuva_dqi_sev_3', 'dqi', 'dqi_cms_hccs']
               group_by: [person_id]

--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -82,7 +82,7 @@ models:
         tests:
           - dbt_expectations.expect_column_unique_value_count_to_be_between:
 # description: A claim cannot be both professional and institutional within the same claim id.
-              min_value: 1
+              min_value: 0
               max_value: 1
               tags: ['tuva_dqi_sev_1', 'dqi', 'dqi_service_categories', 'dqi_ccsr',
                 'dqi_cms_chronic_conditions', 'dqi_tuva_chronic_conditions', 'dqi_cms_hccs',
@@ -170,7 +170,7 @@ models:
         tests:
           - dbt_expectations.expect_column_unique_value_count_to_be_between:
 # description: A claim should not have multiple start dates within the same claim id.
-              min_value: 1
+              min_value: 0
               max_value: 1
               tags: ['tuva_dqi_sev_3', 'dqi', 'dqi_cms_chronic_conditions', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs', 'dqi_ed_classification', 'dqi_financial_pmpm', 'dqi_quality_measures',
@@ -224,7 +224,7 @@ models:
         tests:
           - dbt_expectations.expect_column_unique_value_count_to_be_between:
 # description: A claim should not have multiple end dates within the same claim id.
-              min_value: 1
+              min_value: 0
               max_value: 1
               tags: ['tuva_dqi_sev_1', 'dqi', 'dqi_cms_chronic_conditions', 'dqi_tuva_chronic_conditions',
                 'dqi_cms_hccs', 'dqi_ed_classification', 'dqi_financial_pmpm', 'dqi_quality_measures',


### PR DESCRIPTION
Error message when values are null is confusing, as really interested in value being greater than 1.

Not interested in values <1 as those should error on null tests

## Describe your changes
Updated tests to have a floor of 0 instead of 1

## How has this been tested?
Ran on local


## Reviewer focus
small change


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output