### PR TITLE
Bug 872, backfilling payer and plan with empty string

### DIFF
--- a/models/input_layer/input_layer__eligibility.sql
+++ b/models/input_layer/input_layer__eligibility.sql
@@ -3,7 +3,7 @@
  | as_bool
    )
 }}
-SELECT e.person_id
+select e.person_id
      , e.member_id
      , e.subscriber_id
      , e.gender

--- a/models/input_layer/input_layer__eligibility.sql
+++ b/models/input_layer/input_layer__eligibility.sql
@@ -3,5 +3,35 @@
  | as_bool
    )
 }}
-select *
-from {{ ref('eligibility') }}
+SELECT e.person_id
+     , e.member_id
+     , e.subscriber_id
+     , e.gender
+     , e.race
+     , e.birth_date
+     , e.death_date
+     , e.death_flag
+     , e.enrollment_start_date
+     , e.enrollment_end_date
+     , COALESCE(e.payer, '') as payer
+     , e.payer_type
+     , COALESCE({{ quote_column('plan') }}, '') as {{ quote_column('plan') }}
+     , e.original_reason_entitlement_code
+     , e.dual_status_code
+     , e.medicare_status_code
+     , e.group_id
+     , e.group_name
+     , e.first_name
+     , e.last_name
+     , e.social_security_number
+     , e.subscriber_relation
+     , e.address
+     , e.city
+     , e.state
+     , e.zip_code
+     , e.phone
+     , e.data_source
+     , e.file_name
+     , e.file_date
+     , e.ingest_datetime
+from {{ ref('eligibility') }} as e


### PR DESCRIPTION
## Describe your changes
* `normalized_input__stg_eligibility` already expects these columns, so should not be breaking
* Coalescing with empty string as this will allow the joins to be addressed in this issue


## How has this been tested?
* Will wait for the CIs to run

## Reviewer focus
* Small PR


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
