### PR TITLE
Add duckdb support to create_json_object macro

### DIFF
--- a/macros/cross_database_utils/create_json_object.sql
+++ b/macros/cross_database_utils/create_json_object.sql
@@ -43,7 +43,7 @@
 
 /* default */
 {% macro default__create_json_object(table_ref, group_by_col, object_col_name, object_col_list) %}
-  {{ exceptions.raise_compiler_error("The macro create_json_object is not implemented for this adapter.") }}
+  {{ exceptions.warn("The macro create_json_object is not implemented for this adapter.") }}
 {% endmacro %}
 
 /* snowflake */
@@ -115,7 +115,6 @@ from (
 group by {{ group_by_col }}
 {% endmacro %}
 
-
 /* fabric */
 {% macro fabric__create_json_object(table_ref, group_by_col, object_col_name, object_col_list) %}
 select
@@ -135,6 +134,29 @@ select
             + '}'
         AS VARCHAR(MAX)), ','
     ) + ']' AS {{ object_col_name }}
+from {{ table_ref }}
+group by {{ group_by_col }}
+{% endmacro %}
+
+/* duckdb */
+{% macro duckdb__create_json_object(table_ref, group_by_col, object_col_name, object_col_list) %}
+select
+    {{ group_by_col }}
+    , to_json(
+        list(
+            {
+                {%- for col in object_col_list %}
+                {% if not loop.first %}, {% endif -%}
+                '{{ the_tuva_project.snake_to_camel(col) }}':
+                {%- if 'list' in col | lower -%}
+                {{ col }}::JSON /* Cast to JSON to handle lists properly */
+                {%- else -%}
+                {{ col }}
+                {%- endif -%}
+                {%- endfor %}
+            }
+        )
+    ) as {{ object_col_name }}
 from {{ table_ref }}
 group by {{ group_by_col }}
 {% endmacro %}


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

* Adds duckdb logic to create_json_object macro
* Changes default macro to warn instead of compiler error

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

@davidshimamoto tested locally.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2lpMXEzdHp4am5udnQwemNxMTE2azd0YnZtYzV6MjBneXBlbHduaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/DtJAgycIRLK80/giphy.gif)


## Loom link
