### PR TITLE
Make sure we only get ICD-10-PCS codes in CCSR long procedure category

### DIFF
--- a/models/ccsr/final/ccsr__long_procedure_category.sql
+++ b/models/ccsr/final/ccsr__long_procedure_category.sql
@@ -33,5 +33,5 @@ select distinct
     , {{ var('prccsr_version') }} as prccsr_version
     , '{{ var('tuva_last_run') }}' as tuva_last_run
 from procedures
-left outer join ccsr__procedure_category_map
+inner join ccsr__procedure_category_map
     on procedures.normalized_code = ccsr__procedure_category_map.code


### PR DESCRIPTION
## Describe your changes
Previously we were allowing non ICD-10-PCS codes through to `long_procedure_category`. This PR makes sure we do not allow these codes to flow through. closes #856 


## How has this been tested?
ran locally. this query returns no rows
```sql
select
from ccsr.long_procedure_category
where ccsr_category is null
and normalized_code is not null
limit 10
```


## Reviewer focus
Sanity check on join change


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
