### PR TITLE
Fix uniqueness check on input_layer__eligibility to include member_id

### DIFF
--- a/models/input_layer/input_layer__eligibility.yml
+++ b/models/input_layer/input_layer__eligibility.yml
@@ -12,6 +12,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - person_id
+            - member_id
             - enrollment_start_date
             - enrollment_end_date
             - "{{ '\"plan\"' if (target.type == 'fabric') else 'plan' }}"


### PR DESCRIPTION
## Describe your changes
The uniqueness check on input_layer__eligibility should include `member_id` to accomodate people who qualify for a plan under two memberships.


## How has this been tested?
Run `dbt test` on the project with the test data.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
