### PR TITLE
Add member_id to the member_months_key grain

### DIFF
--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
@@ -31,6 +31,7 @@ select distinct
   dense_rank() over (
     order by
       a.person_id
+    , a.member_id
     , b.year_month
     , a.payer
     , a.{{ quote_column('plan') }}


### PR DESCRIPTION
## Describe your changes
Updated member_months to include member_id in the creation of the member_months_key


## How has this been tested?
 dbt run -s claims_enrollment__member_months
Verified the change in key values


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
