### PR TITLE
Bugfix member months grain

### DIFF
--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
@@ -14,7 +14,7 @@ with stg_eligibility as (
     , min(enrollment_start_date) as min_enrollment_start_date
     , max(enrollment_end_date) as max_enrollment_end_date
   from {{ ref('normalized_input__eligibility') }} as elig
-  group by 
+  group by
     person_id
     , payer
     , {{ quote_column('plan') }}
@@ -30,7 +30,8 @@ with stg_eligibility as (
   from {{ ref('reference_data__calendar') }}
   group by year, month, year_month
 )
-select 
+
+select
   -- Generate a unique key for each member month
   dense_rank() over (
     order by
@@ -43,7 +44,7 @@ select
   , a.person_id
   -- As a temporary fix, we are nulling out member_id to get to the grain we want. 
   -- In a future release we will remove this field.
-  , cast(null as {{ dbt.type_string() }}) as member_id 
+  , cast(null as {{ dbt.type_string() }}) as member_id
   , b.year_month
   , a.payer
   , a.{{ quote_column('plan') }}


### PR DESCRIPTION
## Describe your changes
`member_months`  breaks when a person with multiple plan memberships is fed into the input layer eligibility file. Because `member_id` is part of the model, this results in multiple rows per `person_id`.  To fix this, I nulled out `member_id`, and applied an aggregate to the eligibility data as it's staged for member months to get it to the correct grain.


## How has this been tested?
Ran the model with synthetic data that simulates the problem. 


## Reviewer focus
Note that `tuva_last_run` has been omitted, but this field is not used anywhere, so it was not needed.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
