### PR TITLE
Bill type code multiple not sev 1

### DIFF
--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -457,7 +457,7 @@ models:
 # description: A claim should not have multiple bill type codes within the same claim id.
               min_value: 0
               max_value: 1
-              tags: ['tuva_dqi_sev_1', 'dqi', 'dqi_cms_chronic_conditions']
+              tags: ['tuva_dqi_sev_4', 'dqi', 'dqi_cms_chronic_conditions']
               group_by: [claim_id]
               strictly: false
               config:


### PR DESCRIPTION
Multiple bill type codes in claim should not be a severity 1 dqi issue. This is taken care of in normalization layer.