### PR TITLE
Change line level claim date to header level

### DIFF
--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__flag_claims_with_enrollment.sql
@@ -14,11 +14,11 @@ with claim_dates as (
         , payer
         , {{ quote_column('plan') }}
         , data_source
-        , coalesce(claim_line_start_date, claim_start_date, admission_date) as inferred_claim_start_date
+        , coalesce(claim_start_date, admission_date, claim_line_start_date) as inferred_claim_start_date
         , case
-            when claim_line_start_date is not null then 'claim_line_start_date'
-            when claim_line_start_date is null and claim_start_date is not null then 'claim_start_date'
-            when claim_line_start_date is null and claim_start_date is null and admission_date is not null then 'admission_date'
+            when claim_start_date is not null then 'claim_start_date'
+            when claim_start_date is null and admission_date is not null then 'admission_date'
+            when claim_start_date is null and admission_date is null and claim_line_start_date is not null then 'claim_line_start_date'
         end as inferred_claim_start_column_used
     from {{ ref('normalized_input__medical_claim') }}
 )


### PR DESCRIPTION
## Describe your changes

This PR resolves https://github.com/tuva-health/tuva/issues/913

- Updated the logic in `claims_enrollment__flag_claims_with_enrollment.sql` to prioritize claim header dates for determining member eligibility.

    The new date hierarchy for `inferred_claim_start_date` is:
  

    1. claim_start_date (claim header)
    2. admission_date (if claim_start_date is null)
    3. claim_line_start_date (only if both above are null)

- Updated the `inferred_claim_start_column_used` field to reflect this new hierarchy.

This change ensures that enrollment flagging and all downstream calculations are based on the claim header date.

## How has this been tested?
Ran `dbt build` for Snowflake, BigQuery, Redshift and Fabric


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
