### PR TITLE
932 if encounters between claims and clinical datasets overlap ie adt both encounter get thrown out in readmissions

### DIFF
--- a/models/readmissions/intermediate/readmissions__encounter.sql
+++ b/models/readmissions/intermediate/readmissions__encounter.sql
@@ -18,6 +18,6 @@ select
     , cast(drg_code as {{ dbt.type_string() }}) as drg_code
     , cast(paid_amount as {{ dbt.type_numeric() }}) as paid_amount
     , cast(primary_diagnosis_code as {{ dbt.type_string() }}) as primary_diagnosis_code
-    , cast(encounter_source_type as {{ dbt.type_string() }})
+    , cast(encounter_source_type as {{ dbt.type_string() }}) as encounter_source_type
     , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('readmissions__stg_core__encounter') }}

--- a/models/readmissions/intermediate/readmissions__encounter.sql
+++ b/models/readmissions/intermediate/readmissions__encounter.sql
@@ -18,5 +18,6 @@ select
     , cast(drg_code as {{ dbt.type_string() }}) as drg_code
     , cast(paid_amount as {{ dbt.type_numeric() }}) as paid_amount
     , cast(primary_diagnosis_code as {{ dbt.type_string() }}) as primary_diagnosis_code
+    , cast(encounter_source_type as {{ dbt.type_string() }})
     , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('readmissions__stg_core__encounter') }}

--- a/models/readmissions/intermediate/readmissions__encounter_data_quality.sql
+++ b/models/readmissions/intermediate/readmissions__encounter_data_quality.sql
@@ -54,12 +54,9 @@ select
 	else 0
     end as no_diagnosis_ccs_flag
     , aa.ccs_diagnosis_category as diagnosis_ccs
-    , case
-        when aa.encounter_id in (select distinct encounter_id_a
-	                         from {{ ref('readmissions__encounter_overlap') }})
-	     or
-	     aa.encounter_id in (select distinct encounter_id_b
-	                         from {{ ref('readmissions__encounter_overlap') }})
+    , case /* WHEN ENCOUNTER IS NOT THE BEST, THEN FLAG THIS ERROR. */
+        when exists (select 1 from {{ ref('readmissions__encounter_overlap') }} as overlap
+                              where aa.encounter_id = overlap.encounter_id and overlap.is_best_encounter = 0)
 	then 1
 	else 0
     end as overlaps_with_another_encounter_flag

--- a/models/readmissions/intermediate/readmissions__encounter_overlap.sql
+++ b/models/readmissions/intermediate/readmissions__encounter_overlap.sql
@@ -3,55 +3,116 @@
    )
 }}
 
--- Here we give a list of all pairs of encounters
--- that have some date overlap.
 
+with encounter_enhanced as (
+  select
+    *
+    -- Calculate actual length of stay in days
+    , COALESCE(
+      case
+        when encounter_end_date >= encounter_start_date
+        then encounter_end_date - encounter_start_date + 1
+        else 1
+      end
+      , 1
+    ) as actual_length_of_stay
 
-with encounters_with_row_num as (
-select
-    encounter_id
-    , person_id
-    , admit_date
-    , discharge_date
-    , row_number() over (
-        partition by person_id
-order by encounter_id
-	) as row_num
-from {{ ref('readmissions__encounter') }}
-)
-
-
-, cartesian as (
-select
-    aa.encounter_id as encounter_id_a
-    , bb.encounter_id as encounter_id_b
-    , aa.person_id
-    , aa.admit_date as ai
-    , aa.discharge_date as af
-    , bb.admit_date as bi
-    , bb.discharge_date as bf
+    -- Source type priority (lower number = higher priority)
     , case
-        when (aa.admit_date between bb.admit_date and bb.discharge_date) or (aa.discharge_date between bb.admit_date and bb.discharge_date) or
-             (bb.admit_date between aa.admit_date and aa.discharge_date) or (bb.discharge_date between aa.admit_date and aa.discharge_date)
-        then 1
-        else 0
-    end as overlap
-    from encounters_with_row_num as aa
-    left outer join encounters_with_row_num as bb
-    on aa.person_id = bb.person_id and aa.row_num < bb.row_num
+      when UPPER(TRIM(COALESCE(encounter_source_type, ''))) = 'CLAIM' then 1
+      else 2
+    end as source_type_priority
+
+    -- Data completeness score (count of complete fields, higher = better)
+    , (case when discharge_disposition_code is not null
+          and TRIM(discharge_disposition_code) != ''
+          and TRIM(discharge_disposition_code) != '00' then 1 else 0 end) +
+    (case when drg_code_type is not null
+          and TRIM(drg_code_type) != '' then 1 else 0 end) +
+    (case when drg_code is not null
+          and TRIM(drg_code) != ''
+          and TRIM(drg_code) not in ('998', '999') then 1 else 0 end) +
+    (case when paid_amount is not null then 1 else 0 end) +
+    (case when primary_diagnosis_code is not null
+          and TRIM(primary_diagnosis_code) != '' then 1 else 0 end) as completeness_score
+  from {{ ref('readmissions__encounter') }}
+)
+
+-- Identify all encounters that have overlapping dates with other encounters for the same person
+, overlapping_encounters as (
+  select distinct
+    e1.encounter_id
+    , e1.person_id
+    , e1.encounter_start_date
+    , e1.encounter_end_date
+  from encounter_enhanced as e1
+  where exists (
+    select 1
+    from encounter_enhanced as e2
+    where e1.person_id = e2.person_id
+      and e1.encounter_id != e2.encounter_id
+      and e1.encounter_start_date <= e2.encounter_end_date
+      and e1.encounter_end_date >= e2.encounter_start_date
+  )
+)
+
+-- Create overlap groups by assigning a group identifier
+, overlap_groups as (
+  select
+    e1.encounter_id
+    , e1.person_id
+    , MIN(e2.encounter_id) over (
+      partition by e1.person_id, e1.encounter_id
+    ) as overlap_group_id
+  from overlapping_encounters as e1
+  inner join overlapping_encounters as e2
+    on e1.person_id = e2.person_id
+    and e1.encounter_start_date <= e2.encounter_end_date
+    and e1.encounter_end_date >= e2.encounter_start_date
+)
+
+-- Rank encounters within each overlap group
+, encounter_rankings as (
+  select
+    e.*
+    , COALESCE(og.overlap_group_id, e.encounter_id) as overlap_group_id
+    , case when og.encounter_id is not null then 1 else 0 end as has_overlaps
+    , ROW_NUMBER() over (
+      partition by e.person_id, COALESCE(og.overlap_group_id, e.encounter_id)
+      order by
+        e.source_type_priority asc        -- prefer 'claim' source type
+        , e.actual_length_of_stay desc      -- prefer longer date spans
+        , e.completeness_score desc         -- prefer more complete data
+        , e.encounter_id asc                 -- Consistent tie-breaker
+    ) as encounter_rank_in_group
+  from encounter_enhanced as e
+  left outer join overlap_groups as og
+    on e.encounter_id = og.encounter_id
+    and e.person_id = og.person_id
 )
 
 
-, overlapping_pairs as (
-    select
-        person_id
-        , encounter_id_a
-	, encounter_id_b
-    from cartesian
-    where overlap = 1
-)
+select
+  encounter_id
+  , person_id
+  , encounter_type
+  , encounter_start_date
+  , encounter_end_date
+  , actual_length_of_stay
+  , source_type_priority
+  , completeness_score
+  , overlap_group_id
+  , has_overlaps
+  , encounter_rank_in_group
+  , case
+    when encounter_rank_in_group = 1 then 1
+    else 0
+  end as is_best_encounter
 
+  , case
+    when encounter_rank_in_group = 1 and has_overlaps = 1 then 'Selected as best among overlapping encounters'
+    when encounter_rank_in_group = 1 and has_overlaps = 0 then 'No overlapping encounters'
+    else 'Not selected - better encounter exists'
+  end as selection_reason
 
-
-select *, '{{ var('tuva_last_run') }}' as tuva_last_run
-from overlapping_pairs
+from encounter_rankings

--- a/models/readmissions/intermediate/readmissions__encounter_overlap.sql
+++ b/models/readmissions/intermediate/readmissions__encounter_overlap.sql
@@ -10,8 +10,8 @@ with encounter_enhanced as (
     -- Calculate actual length of stay in days
     , COALESCE(
       case
-        when encounter_end_date >= encounter_start_date
-        then encounter_end_date - encounter_start_date + 1
+        when discharge_date >= admit_date
+        then discharge_date - admit_date + 1
         else 1
       end
       , 1
@@ -43,16 +43,16 @@ with encounter_enhanced as (
   select distinct
     e1.encounter_id
     , e1.person_id
-    , e1.encounter_start_date
-    , e1.encounter_end_date
+    , e1.admit_date
+    , e1.discharge_date
   from encounter_enhanced as e1
   where exists (
     select 1
     from encounter_enhanced as e2
     where e1.person_id = e2.person_id
       and e1.encounter_id != e2.encounter_id
-      and e1.encounter_start_date <= e2.encounter_end_date
-      and e1.encounter_end_date >= e2.encounter_start_date
+      and e1.admit_date <= e2.discharge_date
+      and e1.discharge_date >= e2.admit_date
   )
 )
 
@@ -67,8 +67,8 @@ with encounter_enhanced as (
   from overlapping_encounters as e1
   inner join overlapping_encounters as e2
     on e1.person_id = e2.person_id
-    and e1.encounter_start_date <= e2.encounter_end_date
-    and e1.encounter_end_date >= e2.encounter_start_date
+    and e1.admit_date <= e2.discharge_date
+    and e1.discharge_date >= e2.admit_date
 )
 
 -- Rank encounters within each overlap group
@@ -96,8 +96,8 @@ select
   encounter_id
   , person_id
   , encounter_type
-  , encounter_start_date
-  , encounter_end_date
+  , admit_date
+  , discharge_date
   , actual_length_of_stay
   , source_type_priority
   , completeness_score

--- a/models/readmissions/intermediate/readmissions__encounter_overlap.sql
+++ b/models/readmissions/intermediate/readmissions__encounter_overlap.sql
@@ -95,7 +95,6 @@ with encounter_enhanced as (
 select
   encounter_id
   , person_id
-  , encounter_type
   , admit_date
   , discharge_date
   , actual_length_of_stay

--- a/models/readmissions/intermediate/readmissions__encounter_overlap.sql
+++ b/models/readmissions/intermediate/readmissions__encounter_overlap.sql
@@ -7,12 +7,10 @@
 with encounter_enhanced as (
   select
     *
-    -- Calculate actual length of stay in days
     , COALESCE(
       case
-        when discharge_date >= admit_date
-        then discharge_date - admit_date + 1
-        else 1
+        when {{ dbt.datediff("discharge_date", "admit_date","day") }} >= 1
+        then {{ dbt.datediff("discharge_date", "admit_date","day") }}
       end
       , 1
     ) as actual_length_of_stay

--- a/models/readmissions/intermediate/readmissions__encounter_overlap.sql
+++ b/models/readmissions/intermediate/readmissions__encounter_overlap.sql
@@ -58,7 +58,7 @@ with encounter_enhanced as (
 
 -- Create overlap groups by assigning a group identifier
 , overlap_groups as (
-  select
+  select distinct /* distinct here to prevent fan out for >2 overlapping encounters. */
     e1.encounter_id
     , e1.person_id
     , MIN(e2.encounter_id) over (

--- a/models/readmissions/intermediate/readmissions__readmission_crude.sql
+++ b/models/readmissions/intermediate/readmissions__readmission_crude.sql
@@ -16,19 +16,15 @@ select
     , enc.admit_date
     , enc.discharge_date
 from {{ ref('readmissions__encounter') }} as enc
-left outer join {{ ref('readmissions__encounter_overlap') }} as over_a
-    on enc.encounter_id = over_a.encounter_id_a
-left outer join {{ ref('readmissions__encounter_overlap') }} as over_b
-    on enc.encounter_id = over_b.encounter_id_b
 where
     admit_date is not null
     and
     discharge_date is not null
     and
     admit_date <= discharge_date
-and over_a.encounter_id_a is null and over_b.encounter_id_b is null
+and not exists (select 1 from {{ ref('readmissions__encounter_overlap') }} as overlap
+                         where overlap.encounter_id = enc.encounter_id and overlap.is_best_encounter = 0)
     )
-
 
 , encounter_sequence as (
 select

--- a/models/readmissions/readmissions_models.yml
+++ b/models/readmissions/readmissions_models.yml
@@ -265,14 +265,14 @@ models:
       alias: _int_encounter_overlap
       tags: readmissions
       materialized: view
-    description: "This model lists all pairs of encounters that have some date overlap."
+    description: "This model lists and labels encounters that overlap to identify the best one out of the group."
     columns:
       - name: person_id
         description: "The unique identifier for the patient"
-      - name: encounter_id_A
-        description: "Unique identifier for one of the overlapping encounters"
-      - name: encounter_id_B
-        description: "Unique identifier for the other overlapping encounter"
+      - name: is_best_encounter
+        description: "Flag that identifies the best encounter that has overlapping dates between encounters for the same patient."
+      - name: selection_reason
+        description: "Reason why or why not a particular encounter is selected as best for overlapping dates"
 
   - name: readmissions__encounter_specialty_cohort
     config:

--- a/models/readmissions/staging/readmissions__stg_core__encounter.sql
+++ b/models/readmissions/staging/readmissions__stg_core__encounter.sql
@@ -14,6 +14,7 @@ select
     , drg_code
     , paid_amount
     , primary_diagnosis_code
+    , encounter_source_type
     , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('core__encounter') }}
 where encounter_type = 'acute inpatient'


### PR DESCRIPTION
## Describe your changes
In readmission mart, if clinical and claim data were brought together, all clinical data that overlapped with adt / encounter events would get 0'd out by readmissions logic to exclude any and all overlapping encounter. new logic introduced to take claims data over clinical data, and not use the clinical data as a reason to exclude the claims data. This involved updating the overlapping dates logic.

## How has this been tested?
Tested on local walking through specific patient examples.

## Reviewer focus
Focus on logic for flagging and overlapping claims in `readmissions__encounter_overlap.sql`. Go through patient count examples in synthetic data.

## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output