### PR TITLE
Minor syntax update for date casting for dbt 1.6.3 support

### DIFF
--- a/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__generate_encounter_id.sql
+++ b/models/claims_preprocessing/encounters/intermediate/ambulatory_surgery_center/asc__generate_encounter_id.sql
@@ -30,7 +30,7 @@ with base_data as (
     select
         gd.*
       , case
-            when start_date > coalesce(previous_max_end_date, {{ dbt.cast("'1900-01-01'", api.Column.translate_type('date')) }} ) then 1
+            when start_date > coalesce(previous_max_end_date, cast('1900-01-01' as date)) then 1
             else 0
         end as new_group_flag
     from grouped_data as gd


### PR DESCRIPTION
## Describe your changes

Updated date casting logic to more adapted format in Tuva package.
This enables Github Action run error free in demo repo and solves https://github.com/tuva-health/demo/issues/53

## How has this been tested?
Ran `dbt build -s asc__generate_encounter_id` in snowflake, bigquery and redshift

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
