### PR TITLE
Add testing to check for overlap between medical claim / pharmacy claim and eligibility

### DIFF
--- a/tests/medical_claim_eligibility_overlap_check.sql
+++ b/tests/medical_claim_eligibility_overlap_check.sql
@@ -1,0 +1,50 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool,
+     tags = ['dqi', 'tuva_dqi_sev_2']
+   )
+}}
+
+with eligibility as (
+    select
+        person_id
+        , member_id
+        , enrollment_start_date
+        , enrollment_end_date
+        , payer
+        , {{ quote_column('plan') }}
+        , data_source
+    from {{ ref('input_layer__eligibility') }}
+),
+
+medical_claims as (
+    select
+        person_id
+        , member_id
+        , payer
+        , {{ quote_column('plan') }}
+        , data_source
+        , coalesce(claim_start_date, admission_date, claim_line_start_date) 
+            as inferred_claim_start_date
+    from {{ ref('input_layer__medical_claim') }}
+),
+
+final as (
+    select  
+        m.data_source
+        , count(*) as n_overlapping_rows
+    from medical_claims as m
+    inner join eligibility as e
+    on m.person_id = e.person_id
+    and m.member_id = e.member_id
+    and m.payer = e.payer
+    and m.{{ quote_column('plan') }} = e.{{ quote_column('plan') }}
+    and m.inferred_claim_start_date between e.enrollment_start_date and e.enrollment_end_date
+    group by m.data_source
+)
+
+select 
+    data_source
+    , n_overlapping_rows
+from final
+where n_overlapping_rows < 1

--- a/tests/pharmacy_claim_eligibility_overlap_check.sql
+++ b/tests/pharmacy_claim_eligibility_overlap_check.sql
@@ -1,0 +1,49 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool,
+     tags = ['dqi', 'tuva_dqi_sev_2']
+   )
+}}
+
+with eligibility as (
+    select
+        person_id
+        , member_id
+        , enrollment_start_date
+        , enrollment_end_date
+        , payer
+        , {{ quote_column('plan') }}
+        , data_source
+    from {{ ref('input_layer__eligibility') }}
+),
+
+pharmacy_claims as (
+    select
+        person_id
+        , member_id
+        , payer
+        , {{ quote_column('plan') }}
+        , data_source
+        , dispensing_date
+    from {{ ref('input_layer__pharmacy_claim') }}
+),
+
+final as (
+    select  
+        p.data_source
+        , count(*) as n_overlapping_rows
+    from pharmacy_claims as p
+    inner join eligibility as e
+    on p.person_id = e.person_id
+    and p.member_id = e.member_id
+    and p.payer = e.payer
+    and p.{{ quote_column('plan') }} = e.{{ quote_column('plan') }}
+    and p.dispensing_date between e.enrollment_start_date and e.enrollment_end_date
+    group by p.data_source
+)
+
+select 
+    data_source
+    , n_overlapping_rows
+from final
+where n_overlapping_rows < 1


### PR DESCRIPTION
## Describe your changes
This PR adds two tests; one checks for overlap between medical claim and eligibility, and the other for overlap between pharmacy claim and eligibility. These tests are currently labeled DQI severity 2, and are meant to detect zero rows in any of eligibility, medical claim, or pharmacy claim, and/or a lack of overlap between either of the claims tables and eligibility (by data source).

## How has this been tested?
tested locally
```bash
dbt test --select medical_claim_eligibility_overlap_check pharmacy_claim_eligibility_overlap_check
```
## Reviewer focus
Approach, tagging for DQI, location of tests in `tests/` directory


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [x] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
