### PR TITLE
Add action to automate updating and publishing dbt docs 

### DIFF
--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -34,8 +34,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -60,20 +60,18 @@ jobs:
           dbt docs generate --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
 
-	  - name: Setup Pages
-		uses: actions/configure-pages@v4
-
-	  - name: Upload artifact
-		uses: actions/upload-pages-artifact@v3
-		with:
-		  path: './target'  # dbt generates docs in the target directory
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './target'  # dbt generates docs in the target directory
 
   deploy:
+    needs: generate-docs
+    runs-on: ubuntu-latest
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: generate-docs
 
     steps:
     - name: Deploy to GitHub Pages

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -46,7 +46,7 @@ env:
 
 jobs:
   generate-docs:
-    runs-on: ubuntu-latestdefaults:
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./ci_testing

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -1,25 +1,13 @@
 name: Generate and Deploy dbt Docs
 
 on:
-  release:
-    types: [published]  # Triggers when a release is published
   push:
-    branches: [ update-docs-workflow ]  # Test branch - remove after testing
-  workflow_dispatch:  # Allows manual triggering
-    inputs:
-      environment:
-        description: 'Environment (production/staging)'
-        required: false
-        default: 'production'
-        type: choice
-        options:
-        - production
-        - staging
-      force_deploy:
-        description: 'Force deployment even on pre-release'
-        required: false
-        default: false
-        type: boolean
+    branches:
+      - main
+    paths:
+      - '**.yml'
+      - '**.yaml'
+      - '**.sql'
 
 permissions:
   contents: read
@@ -118,17 +106,16 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './integration_tests/docs_generate/target'  # dbt generates docs in the target directory
+          path: './integration_tests/docs_generate/target'
 
   deploy:
     needs: generate-docs
     runs-on: ubuntu-latest
 
     environment:
-      name: ${{ github.event.release.prerelease && 'github-pages-staging' || 'github-pages' }}
+      name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    if: ${{ !github.event.release.prerelease || github.event.inputs.force_deploy == 'true' }}
     steps:
     - name: Deploy to GitHub Pages
       id: deployment

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./ci_testing
+        working-directory: ./integration_tests/docs_generate
 
     steps:
       - name: Checkout repository
@@ -81,7 +81,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './ci_testing/target'  # dbt generates docs in the target directory
+          path: './integration_tests/docs_generate/target'  # dbt generates docs in the target directory
 
   deploy:
     needs: generate-docs

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -33,7 +33,6 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.9'
-  LINT_SCRIPT_PATH: ./lint_tuva_project.sh
 
 #######  Secrets #######
 #######  Snowflake
@@ -47,7 +46,10 @@ env:
 
 jobs:
   generate-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latestdefaults:
+    defaults:
+      run:
+        working-directory: ./ci_testing
 
     steps:
       - name: Checkout repository
@@ -65,16 +67,13 @@ jobs:
 
       - name: dbt-deps
         run: dbt deps --profiles-dir ./profiles/snowflake
-        working-directory: ci_testing
 
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
-        working-directory: ci_testing
 
       - name: dbt-docs-generate
         run: |
           dbt docs generate --profiles-dir ./profiles/snowflake
-        working-directory: ci_testing
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -82,7 +81,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './target'  # dbt generates docs in the target directory
+          path: './ci_testing/target'  # dbt generates docs in the target directory
 
   deploy:
     needs: generate-docs

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -3,6 +3,8 @@ name: Generate and Deploy dbt Docs
 on:
   release:
     types: [published]  # Triggers when a release is published
+  push:
+    branches: [ update-docs-workflow ]  # Test branch - remove after testing
   workflow_dispatch:  # Allows manual triggering
     inputs:
       environment:

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -71,9 +71,11 @@ jobs:
       - name: dbt-debug
         run: dbt debug --profiles-dir ./profiles/snowflake
 
+      - name: dbt-build
+        run: dbt build --full-refresh --profiles-dir ./profiles/snowflake
+
       - name: dbt-docs-generate
-        run: |
-          dbt docs generate --profiles-dir ./profiles/snowflake
+        run: dbt docs generate --profiles-dir ./profiles/snowflake
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -4,6 +4,20 @@ on:
   release:
     types: [published]  # Triggers when a release is published
   workflow_dispatch:  # Allows manual triggering
+    inputs:
+      environment:
+        description: 'Environment (production/staging)'
+        required: false
+        default: 'production'
+        type: choice
+        options:
+        - production
+        - staging
+      force_deploy:
+        description: 'Force deployment even on pre-release'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -70,9 +84,10 @@ jobs:
     runs-on: ubuntu-latest
 
     environment:
-      name: github-pages
+      name: ${{ github.event.release.prerelease && 'github-pages-staging' || 'github-pages' }}
       url: ${{ steps.deployment.outputs.page_url }}
 
+    if: ${{ !github.event.release.prerelease || github.event.inputs.force_deploy == 'true' }}
     steps:
     - name: Deploy to GitHub Pages
       id: deployment

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -65,17 +65,37 @@ jobs:
           python -m pip install --upgrade pip
           pip install dbt-core==1.8.6 dbt-snowflake
 
+      # --- Setup dbt Profile ---
+      - name: Create dbt profiles directory
+        run: mkdir -p ~/.dbt
+
+      - name: Create dbt profiles.yml for Snowflake (for docs context)
+        run: |
+          echo "default:
+            outputs:
+              dev:
+                account: \"{{ env_var('DBT_TUVA_SNOWFLAKE_ACCOUNT') }}\"
+                database: dev_ci_testing
+                password: \"{{ env_var('DBT_SNOWFLAKE_CI_PASSWORD') }}\"
+                role: \"{{ env_var('DBT_SNOWFLAKE_CI_ROLE') }}\"
+                schema: \"{{ env_var('DBT_SNOWFLAKE_CI_SCHEMA') }}\"
+                threads: 8
+                type: snowflake
+                user: \"{{ env_var('DBT_SNOWFLAKE_CI_USER') }}\"
+                warehouse: \"{{ env_var('DBT_SNOWFLAKE_CI_WAREHOUSE') }}\"
+            target: dev" > ~/.dbt/profiles.yml
+
       - name: dbt-deps
-        run: dbt deps --profiles-dir ./profiles/snowflake
+        run: dbt deps --profiles-dir ./.dbt
 
       - name: dbt-debug
-        run: dbt debug --profiles-dir ./profiles/snowflake
+        run: dbt debug --profiles-dir ./.dbt
 
       - name: dbt-build
-        run: dbt build --profiles-dir ./profiles/snowflake
+        run: dbt build --profiles-dir ./.dbt
 
       - name: dbt-docs-generate
-        run: dbt docs generate --profiles-dir ./profiles/snowflake
+        run: dbt docs generate --profiles-dir ./.dbt
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -1,0 +1,81 @@
+name: Generate and Deploy dbt Docs
+
+on:
+  release:
+    types: [published]  # Triggers when a release is published
+  workflow_dispatch:  # Allows manual triggering
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: '3.9'
+  LINT_SCRIPT_PATH: ./lint_tuva_project.sh
+
+#######  Secrets #######
+#######  Snowflake
+  DBT_TUVA_SNOWFLAKE_ACCOUNT: ${{ secrets.DBT_TUVA_SNOWFLAKE_ACCOUNT }}
+  DBT_TUVA_CI_DATABASE: ${{ secrets.DBT_TUVA_CI_DATABASE }}
+  DBT_SNOWFLAKE_CI_PASSWORD: ${{ secrets.DBT_SNOWFLAKE_CI_PASSWORD }}
+  DBT_SNOWFLAKE_CI_ROLE: ${{ secrets.DBT_SNOWFLAKE_CI_ROLE }}
+  DBT_SNOWFLAKE_CI_SCHEMA: ${{ secrets.DBT_SNOWFLAKE_CI_SCHEMA }}
+  DBT_SNOWFLAKE_CI_USER: ${{ secrets.DBT_SNOWFLAKE_CI_USER }}
+  DBT_SNOWFLAKE_CI_WAREHOUSE: ${{ secrets.DBT_SNOWFLAKE_CI_WAREHOUSE }}
+
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dbt-core and Snowflake adapter
+        run: |
+          python -m pip install --upgrade pip
+          pip install dbt-core==1.8.6 dbt-snowflake
+
+      - name: dbt-deps
+        run: dbt deps --profiles-dir ./profiles/snowflake
+        working-directory: ci_testing
+
+      - name: dbt-debug
+        run: dbt debug --profiles-dir ./profiles/snowflake
+        working-directory: ci_testing
+
+      - name: dbt-docs-generate
+        run: |
+          dbt docs generate --profiles-dir ./profiles/snowflake
+        working-directory: ci_testing
+
+	  - name: Setup Pages
+		uses: actions/configure-pages@v4
+
+	  - name: Upload artifact
+		uses: actions/upload-pages-artifact@v3
+		with:
+		  path: './target'  # dbt generates docs in the target directory
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: generate-docs
+
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./integration_tests/docs_generate
+        working-directory: ./ci_testing
 
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
         run: dbt debug --profiles-dir ./profiles/snowflake
 
       - name: dbt-build
-        run: dbt build --full-refresh --profiles-dir ./profiles/snowflake
+        run: dbt build --profiles-dir ./profiles/snowflake
 
       - name: dbt-docs-generate
         run: dbt docs generate --profiles-dir ./profiles/snowflake

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./ci_testing
+        working-directory: ./integration_tests/docs_generate
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -76,6 +76,9 @@ jobs:
           dbt docs generate --profiles-dir ./profiles/snowflake
         working-directory: ci_testing
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -66,8 +66,8 @@ jobs:
           pip install dbt-core==1.8.6 dbt-snowflake
 
       # --- Setup dbt Profile ---
-      - name: Create dbt profiles directory
-        run: mkdir -p ~/.dbt
+      - name: Create dbt profiles directory in working directory
+        run: mkdir -p .dbt
 
       - name: Create dbt profiles.yml for Snowflake (for docs context)
         run: |
@@ -83,19 +83,34 @@ jobs:
                 type: snowflake
                 user: \"{{ env_var('DBT_SNOWFLAKE_CI_USER') }}\"
                 warehouse: \"{{ env_var('DBT_SNOWFLAKE_CI_WAREHOUSE') }}\"
-            target: dev" > ~/.dbt/profiles.yml
+            target: dev" > .dbt/profiles.yml
+
+      - name: Verify profiles.yml exists
+        run: |
+          echo "Current working directory: $(pwd)"
+          echo "Contents of .dbt directory:"
+          ls -la .dbt/
+          echo "Contents of profiles.yml:"
+          cat .dbt/profiles.yml
 
       - name: dbt-deps
-        run: dbt deps --profiles-dir ./.dbt
+        run: dbt deps --profiles-dir .dbt
 
       - name: dbt-debug
-        run: dbt debug --profiles-dir ./.dbt
+        run: dbt debug --profiles-dir .dbt
 
       - name: dbt-build
-        run: dbt build --profiles-dir ./.dbt
+        run: dbt build --profiles-dir .dbt
 
       - name: dbt-docs-generate
-        run: dbt docs generate --profiles-dir ./.dbt
+        run: dbt docs generate --profiles-dir .dbt
+
+      - name: Verify target directory was created
+        run: |
+          echo "Contents of current directory:"
+          ls -la
+          echo "Contents of target directory:"
+          ls -la target/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
## Describe your changes
Adds github actions workflow to generate and publish dbt docs to github pages when main is updated.
Closes #836 

## How has this been tested?
Tested with a trigger on dev branch.

## Reviewer focus
n/a

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
