### PR TITLE
Fix PMPM Prep pk

### DIFF
--- a/models/financial_pmpm/financial_pmpm_models.yml
+++ b/models/financial_pmpm/financial_pmpm_models.yml
@@ -17,6 +17,7 @@ models:
           combination_of_columns:
             - person_id
             - year_month
+            - payer
             - data_source
             - "{{ quote_column('plan') }}"
     description: >


### PR DESCRIPTION
## Describe your changes
Adds payer to the pmpm_prep pk. Previously we were aggregating by `payer` in financial_pmpm__pmpm_prep, but we were not including it in the pk. Closes #951 


## How has this been tested?
tested locally
```bash
dbt test --select financial_pmpm__pmpm_prep
```
## Reviewer focus
Sanity check on pk

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR

### Package release checklist
- [ ] I have updated [dbt docs](https://www.notion.so/tuvahealth/Building-dbt-Docs-16df2f00df244f29b9d6756d8adbc2d9)
- [ ] I have updated the version number in the `dbt_project.yml`


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
