### PR TITLE
970 | Creating de-duplication logic for patients in both claims and clinical

### DIFF
--- a/models/core/final/core__patient.sql
+++ b/models/core/final/core__patient.sql
@@ -13,7 +13,7 @@ with person_list_to_exclude_because_in_claims as (
 select *
 from {{ ref('core__stg_claims_patient') }}
 union all
-select *
+select cscp.*
 from {{ ref('core__stg_clinical_patient') }} as cscp
 left outer join person_list_to_exclude_because_in_claims as pltebic on cscp.person_id = pltebic.person_id
 /* IF EXISTS IN CLAIMS, CHOOSE CLAIMS RECORD OVER CLINICAL RECORD */

--- a/models/core/final/core__patient.sql
+++ b/models/core/final/core__patient.sql
@@ -6,9 +6,18 @@
 
 {% if var('clinical_enabled', var('tuva_marts_enabled',False)) == true and var('claims_enabled', var('tuva_marts_enabled',False)) == true -%}
 
-select * from {{ ref('core__stg_claims_patient') }}
+with person_list_to_exclude_because_in_claims as (
+    select distinct person_id
+    from {{ ref('core__stg_claims_patient') }}
+)
+select *
+from {{ ref('core__stg_claims_patient') }}
 union all
-select * from {{ ref('core__stg_clinical_patient') }}
+select *
+from {{ ref('core__stg_clinical_patient') }} as cscp
+left outer join person_list_to_exclude_because_in_claims as pltebic on cscp.person_id = pltebic.person_id
+/* IF EXISTS IN CLAIMS, CHOOSE CLAIMS RECORD OVER CLINICAL RECORD */
+where pltebic.person_id is null
 
 {% elif var('clinical_enabled', var('tuva_marts_enabled',False)) == true -%}
 


### PR DESCRIPTION
Made decision to choose claims over clinical for datasets. Patient table has an expectation of PK on the person_id column.

## Describe your changes
Core patient id table expects pk on person id. In instance that same person id even if from multiple data sources is in both clinical and claims data, this causes issues because of PK expectations, joins, and fan outs. This is a temporary solution to address this prior to a large refactor / thinking through the primary keys. 

## How has this been tested?
Will run the CI

## Reviewer focus
Single file change

## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [NA] (Optional) I have recorded a Loom to explain this PR

