### PR TITLE
Add HTML data quality dashboard

### DIFF
--- a/ui/data_quality_dashboard.html
+++ b/ui/data_quality_dashboard.html
@@ -1,0 +1,1240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tuva Data Quality Dashboard</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+            min-height: 100vh;
+            padding: 20px;
+            color: #2d3748;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.08);
+            overflow: hidden;
+            border: 1px solid #e2e8f0;
+        }
+
+        .header {
+            background: linear-gradient(135deg, #2b6cb0 0%, #1a365d 100%);
+            color: white;
+            padding: 40px 30px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .header::before {
+            content: '';
+            position: absolute;
+            top: -50%;
+            right: -10%;
+            width: 100px;
+            height: 200%;
+            background: linear-gradient(45deg, #fbbf24 0%, #f59e0b 100%);
+            transform: rotate(15deg);
+            opacity: 0.2;
+        }
+
+        .header::after {
+            content: '';
+            position: absolute;
+            top: -30%;
+            right: 5%;
+            width: 60px;
+            height: 160%;
+            background: linear-gradient(45deg, #60a5fa 0%, #3b82f6 100%);
+            transform: rotate(-10deg);
+            opacity: 0.3;
+        }
+
+        .header h1 {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+            font-weight: 700;
+            position: relative;
+            z-index: 2;
+        }
+
+        .header p {
+            font-size: 1.1rem;
+            opacity: 0.95;
+            position: relative;
+            z-index: 2;
+        }
+
+        .upload-area {
+            margin: 40px;
+            padding: 60px;
+            border: 3px dashed #cbd5e0;
+            border-radius: 16px;
+            text-align: center;
+            background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+            transition: all 0.3s ease;
+            cursor: pointer;
+        }
+
+        .upload-area:hover {
+            border-color: #3b82f6;
+            background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+            transform: translateY(-2px);
+        }
+
+        .upload-area.dragover {
+            border-color: #2563eb;
+            background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+            transform: scale(1.02);
+        }
+
+        .upload-icon {
+            font-size: 3rem;
+            margin-bottom: 20px;
+            color: #a0aec0;
+        }
+
+        .upload-text {
+            font-size: 1.2rem;
+            color: #4a5568;
+            margin-bottom: 10px;
+        }
+
+        .upload-hint {
+            color: #718096;
+            font-size: 0.9rem;
+        }
+
+        .dashboard {
+            display: none;
+            padding: 30px;
+        }
+
+        .refresh-area {
+            background: linear-gradient(135deg, #ecfeff 0%, #cffafe 100%);
+            border: 2px dashed #06b6d4;
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 30px;
+            text-align: center;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .refresh-area:hover {
+            background: linear-gradient(135deg, #cffafe 0%, #a7f3d0 100%);
+            border-color: #0891b2;
+            transform: translateY(-1px);
+        }
+
+        .refresh-area.dragover {
+            background: linear-gradient(135deg, #a7f3d0 0%, #86efac 100%);
+            border-color: #059669;
+            transform: scale(1.02);
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+
+        .stat-card {
+            background: white;
+            padding: 25px;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+            border: 1px solid #e2e8f0;
+            border-left: 4px solid #3b82f6;
+            transition: all 0.3s ease;
+        }
+
+        .stat-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+        }
+
+        .stat-card.success {
+            border-left-color: #10b981;
+            background: linear-gradient(135deg, #ffffff 0%, #f0fdf4 100%);
+        }
+
+        .stat-card.error {
+            border-left-color: #ef4444;
+            background: linear-gradient(135deg, #ffffff 0%, #fef2f2 100%);
+        }
+
+        .stat-card.warning {
+            border-left-color: #f59e0b;
+            background: linear-gradient(135deg, #ffffff 0%, #fffbeb 100%);
+        }
+
+        .stat-number {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 5px;
+            color: #1a202c;
+        }
+
+        .stat-label {
+            color: #64748b;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            font-weight: 600;
+        }
+
+        .section {
+            margin-bottom: 40px;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            margin-bottom: 20px;
+            color: #2d3748;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .folder-section {
+            margin-bottom: 30px;
+        }
+
+        .folder-title {
+            font-size: 1.2rem;
+            font-weight: 600;
+            color: #4a5568;
+            margin-bottom: 15px;
+            padding: 10px 15px;
+            background: #f7fafc;
+            border-radius: 6px;
+            border-left: 4px solid #667eea;
+        }
+
+        .test-item {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            margin-bottom: 15px;
+            overflow: hidden;
+            transition: all 0.3s ease;
+        }
+
+        .test-item:hover {
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+
+        .test-item.failed {
+            border-left: 4px solid #f56565;
+        }
+
+        .test-item.warning {
+            border-left: 4px solid #ed8936;
+        }
+
+        .test-status.warning {
+            color: #ed8936;
+        }
+
+        .test-header {
+            padding: 20px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .test-info {
+            flex: 1;
+        }
+
+        .test-name {
+            font-weight: 600;
+            color: #2d3748;
+            margin-bottom: 5px;
+        }
+
+        .test-model {
+            color: #718096;
+            font-size: 0.9rem;
+        }
+
+        .test-status {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-weight: 600;
+        }
+
+        .test-status.failed {
+            color: #f56565;
+        }
+
+        .test-status.passed {
+            color: #48bb78;
+        }
+
+        .test-details {
+            display: none;
+            padding: 0 20px 20px;
+            border-top: 1px solid #e2e8f0;
+            background: #f8f9fa;
+        }
+
+        .test-details.open {
+            display: block;
+        }
+
+        .error-message {
+            background: #fed7d7;
+            color: #c53030;
+            padding: 15px;
+            border-radius: 6px;
+            margin: 15px 0;
+            font-family: 'Courier New', monospace;
+            font-size: 0.9rem;
+            white-space: pre-wrap;
+        }
+
+        .sql-code {
+            background: #2d3748;
+            color: #e2e8f0;
+            padding: 20px;
+            border-radius: 6px;
+            margin: 15px 0;
+            font-family: 'Courier New', monospace;
+            font-size: 0.85rem;
+            overflow-x: auto;
+            white-space: pre-wrap;
+        }
+
+        .test-docs {
+            background: #edf2f7;
+            padding: 15px;
+            border-radius: 6px;
+            margin: 15px 0;
+        }
+
+        .test-docs h4 {
+            color: #2d3748;
+            margin-bottom: 10px;
+        }
+
+        .test-docs p {
+            color: #4a5568;
+            line-height: 1.6;
+        }
+
+        .chart-container {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            margin-bottom: 30px;
+        }
+
+        .chart {
+            width: 100%;
+            height: 300px;
+        }
+
+        .instructions {
+            background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+            border: 1px solid #93c5fd;
+            border-radius: 12px;
+            padding: 25px;
+            margin: 25px 40px;
+        }
+
+        .instructions h3 {
+            color: #1e40af;
+            margin-bottom: 15px;
+            font-weight: 700;
+        }
+
+        .instructions ol {
+            color: #1e3a8a;
+            margin-left: 20px;
+            line-height: 1.6;
+        }
+
+        .instructions li {
+            margin-bottom: 8px;
+        }
+
+        .instructions code {
+            background: #1e40af;
+            color: white;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 0.9rem;
+        }
+
+        .toggle-arrow {
+            transition: transform 0.3s ease;
+        }
+
+        .toggle-arrow.open {
+            transform: rotate(90deg);
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 40px;
+            color: #718096;
+        }
+
+        .summary-chart {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            margin-bottom: 20px;
+        }
+
+        .donut-chart {
+            position: relative;
+            width: 150px;
+            height: 150px;
+        }
+
+        .donut-segment {
+            fill: none;
+            stroke-width: 20;
+        }
+
+        .donut-text {
+            text-anchor: middle;
+            dominant-baseline: middle;
+            font-size: 1.2rem;
+            font-weight: bold;
+        }
+
+        .legend {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+            margin-top: 20px;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .grade-badge {
+            display: inline-block;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-weight: bold;
+            font-size: 1.2rem;
+            min-width: 40px;
+            text-align: center;
+        }
+
+        .grade-a { background: linear-gradient(135deg, #10b981 0%, #059669 100%); color: white; }
+        .grade-b { background: linear-gradient(135deg, #059669 0%, #047857 100%); color: white; }
+        .grade-c { background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%); color: white; }
+        .grade-d { background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%); color: white; }
+        .grade-f { background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%); color: white; }
+
+        .severity-badge {
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            font-weight: 700;
+            margin-left: 8px;
+            text-transform: uppercase;
+            letter-spacing: 0.02em;
+        }
+
+        .severity-1 {
+            background: linear-gradient(135deg, #fecaca 0%, #fca5a5 100%);
+            color: #991b1b;
+            border: 1px solid #fca5a5;
+        }
+        .severity-2 {
+            background: linear-gradient(135deg, #fed7aa 0%, #fdba74 100%);
+            color: #9a3412;
+            border: 1px solid #fdba74;
+        }
+        .severity-3 {
+            background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+        .severity-4 {
+            background: linear-gradient(135deg, #ddd6fe 0%, #c4b5fd 100%);
+            color: #5b21b6;
+            border: 1px solid #c4b5fd;
+        }
+        .severity-5 {
+            background: linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 100%);
+            color: #3730a3;
+            border: 1px solid #c7d2fe;
+        }
+
+        .group-card {
+            background: white;
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
+            padding: 20px;
+            transition: all 0.3s ease;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+        }
+
+        .group-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+        }
+
+        .group-card.usable {
+            border-left: 4px solid #10b981;
+        }
+
+        .group-card.caution {
+            border-left: 4px solid #f59e0b;
+        }
+
+        .group-card.not-usable {
+            border-left: 4px solid #ef4444;
+        }
+
+        .group-card-header {
+            display: flex;
+            justify-content: between;
+            align-items: center;
+            margin-bottom: 15px;
+        }
+
+        .group-card-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: #1a202c;
+        }
+
+        .group-card-count {
+            font-size: 0.8rem;
+            color: #64748b;
+            background: #f1f5f9;
+            padding: 2px 8px;
+            border-radius: 12px;
+        }
+
+        .group-card-status {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .group-card-icon {
+            font-size: 1.5rem;
+        }
+
+        .group-card-text {
+            font-weight: 600;
+            font-size: 0.9rem;
+        }
+
+        .groups-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🧪 Tuva Data Quality Dashboard</h1>
+            <p>Systematically assess your healthcare data quality with the Tuva Data Quality Framework.</p>
+        </div>
+
+        <div class="instructions">
+            <h3>📋 How to Use This Dashboard</h3>
+            <ol>
+                <li>Run your dbt tests: <code>dbt test</code></li>
+                <li>Locate your dbt project's <code>target/</code> folder</li>
+                <li>Drag and drop <code>run_results.json</code> and <code>manifest.json</code> files below</li>
+                <li>View detailed test results, failures, and model documentation</li>
+            </ol>
+        </div>
+
+        <div class="upload-area" id="uploadArea">
+            <div class="upload-icon">📁</div>
+            <div class="upload-text">Drag & drop your dbt files here</div>
+            <div class="upload-hint">Drop run_results.json and manifest.json from your target/ folder</div>
+            <input type="file" id="fileInput" multiple accept=".json" style="display: none;">
+        </div>
+
+        <div class="dashboard" id="dashboard">
+            <div class="refresh-area" id="refreshArea">
+                <div style="font-size: 1.1rem; font-weight: 600; color: #2c7a7b; margin-bottom: 5px;">
+                    🔄 Update Results
+                </div>
+                <div style="color: #4a5568; font-size: 0.9rem;">
+                    Drag & drop new run_results.json and manifest.json files to refresh the dashboard
+                </div>
+            </div>
+
+                    <div style="text-align: center;">
+                        <h3 style="font-size: 1.2rem; font-weight: 600; color: #1a202c; margin-bottom: 20px;">Overall Grade</h3><div id="overallGrade" class="grade-badge" style="font-size: 3rem; padding: 20px 30px; min-width: 80px;">
+                            <!-- Grade will be populated here -->
+                        </div>
+                    </div>
+            <div class="section">
+                <div class="section-title">
+                    📊 Summary
+                </div>
+               <div class="stats-grid" id="statsGrid">
+                    <!-- Stats will be populated here -->
+                </div>
+
+                <div style="display: flex; align-items: flex-start; justify-content: space-between; gap: 40px;">
+                    <div style="flex: 1;">
+                        <h3 style="font-size: 1.2rem; font-weight: 600; color: #1a202c; margin-bottom: 20px;">Issues by Severity Level</h3>
+                        <div id="severityBreakdown" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 15px;">
+                            <!-- Severity breakdown will be populated here -->
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="section">
+                <div class="section-title">
+                    🎯 Data Mart Usability
+                </div>
+                <div id="qualityGroups">
+                    <!-- Quality groups will be populated here -->
+                </div>
+            </div>
+
+            <div class="section">
+                <div class="section-title">
+                    🚨 All Issues (Ordered by Severity)
+                </div>
+                <div id="allIssues">
+                    <!-- All issues will be populated here -->
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let runResults = null;
+        let manifest = null;
+
+        const uploadArea = document.getElementById('uploadArea');
+        const refreshArea = document.getElementById('refreshArea');
+        const fileInput = document.getElementById('fileInput');
+        const dashboard = document.getElementById('dashboard');
+
+        // File upload handling for both upload and refresh areas
+        uploadArea.addEventListener('click', () => fileInput.click());
+        uploadArea.addEventListener('dragover', handleDragOver);
+        uploadArea.addEventListener('dragleave', handleDragLeave);
+        uploadArea.addEventListener('drop', handleDrop);
+
+        refreshArea.addEventListener('click', () => fileInput.click());
+        refreshArea.addEventListener('dragover', handleRefreshDragOver);
+        refreshArea.addEventListener('dragleave', handleRefreshDragLeave);
+        refreshArea.addEventListener('drop', handleRefreshDrop);
+
+        fileInput.addEventListener('change', handleFileSelect);
+
+        function handleDragOver(e) {
+            e.preventDefault();
+            uploadArea.classList.add('dragover');
+        }
+
+        function handleDragLeave(e) {
+            e.preventDefault();
+            uploadArea.classList.remove('dragover');
+        }
+
+        function handleDrop(e) {
+            e.preventDefault();
+            uploadArea.classList.remove('dragover');
+            const files = e.dataTransfer.files;
+            processFiles(files);
+        }
+
+        function handleRefreshDragOver(e) {
+            e.preventDefault();
+            refreshArea.classList.add('dragover');
+        }
+
+        function handleRefreshDragLeave(e) {
+            e.preventDefault();
+            refreshArea.classList.remove('dragover');
+        }
+
+        function handleRefreshDrop(e) {
+            e.preventDefault();
+            refreshArea.classList.remove('dragover');
+            const files = e.dataTransfer.files;
+            processFiles(files);
+        }
+
+        function handleFileSelect(e) {
+            const files = e.target.files;
+            processFiles(files);
+        }
+
+        function processFiles(files) {
+            Array.from(files).forEach(file => {
+                if (file.name.includes('run_results.json')) {
+                    readJsonFile(file, (data) => {
+                        runResults = data;
+                        checkAndRender();
+                    });
+                } else if (file.name.includes('manifest.json')) {
+                    readJsonFile(file, (data) => {
+                        manifest = data;
+                        checkAndRender();
+                    });
+                }
+            });
+        }
+
+        function readJsonFile(file, callback) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                try {
+                    const data = JSON.parse(e.target.result);
+                    callback(data);
+                } catch (error) {
+                    alert(`Error reading ${file.name}: ${error.message}`);
+                }
+            };
+            reader.readAsText(file);
+        }
+
+        function checkAndRender() {
+            if (runResults && manifest) {
+                renderDashboard();
+            }
+        }
+
+        function renderDashboard() {
+            uploadArea.style.display = 'none';
+            dashboard.style.display = 'block';
+
+            const testResults = extractTestResults();
+            renderStats(testResults);
+            const overallGrade = calculateOverallGrade(testResults);
+            renderSummaryChart(testResults, overallGrade);
+            renderQualityGroups(testResults);
+            renderAllIssues(testResults);
+        }
+
+        function extractTestResults() {
+            const results = [];
+
+            // Debug logging
+            console.log('Total results in run_results:', runResults.results.length);
+
+            // Check what resource types we actually have
+            const resourceTypes = {};
+            runResults.results.forEach(result => {
+                resourceTypes[result.resource_type] = (resourceTypes[result.resource_type] || 0) + 1;
+            });
+            console.log('Resource types found:', resourceTypes);
+
+            // Look for tests with different possible resource_type values
+            const testResults = runResults.results.filter(r =>
+                r.resource_type === 'test' ||
+                r.resource_type === 'data_test' ||
+                r.resource_type === 'schema_test' ||
+                r.resource_type === 'generic_test' ||
+                r.unique_id.includes('.test.') ||
+                (r.unique_id.includes('test:') || r.unique_id.startsWith('test.'))
+            );
+            console.log('Test results found:', testResults.length);
+
+            // Also check if we're missing the manifest for some reason
+            if (!manifest || !manifest.nodes) {
+                console.error('Manifest is missing or invalid');
+                return results;
+            }
+
+            runResults.results.forEach(result => {
+                // Cast a wider net for what might be a test
+                const isTest = result.resource_type === 'test' ||
+                              result.resource_type === 'data_test' ||
+                              result.resource_type === 'schema_test' ||
+                              result.resource_type === 'generic_test' ||
+                              result.unique_id.includes('.test.') ||
+                              (result.unique_id.includes('test:') || result.unique_id.startsWith('test.'));
+
+                if (isTest) {
+                    const testNode = manifest.nodes[result.unique_id];
+
+                    if (!testNode) {
+                        console.warn('Test node not found in manifest:', result.unique_id);
+                        // Still try to create a result with limited info
+                        results.push({
+                            unique_id: result.unique_id,
+                            name: result.unique_id.split('.').pop() || 'Unknown Test',
+                            status: result.status,
+                            message: result.message,
+                            failures: result.failures,
+                            execution_time: result.execution_time,
+                            compiled_code: null,
+                            raw_code: null,
+                            model_name: 'Unknown',
+                            model_path: '',
+                            test_description: '',
+                            folder: 'root',
+                            tags: [],
+                            severity: null,
+                            group: null,
+                            groups: []
+                        });
+                        return;
+                    }
+
+                    // Extract severity and groups from tags
+                    const tags = testNode.tags || [];
+                    const severity = getSeverityFromTags(tags);
+                    const groups = getGroupsFromTags(tags);
+
+                    const modelNode = testNode.depends_on?.nodes?.find(nodeId =>
+                        manifest.nodes[nodeId] && manifest.nodes[nodeId].resource_type === 'model'
+                    );
+
+                    results.push({
+                        unique_id: result.unique_id,
+                        name: testNode.name || result.unique_id.split('.').pop(),
+                        status: result.status,
+                        message: result.message,
+                        failures: result.failures,
+                        execution_time: result.execution_time,
+                        compiled_code: testNode.compiled_code,
+                        raw_code: testNode.raw_code,
+                        model_name: modelNode ? manifest.nodes[modelNode].name : 'Unknown',
+                        model_path: modelNode ? manifest.nodes[modelNode].original_file_path : '',
+                        test_description: testNode.description || '', // Use test description instead of model description
+                        folder: testNode.original_file_path ? testNode.original_file_path.split('/').slice(0, -1).join('/') : 'root',
+                        tags: tags,
+                        severity: severity,
+                        group: groups.length > 0 ? groups[0] : null, // Keep for backward compatibility
+                        groups: groups // New: all groups this test belongs to
+                    });
+                }
+            });
+
+            console.log('Final processed results:', results.length);
+            return results;
+        }
+
+        function getSeverityFromTags(tags) {
+            if (tags.includes('tuva_dqi_sev_1')) return 1;
+            if (tags.includes('tuva_dqi_sev_2')) return 2;
+            if (tags.includes('tuva_dqi_sev_3')) return 3;
+            if (tags.includes('tuva_dqi_sev_4')) return 4;
+            if (tags.includes('tuva_dqi_sev_5')) return 5;
+            return null;
+        }
+
+        function getGroupsFromTags(tags) {
+            const groups = [];
+
+            if (tags.includes('dqi_ccsr')) groups.push('CCSR');
+            if (tags.includes('dqi_cms_chronic_conditions')) groups.push('CMS Chronic Conditions');
+            if (tags.includes('dqi_cms_hccs')) groups.push('CMS HCCs');
+            if (tags.includes('dqi_ed_classification')) groups.push('ED Classification');
+            if (tags.includes('dqi_financial_pmpm')) groups.push('Financial PMPM');
+            if (tags.includes('dqi_quality_measures')) groups.push('Quality Measures');
+            if (tags.includes('dqi_readmission')) groups.push('Readmission');
+            if (tags.includes('dqi_service_categories')) groups.push('Service Categories');
+            if (tags.includes('dqi_tuva_chronic_conditions')) groups.push('Tuva Chronic Conditions');
+
+            return groups;
+        }
+
+        function getGroupFromTags(tags) {
+            // Keep this for backward compatibility, but return first group or null
+            const groups = getGroupsFromTags(tags);
+            return groups.length > 0 ? groups[0] : null;
+        }
+
+        function getGroupStatus(tests) {
+            const issues = tests.filter(t => t.status === 'fail' || t.status === 'warn');
+
+            if (issues.length === 0) {
+                return {
+                    status: 'usable',
+                    icon: '✅',
+                    text: 'Usable',
+                    class: 'success'
+                };
+            }
+
+            // Check for severity 1-2 issues
+            const hasSev1or2 = issues.some(t => t.severity === 1 || t.severity === 2);
+            if (hasSev1or2) {
+                return {
+                    status: 'not-usable',
+                    icon: '❌',
+                    text: 'Not Usable',
+                    class: 'error'
+                };
+            }
+
+            // Check for severity 3 issues
+            const hasSev3 = issues.some(t => t.severity === 3);
+            if (hasSev3) {
+                return {
+                    status: 'caution',
+                    icon: '⚠️',
+                    text: 'Use with Caution',
+                    class: 'warning'
+                };
+            }
+
+            // Only severity 4-5 issues (or no severity info)
+            return {
+                status: 'usable',
+                icon: '✅',
+                text: 'Usable',
+                class: 'success'
+            };
+        }
+
+        function renderQualityGroups(testResults) {
+            const groups = {};
+
+            // Initialize all possible groups
+            const allGroupNames = ['CCSR', 'CMS Chronic Conditions', 'CMS HCCs', 'ED Classification',
+                                 'Financial PMPM', 'Quality Measures', 'Readmission', 'Service Categories',
+                                 'Tuva Chronic Conditions'];
+
+            allGroupNames.forEach(groupName => {
+                groups[groupName] = [];
+            });
+
+            // Add each test to all applicable groups
+            testResults.forEach(test => {
+                if (test.groups && test.groups.length > 0) {
+                    test.groups.forEach(groupName => {
+                        if (groups[groupName]) {
+                            groups[groupName].push(test);
+                        }
+                    });
+                }
+            });
+
+            let html = '<div class="groups-grid">';
+
+            // Only show groups that have tests
+            Object.keys(groups).sort().forEach(groupName => {
+                const tests = groups[groupName];
+                if (tests.length === 0) return; // Skip empty groups
+
+                const groupStatus = getGroupStatus(tests);
+
+                html += `
+                    <div class="group-card ${groupStatus.status}">
+                        <div class="group-card-header">
+                            <div>
+                                <div class="group-card-title">${groupName}</div>
+                                <div class="group-card-count">${tests.length} tests</div>
+                            </div>
+                        </div>
+                        <div class="group-card-status">
+                            <div class="group-card-icon">${groupStatus.icon}</div>
+                            <div class="group-card-text" style="color: ${groupStatus.class === 'success' ? '#10b981' : groupStatus.class === 'warning' ? '#f59e0b' : '#ef4444'};">
+                                ${groupStatus.text}
+                            </div>
+                        </div>
+                    </div>
+                `;
+            });
+
+            html += '</div>';
+            document.getElementById('qualityGroups').innerHTML = html;
+        }
+
+        function renderStats(testResults) {
+            const passed = testResults.filter(t => t.status === 'pass').length;
+            const failed = testResults.filter(t => t.status === 'fail').length;
+            const warnings = testResults.filter(t => t.status === 'warn').length;
+            const total = testResults.length;
+
+            document.getElementById('statsGrid').innerHTML = `
+                <div class="stat-card">
+                    <div class="stat-number">${total}</div>
+                    <div class="stat-label">Total Tests</div>
+                </div>
+                <div class="stat-card success">
+                    <div class="stat-number">${passed}</div>
+                    <div class="stat-label">Passed</div>
+                </div>
+                <div class="stat-card error">
+                    <div class="stat-number">${failed}</div>
+                    <div class="stat-label">Failed</div>
+                </div>
+                <div class="stat-card warning">
+                    <div class="stat-number">${warnings}</div>
+                    <div class="stat-label">Warnings</div>
+                </div>
+            `;
+        }
+
+        function calculateOverallGrade(testResults) {
+            const issues = testResults.filter(t => t.status === 'fail' || t.status === 'warn');
+
+            if (issues.length === 0) return 'A';
+
+            // Debug logging to help identify the issue
+            console.log('Issues (failed + warnings):', issues.length);
+            console.log('Issues with severity info:', issues.map(t => ({ name: t.name, severity: t.severity, status: t.status, tags: t.tags })));
+
+            // Check for severity levels in issues (failed tests + warnings)
+            const issuesWithSeverity = issues.filter(t => t.severity !== null && t.severity !== undefined);
+            console.log('Issues with severity:', issuesWithSeverity.length);
+
+            if (issuesWithSeverity.length === 0) {
+                // If no issues have severity info, grade based on presence of issues
+                return issues.length === 0 ? 'A' : 'C';
+            }
+
+            const hasLevel1 = issuesWithSeverity.some(t => t.severity === 1);
+            const hasLevel2 = issuesWithSeverity.some(t => t.severity === 2);
+            const hasLevel3 = issuesWithSeverity.some(t => t.severity === 3);
+            const hasLevel4 = issuesWithSeverity.some(t => t.severity === 4);
+
+            console.log('Severity levels found:', { level1: hasLevel1, level2: hasLevel2, level3: hasLevel3, level4: hasLevel4 });
+
+            // Grade based on highest severity level present
+            if (hasLevel1) return 'F';  // Has severity level 1 issues
+            if (hasLevel2) return 'D';  // Has severity level 2 issues but no level 1
+            if (hasLevel3) return 'C';  // Has severity level 3 issues but no level 1-2
+            if (hasLevel4) return 'B';  // Has severity level 4 issues but no level 1-3
+
+            return 'A';  // No severity level 1-4 issues detected
+        }
+
+        function renderSummaryChart(testResults, overallGrade) {
+            // Calculate severity breakdown from failed tests and warnings
+            const issues = testResults.filter(t => t.status === 'fail' || t.status === 'warn');
+            const severityCounts = {
+                1: 0, 2: 0, 3: 0, 4: 0, 5: 0
+            };
+
+            issues.forEach(test => {
+                if (test.severity !== null && test.severity !== undefined) {
+                    severityCounts[test.severity]++;
+                }
+            });
+
+            // Render severity breakdown
+            const severityHtml = `
+                <div class="stat-card error">
+                    <div class="stat-number">${severityCounts[1]}</div>
+                    <div class="stat-label">Level 1</div>
+                </div>
+                <div class="stat-card error">
+                    <div class="stat-number">${severityCounts[2]}</div>
+                    <div class="stat-label">Level 2</div>
+                </div>
+                <div class="stat-card warning">
+                    <div class="stat-number">${severityCounts[3]}</div>
+                    <div class="stat-label">Level 3</div>
+                </div>
+                <div class="stat-card warning">
+                    <div class="stat-number">${severityCounts[4]}</div>
+                    <div class="stat-label">Level 4</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">${severityCounts[5]}</div>
+                    <div class="stat-label">Level 5</div>
+                </div>
+            `;
+
+            document.getElementById('severityBreakdown').innerHTML = severityHtml;
+
+            // Render the overall grade
+            const gradeElement = document.getElementById('overallGrade');
+            gradeElement.textContent = overallGrade;
+            gradeElement.className = `grade-badge grade-${overallGrade.toLowerCase()}`;
+        }
+
+        function renderFailedTests(testResults) {
+            const failedTests = testResults.filter(t => t.status === 'fail');
+
+            if (failedTests.length === 0) {
+                document.getElementById('failedTests').innerHTML = '<div class="empty-state">🎉 No failed tests! All tests are passing.</div>';
+                return;
+            }
+
+            let html = '';
+            failedTests.forEach(test => {
+                html += renderTestItem(test);
+            });
+
+            document.getElementById('failedTests').innerHTML = html;
+        }
+
+        function renderWarningTests(testResults) {
+            const warningTests = testResults.filter(t => t.status === 'warn');
+
+            if (warningTests.length === 0) {
+                document.getElementById('warningTests').innerHTML = '<div class="empty-state">✅ No tests with warnings.</div>';
+                return;
+            }
+
+            let html = '';
+            warningTests.forEach(test => {
+                html += renderTestItem(test);
+            });
+
+            document.getElementById('warningTests').innerHTML = html;
+        }
+
+        function renderAllIssues(testResults) {
+            const issues = testResults.filter(t => t.status === 'fail' || t.status === 'warn');
+
+            if (issues.length === 0) {
+                document.getElementById('allIssues').innerHTML = '<div class="empty-state">🎉 No issues found! All tests are passing.</div>';
+                return;
+            }
+
+            // Sort by severity (1 = highest priority, 5 = lowest priority, null/undefined last)
+            issues.sort((a, b) => {
+                // Handle null/undefined severity
+                if (a.severity === null || a.severity === undefined) return 1;
+                if (b.severity === null || b.severity === undefined) return -1;
+
+                // Sort by severity (ascending - 1 is most critical)
+                if (a.severity !== b.severity) {
+                    return a.severity - b.severity;
+                }
+
+                // If same severity, sort by status (fail before warn)
+                if (a.status !== b.status) {
+                    return a.status === 'fail' ? -1 : 1;
+                }
+
+                // Finally sort by name
+                return a.name.localeCompare(b.name);
+            });
+
+            let html = '';
+            issues.forEach(test => {
+                html += renderTestItem(test);
+            });
+
+            document.getElementById('allIssues').innerHTML = html;
+        }
+
+        function renderAllTests(testResults) {
+            let html = '';
+            testResults.forEach(test => {
+                html += renderTestItem(test);
+            });
+
+            document.getElementById('allTests').innerHTML = html;
+        }
+
+        function groupTestsByFolder(tests) {
+            const grouped = {};
+            tests.forEach(test => {
+                const folder = test.folder || 'root';
+                if (!grouped[folder]) {
+                    grouped[folder] = [];
+                }
+                grouped[folder].push(test);
+            });
+            return grouped;
+        }
+
+        function renderTestItem(test) {
+            let statusIcon, statusClass;
+
+            if (test.status === 'pass') {
+                statusIcon = '✅';
+                statusClass = 'passed';
+            } else if (test.status === 'warn') {
+                statusIcon = '⚠️';
+                statusClass = 'warning';
+            } else {
+                statusIcon = '❌';
+                statusClass = 'failed';
+            }
+
+            const severityBadge = test.severity ? `<span class="severity-badge severity-${test.severity}">Level ${test.severity}</span>` : '';
+            const groupsText = test.groups && test.groups.length > 0 ? test.groups.join(', ') : 'None';
+
+            return `
+                <div class="test-item ${statusClass}">
+                    <div class="test-header" onclick="toggleTestDetails('${test.unique_id}')">
+                        <div class="test-info">
+                            <div class="test-name">${severityBadge} ${test.name}</div>
+                            <div class="test-model">Model: ${test.model_name} | Groups: ${groupsText}</div>
+                        </div>
+                        <div class="test-status ${statusClass}">
+                            ${statusIcon} ${test.status.toUpperCase()}
+                            <span class="toggle-arrow" id="arrow-${test.unique_id}">▶</span>
+                        </div>
+                    </div>
+                    <div class="test-details" id="details-${test.unique_id}">
+                        ${(test.status === 'fail' || test.status === 'warn') && test.message ? `
+                            <div class="error-message">${test.message}</div>
+                        ` : ''}
+                        ${test.test_description ? `
+                            <div class="test-docs">
+                                <h4>Test Description</h4>
+                                <p>${test.test_description}</p>
+                            </div>
+                        ` : ''}
+                        ${test.compiled_code ? `
+                            <h4>Test SQL</h4>
+                            <div class="sql-code">${test.compiled_code}</div>
+                        ` : ''}
+                        ${test.tags && test.tags.length > 0 ? `
+                            <div style="margin-top: 10px;">
+                                <strong>Tags:</strong> ${test.tags.join(', ')}
+                            </div>
+                        ` : ''}
+                        <div style="margin-top: 10px; color: #718096; font-size: 0.9rem;">
+                            Execution time: ${test.execution_time ? test.execution_time.toFixed(3) : 'N/A'}s
+                        </div>
+                    </div>
+                </div>
+            `;
+        }
+
+        function toggleTestDetails(testId) {
+            const details = document.getElementById(`details-${testId}`);
+            const arrow = document.getElementById(`arrow-${testId}`);
+
+            if (details.classList.contains('open')) {
+                details.classList.remove('open');
+                arrow.classList.remove('open');
+            } else {
+                details.classList.add('open');
+                arrow.classList.add('open');
+            }
+        }
+    </script>
+</body>
+</html>

--- a/ui/data_quality_dashboard.html
+++ b/ui/data_quality_dashboard.html
@@ -1,4 +1,12 @@
 <!DOCTYPE html>
+<!-- 
+⚠️ LOCAL DEVELOPMENT TOOL ONLY ⚠️
+This tool has known XSS vulnerabilities and should NEVER be:
+- Deployed to any server (internal or external)
+- Used with untrusted JSON files
+- Converted to a web service
+Only use with JSON files you generated yourself from dbt.
+-->
 <html lang="en">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Describe your changes
Adds an HTML file that would replace the current DQI dashboard. It uses the `manifest.json` and `run_results.json` files to display the test results without the need to use Elementary or serve a python app.

## How has this been tested?
Ran `dbt test` on the CI data and verified that the results are the same as what you'd see on the DQI dashboard. The only difference (which I think should be discussed) is the inclusion of test results that dont have a severity tag, whereas the current dashboard just drops them.

## Reviewer focus
N/A

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
