### PR TITLE
Fix duckdb seed loads to include the first row.

### DIFF
--- a/macros/cross_database_utils/load_seed.sql
+++ b/macros/cross_database_utils/load_seed.sql
@@ -36,7 +36,7 @@
         read_csv('s3://{{ uri }}/{{ pattern }}*',
         {% if null_marker == true %} nullstr = '\N' {% else %} nullstr = '' {% endif %},
          quote = '"', escape = '"',
-         header=true,
+         header={{headers}},
          columns= { {{ cols }} } )
 
 {% endset %}


### PR DESCRIPTION
## Describe your changes
Fixes #978 

## How has this been tested?
Run `dbt seed -s readmissions__always_planned_ccs_procedure_category` and verified that 3 rows loaded instead of 2.

## Reviewer focus
n/a

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
