### PR TITLE
Update GitHub action: adding release branches to internal workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Create Release
 # creates a draft release if there is a push to main/ that changes "version" in /dbt_project.yml
 # user must manually publish the release and check the latest release option
 

--- a/.github/workflows/tuva_internal_dbt_v1.8.6.yml
+++ b/.github/workflows/tuva_internal_dbt_v1.8.6.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+      - '*release*'
+  push:
+    branches:
+      - '*release*'  # any branch with release in the name
 
 concurrency:
   # Group by workflow and ref, cancel ongoing runs for the same PR/branch


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

* Adds release branches to the internal workflow. This ensures that CI testing will run when a PR is opened on a release branch or when a commit is pushed.

* Renames the release.yml workflow to `.github/workflows/create-release.yml` to avoid confusion with `.github/release.yml`, which is used for generating release notes.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
