### PR TITLE
Fixup internal workflow triggers - add branches back

### DIFF
--- a/.github/workflows/tuva_internal_dbt_v1.8.6.yml
+++ b/.github/workflows/tuva_internal_dbt_v1.8.6.yml
@@ -1,10 +1,15 @@
 name: tuva_internal_dbt_v1.8.6
 on:
-  pull_request:  # run for all PRs
+  pull_request:
+    branches:
+      - main
+      - 'minor-release*'
+      - 'release*'
   push:  # run when code is pushed to a release branch
     branches:
-      - 'main'
-      - '*release*'  # any branch with release in the name
+      - main
+      - 'minor-release*'
+      - 'release*'
   workflow_dispatch:  # for manual triggering
 
 concurrency:


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

Adds branch patterns back to the pull-request list. When left blank, it only runs on the default branch (main). Per [Github docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-filters), wildcards should work when used at the end of a pattern. 

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
