### PR TITLE
Add missing provider fields to dbt docs

### DIFF
--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -892,6 +892,12 @@ seeds:
         description: 'The state of the practice address.'
       - name: practice_zip_code
         description: 'The ZIP code of the practice address.'
+      - name: mailing_telephone_number
+        description: 'Provider Business Mailing Address Telephone Number.'
+      - name: location_telephone_number
+        description: 'Provider Business Practice Location Address Telephone Number.'
+      - name: official_telephone_number
+        description: 'Authorized Official Telephone Number'
       - name: last_updated
         description: 'The date when the provider information was last updated.'
       - name: deactivation_date


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

Adds missing fields/descriptions to dbt docs for provider seed file:
  * mailing_telephone_number
  * location_telephone_number
  * official_telephone_number

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
