### PR TITLE
Add missing input layer fields

### DIFF
--- a/integration_tests/docs_generate/models/_models.yml
+++ b/integration_tests/docs_generate/models/_models.yml
@@ -60,6 +60,10 @@ models:
         description: '{{ doc("medicare_status_code") }}'
         meta:
           terminology: https://github.com/tuva-health/the_tuva_project/blob/main/seeds/terminology/terminology__medicare_status.csv
+      - name: group_id
+        description: '{{ doc("group_id") }}'
+      - name: group_name
+        description: '{{ doc("group_name") }}'
       - name: first_name
         description: '{{ doc("first_name") }}'
       - name: last_name
@@ -82,6 +86,8 @@ models:
         description: '{{ doc("data_source") }}'
       - name: file_name
         description: '{{ doc("file_name") }}'
+      - name: file_date
+        description: '{{ doc("file_date") }}'
       - name: ingest_datetime
         description: '{{ doc("ingest_datetime") }}'
 
@@ -662,6 +668,8 @@ models:
         description: '{{ doc("data_source") }}'
       - name: file_name
         description: '{{ doc("file_name") }}'
+      - name: file_date
+        description: '{{ doc("file_date") }}'
       - name: ingest_datetime
         description: '{{ doc("ingest_datetime") }}'
 
@@ -737,6 +745,8 @@ models:
         description: '{{ doc("data_source") }}'
       - name: file_name
         description: '{{ doc("file_name") }}'
+      - name: file_date
+        description: '{{ doc("file_date") }}'
       - name: ingest_datetime
         description: '{{ doc("ingest_datetime") }}'
 

--- a/models/input_layer/input_layer__eligibility.yml
+++ b/models/input_layer/input_layer__eligibility.yml
@@ -336,7 +336,7 @@ models:
                 meta:
                   dqi_test_description: "https://resdac.org/cms-data/variables/medicare-status-code-january"
       - name: group_id
-        description: '{{ doc("first_name") }}'
+        description: '{{ doc("group_id") }}'
         tests:
           - dbt_expectations.expect_column_to_exist:
               tags: ['tuva_dqi_sev_1', 'dqi']
@@ -344,7 +344,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - name: group_name
-        description: '{{ doc("first_name") }}'
+        description: '{{ doc("group_name") }}'
         tests:
           - dbt_expectations.expect_column_to_exist:
               tags: ['tuva_dqi_sev_1', 'dqi']
@@ -440,7 +440,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - name: file_date
-        description: '{{ doc("file_name") }}'
+        description: '{{ doc("file_date") }}'
         tests:
           - dbt_expectations.expect_column_to_exist:
               tags: ['tuva_dqi_sev_1', 'dqi']

--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -2361,7 +2361,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
       - name: file_date
-        description: ''
+        description: '{{ doc("file_date") }}'
         tests:
           - dbt_expectations.expect_column_to_exist:
               tags: ['tuva_dqi_sev_1', 'dqi']


### PR DESCRIPTION
## Describe your changes
This PR adds missing fields raised and resolves #833 and cleans up some of the input layer descriptions for `medical_claim` and `eligibility`.

## How has this been tested?


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/guides/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
