### PR TITLE
Fixes inconsistent datatype for integration tests pharmacy_claim_seed

### DIFF
--- a/integration_tests/seeds/_seeds.yml
+++ b/integration_tests/seeds/_seeds.yml
@@ -492,6 +492,12 @@ seeds:
           {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
         charge_amount: |
           {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+        coinsurance_amount: |
+          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+        copayment_amount: |
+          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+        deductible_amount: |
+          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
         in_network_flag: integer
         data_source: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}


### PR DESCRIPTION
## Describe your changes
Fixes inconsistent datatype for integration tests pharmacy_claim_seed columns:
* coinsurance_amount
* deductible_amount
* copayment_amount

Closes #1023 

## How has this been tested?
Followed issue instructions.

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
