### PR TITLE
standardize state from eligibility fix

### DIFF
--- a/dbt_doc_blocks/column_descriptions.md
+++ b/dbt_doc_blocks/column_descriptions.md
@@ -1061,3 +1061,15 @@ Unique year-month of in the dataset computed from eligibility.
 {% docs zip_code %}
 The zip code of the record (e.g., facility location, patient, etc).
 {% enddocs %}
+
+{% docs fips_state_code %}
+FIPS code for the state the patient lives in (most recent known address).
+{% enddocs %}
+
+{% docs normalized_state_name %}
+State for the patient (most recent known address).
+{% enddocs%}
+
+{% docs fips_state_abbreviation %}
+Abbreviated form of the state for the patient (most recient known address).
+{% enddocs%}

--- a/models/claims_preprocessing/claims_preprocessing_models.yml
+++ b/models/claims_preprocessing/claims_preprocessing_models.yml
@@ -188,6 +188,12 @@ models:
         description: State the patient lives in (most recent known address)
       - name: zip_code
         description: Zip code the patient lives in (most recent known address).
+      - name: fips_state_code
+        description: FIPS code for the state the patient lives in (most recent known address).
+      - name: normalized_state_name
+        description: State for the patient (most recent known address).
+      - name: fips_state_abbreviation
+        description: Abbreviated form of the state for the patient (most recent known address).
       - name: phone
         description: Patient's phone number.
       - name: data_source
@@ -1254,3 +1260,11 @@ models:
       tags: 
         - normalized_input
         - claims_preprocessing
+
+  - name: normalized_input__int_eligibility_state_normalize
+    config:
+      materialized: ephemeral
+      tags: 
+        - normalized_input
+        - claims_preprocessing
+        

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -32,9 +32,14 @@ select
   , cast(elig.city as {{ dbt.type_string() }}) as city
   , cast(elig.state as {{ dbt.type_string() }}) as state
   , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
+  , cast(ansi.fips_state_code as {{ dbt.type_string() }}) as fips_state_code
+  , cast(ansi.normalized_state_name as {{ dbt.type_string() }}) as normalized_state_name
+  , cast(ansi.fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
   , cast(elig.phone as {{ dbt.type_string() }}) as phone
   , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_eligibility') }} as elig
 left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
   on elig.person_id_key = date_norm.person_id_key
+left outer join {{ ref('normalized_input__int_eligibility_state_normalize') }} as ansi
+  on elig.person_id_key = ansi.person_id_key

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
@@ -1,0 +1,25 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
+   )
+}}
+
+
+select distinct
+    elig.person_id
+    , {{ concat_custom([
+        "elig.person_id",
+        "coalesce(elig.data_source,'')",
+        "coalesce(elig.payer,'')",
+        "coalesce(elig." ~ quote_column('plan') ~ ",'')",
+        "coalesce(cast(elig.enrollment_start_date as " ~ dbt.type_string() ~ "),'')",
+        "coalesce(cast(elig.enrollment_end_date as " ~ dbt.type_string() ~ "),'')"
+    ]) }} as person_id_key
+    , ansi.ansi_fips_state_name as normalized_state_name
+    , ansi.ansi_fips_state_code as fips_state_code
+    , ansi.ansi_fips_state_abbreviation as fips_state_abbreviation
+    , '{{ var('tuva_last_run') }}' as tuva_last_run
+from {{ ref('normalized_input__stg_eligibility') }} as elig
+left outer join {{ ref('reference_data__ansi_fips_state') }} as ansi
+  on trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_name))
+  

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -138,6 +138,12 @@ models:
       description: '{{ doc("medicare_status_code") }}'
       meta:
         terminology: https://thetuvaproject.com/terminology/medicare-status
+    - name: fips_state_code
+      description: '{{ doc("fips_state_code") }}'
+    - name: normalized_state_name
+      description: '{{ doc("normalized_state_name") }}'
+    - name: fips_state_abbreviation
+      description: '{{ doc("fips_state_abbreviation") }}'
     - name: subscriber_relation
       description: '{{ doc("subscriber_relation") }}'
     - name: group_id

--- a/models/core/staging/core__stg_claims_eligibility.sql
+++ b/models/core/staging/core__stg_claims_eligibility.sql
@@ -41,8 +41,11 @@ select
        , cast(dual_status_code as {{ dbt.type_string() }}) as dual_status_code
        , cast(medicare_status_code as {{ dbt.type_string() }}) as medicare_status_code
        , cast(subscriber_relation as {{ dbt.type_string() }}) as subscriber_relation
-        , cast(group_id as {{ dbt.type_string() }}) as group_id
-        , cast(group_name as {{ dbt.type_string() }}) as group_name
+       , cast(group_id as {{ dbt.type_string() }}) as group_id
+       , cast(group_name as {{ dbt.type_string() }}) as group_name
+       , cast(normalized_state_name as {{ dbt.type_string() }}) as normalized_state_name
+       , cast(fips_state_code as {{ dbt.type_string() }}) as fips_state_code
+       , cast(fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
        , cast(data_source as {{ dbt.type_string() }}) as data_source
        , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('normalized_input__eligibility') }}


### PR DESCRIPTION
## Describe your changes

- Introduction of new normalization model `normalized_input__int_eligibility_state_normalize`
- Addition of new below listed new fields on `core.eligibility` table
  - `normalized_state_name`
  - `fips_state_code`
  - `fips_state_abbreviation`


## How has this been tested?

- Ran `dbt build -s +core__eligibility`
- Tested across Snowflake, RedShift, BigQuery, and Fabric Warehouse

## Reviewer focus
Please review if the necessary fields has been introduced to `core.eligibility` table

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
