### PR TITLE
Removes date/datetime as options for "amount" field data types.

### DIFF
--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -4,10 +4,10 @@ models:
     description: >
       Mapping check to make sure all columns are mapped appropriately into the input
       layer.
-      The medical_claim table contains information on healthcare services and  supplies
-      provided to patients, billed by providers, and paid for by health  insurers.
-      It includes information on the provider who rendered the  service, the amount
-      paid for the service by the health insurer, and the  underlying reason for the
+      The medical_claim table contains information on healthcare services and supplies
+      provided to patients, billed by providers, and paid for by health insurers.
+      It includes information on the provider who rendered the service, the amount
+      paid for the service by the health insurer, and the underlying reason for the
       service (i.e. diagnosis).
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -743,7 +743,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ed_classification', 'dqi_financial_pmpm']
               config:
@@ -758,7 +758,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ed_classification', 'dqi_financial_pmpm']
               config:
@@ -773,7 +773,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_ed_classification']
               config:
@@ -788,7 +788,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi']
               config:
@@ -803,7 +803,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi']
               config:
@@ -818,7 +818,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi']
               config:
@@ -833,7 +833,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi']
               config:

--- a/models/input_layer/input_layer__pharmacy_claim.yml
+++ b/models/input_layer/input_layer__pharmacy_claim.yml
@@ -4,8 +4,8 @@ models:
     description: >
       Mapping check to make sure all columns are mapped appropriately into the input
       layer.
-      The pharmacy_claim table includes information about retail and specialty  drug
-      prescriptions that have been filled by a patient, billed by a  pharmacy, and
+      The pharmacy_claim table includes information about retail and specialty drug
+      prescriptions that have been filled by a patient, billed by a pharmacy, and
       paid by an insurer.
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -199,7 +199,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_financial_pmpm']
               config:
@@ -214,7 +214,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_financial_pmpm']
               config:
@@ -229,7 +229,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_financial_pmpm']
               config:
@@ -244,7 +244,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi']
               config:
@@ -259,7 +259,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi']
               config:
@@ -274,7 +274,7 @@ models:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, number, decimal, numeric, float,
+              column_type_list: [number, decimal, numeric, float,
                 float4, float8, double, double precision, real, float64, bignumeric]
               tags: ['tuva_dqi_sev_2', 'dqi']
               config:


### PR DESCRIPTION
## Describe your changes
The "_amount" fields in the claims tables allowed types "date" and "datetime" which are inappropriate for those fields. Removing them as acceptable options.

## How has this been tested?
Ran `dbt run -s input_layer` and `dbt test -s input_layer`. Confirmed no errors.

## Reviewer focus
n/a

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
