### PR TITLE
Add claim type distribution check

### DIFF
--- a/tests/claim_type_not_only_undetermined_check.sql
+++ b/tests/claim_type_not_only_undetermined_check.sql
@@ -11,7 +11,7 @@
 with claim_type_cte as (
     select
         data_source
-        , min(claim_type = 'undetermined') as has_only_undetermined_claim_types
+        , min(case when claim_type = 'undetermined' then 1 else 0 end) as has_only_undetermined_claim_types
         , count(*) as count_records
     from {{ ref('input_layer__medical_claim') }}
     group by data_source
@@ -20,4 +20,4 @@ with claim_type_cte as (
 select
     *
 from claim_type_cte
-where has_only_undetermined_claim_types
+where has_only_undetermined_claim_types = 1

--- a/tests/claim_type_not_only_undetermined_check.sql
+++ b/tests/claim_type_not_only_undetermined_check.sql
@@ -1,0 +1,23 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool,
+     tags = ['dqi', 'tuva_dqi_sev_2', 'dqi_service_categories', 'dqi_ccsr', 'dqi_cms_chronic_conditions',
+            'dqi_tuva_chronic_conditions', 'dqi_cms_hccs', 'dqi_ed_classification',
+            'dqi_financial_pmpm', 'dqi_quality_measures', 'dqi_readmission'],
+     severity = 'warn'
+   )
+}}
+
+with claim_type_cte as (
+    select
+        data_source
+        , min(claim_type = 'undetermined') as has_only_undetermined_claim_types
+        , count(*) as count_records
+    from {{ ref('input_layer__medical_claim') }}
+    group by data_source
+)
+
+select
+    *
+from claim_type_cte
+where has_only_undetermined_claim_types


### PR DESCRIPTION
## Describe your changes
Adds test to make sure claim type is not only undetermined. This flags a Sev 2 warning and closes #1024

## How has this been tested?
tested locally `dbt test --select medical_claim+1`


## Reviewer focus
Test logic, concept


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [x] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
