### PR TITLE
State normalization pull through

### DIFF
--- a/dbt_doc_blocks/column_descriptions.md
+++ b/dbt_doc_blocks/column_descriptions.md
@@ -1089,3 +1089,15 @@ Unique year-month of in the dataset computed from eligibility.
 {% docs zip_code %}
 The zip code of the record (e.g., facility location, patient, etc).
 {% enddocs %}
+
+{% docs fips_state_code %}
+FIPS code for the state the patient lives in (most recent known address).
+{% enddocs %}
+
+{% docs normalized_state_name %}
+State for the patient (most recent known address).
+{% enddocs%}
+
+{% docs fips_state_abbreviation %}
+Abbreviated form of the state for the patient (most recient known address).
+{% enddocs%}

--- a/models/claims_preprocessing/claims_preprocessing_models.yml
+++ b/models/claims_preprocessing/claims_preprocessing_models.yml
@@ -188,6 +188,12 @@ models:
         description: State the patient lives in (most recent known address)
       - name: zip_code
         description: Zip code the patient lives in (most recent known address).
+      - name: fips_state_code
+        description: FIPS code for the state the patient lives in (most recent known address).
+      - name: normalized_state_name
+        description: State for the patient (most recent known address).
+      - name: fips_state_abbreviation
+        description: Abbreviated form of the state for the patient (most recent known address).
       - name: phone
         description: Patient's phone number.
       - name: data_source
@@ -1254,3 +1260,11 @@ models:
       tags: 
         - normalized_input
         - claims_preprocessing
+
+  - name: normalized_input__int_eligibility_state_normalize
+    config:
+      materialized: ephemeral
+      tags: 
+        - normalized_input
+        - claims_preprocessing
+        

--- a/models/claims_preprocessing/claims_preprocessing_models.yml
+++ b/models/claims_preprocessing/claims_preprocessing_models.yml
@@ -1257,14 +1257,14 @@ models:
   - name: normalized_input__stg_pharmacy_claim
     config:
       materialized: ephemeral
-      tags: 
+      tags:
         - normalized_input
         - claims_preprocessing
+
 
   - name: normalized_input__int_eligibility_state_normalize
     config:
       materialized: ephemeral
-      tags: 
+      tags:
         - normalized_input
         - claims_preprocessing
-        

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -32,9 +32,14 @@ select
   , cast(elig.city as {{ dbt.type_string() }}) as city
   , cast(elig.state as {{ dbt.type_string() }}) as state
   , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
+  , cast(ansi.fips_state_code as {{ dbt.type_string() }}) as fips_state_code
+  , cast(ansi.normalized_state_name as {{ dbt.type_string() }}) as normalized_state_name
+  , cast(ansi.fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
   , cast(elig.phone as {{ dbt.type_string() }}) as phone
   , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_eligibility') }} as elig
 left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
   on elig.person_id_key = date_norm.person_id_key
+left outer join {{ ref('normalized_input__int_eligibility_state_normalize') }} as ansi
+  on elig.person_id_key = ansi.person_id_key

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
@@ -1,0 +1,24 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
+   )
+}}
+
+
+select distinct
+    elig.person_id
+    , {{ concat_custom([
+        "elig.person_id",
+        "coalesce(elig.data_source,'')",
+        "coalesce(elig.payer,'')",
+        "coalesce(elig." ~ quote_column('plan') ~ ",'')",
+        "coalesce(cast(elig.enrollment_start_date as " ~ dbt.type_string() ~ "),'')",
+        "coalesce(cast(elig.enrollment_end_date as " ~ dbt.type_string() ~ "),'')"
+    ]) }} as person_id_key
+    , ansi.ansi_fips_state_name as normalized_state_name
+    , ansi.ansi_fips_state_code as fips_state_code
+    , ansi.ansi_fips_state_abbreviation as fips_state_abbreviation
+    , '{{ var('tuva_last_run') }}' as tuva_last_run
+from {{ ref('normalized_input__stg_eligibility') }} as elig
+left outer join {{ ref('reference_data__ansi_fips_state') }} as ansi
+  on trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_code))

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
@@ -21,4 +21,8 @@ select distinct
     , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('normalized_input__stg_eligibility') }} as elig
 left outer join {{ ref('reference_data__ansi_fips_state') }} as ansi
-  on trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_code))
+  on (
+       trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_abbreviation))
+    or trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_code))
+    or trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_name))
+  )

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -138,6 +138,12 @@ models:
       description: '{{ doc("medicare_status_code") }}'
       meta:
         terminology: https://thetuvaproject.com/terminology/medicare-status
+    - name: fips_state_code
+      description: '{{ doc("fips_state_code") }}'
+    - name: normalized_state_name
+      description: '{{ doc("normalized_state_name") }}'
+    - name: fips_state_abbreviation
+      description: '{{ doc("fips_state_abbreviation") }}'
     - name: subscriber_relation
       description: '{{ doc("subscriber_relation") }}'
     - name: group_id

--- a/models/core/final/core__immunization.sql
+++ b/models/core/final/core__immunization.sql
@@ -31,32 +31,32 @@ select
          when cvx.cvx is not null then 'automatic'
          end as mapping_method
     , coalesce(immunization_status.status, immune.status) as status
-    , coalesce(immunization_status_reason.description ,immune.status_reason) as status_reason
+    , coalesce(immunization_status_reason.description, immune.status_reason) as status_reason
     , immune.occurrence_date
     , immune.source_dose
     , immune.normalized_dose
     , immune.lot_number
-    , coalesce(act_site.description,immune.body_site) as body_site
-    , coalesce(immunization_route.description,immune.route) as route
+    , coalesce(act_site.description, immune.body_site) as body_site
+    , coalesce(immunization_route.description, immune.route) as route
     , immune.location_id
     , immune.practitioner_id
     , immune.data_source
     , immune.tuva_last_run
 from {{ ref('core__stg_clinical_immunization') }} as immune
-left join {{ ref('terminology__cvx') }} as cvx
+left outer join {{ ref('terminology__cvx') }} as cvx
     on immune.source_code_type = 'cvx'
         and immune.source_code = cvx.cvx
-left join {{ ref('terminology__immunization_status') }} as immunization_status
+left outer join {{ ref('terminology__immunization_status') }} as immunization_status
     on immune.status = immunization_status.status_code
-left join {{ ref('terminology__immunization_status_reason') }} as immunization_status_reason
+left outer join {{ ref('terminology__immunization_status_reason') }} as immunization_status_reason
     on immune.status_reason = immunization_status_reason.reason_code
         and (
         immunization_status_reason.code_type = 'actreason' or
         immunization_status_reason.code_type = 'snomed-ct'
         )
-left join {{ ref('terminology__act_site') }} as act_site
+left outer join {{ ref('terminology__act_site') }} as act_site
     on immune.body_site = act_site.body_code
-left join {{ ref('terminology__immunization_route_code') }} as immunization_route
+left outer join {{ ref('terminology__immunization_route_code') }} as immunization_route
     on immune.route = immunization_route.route_code
 
  {% else %}

--- a/models/core/staging/core__stg_claims_eligibility.sql
+++ b/models/core/staging/core__stg_claims_eligibility.sql
@@ -41,8 +41,11 @@ select
        , cast(dual_status_code as {{ dbt.type_string() }}) as dual_status_code
        , cast(medicare_status_code as {{ dbt.type_string() }}) as medicare_status_code
        , cast(subscriber_relation as {{ dbt.type_string() }}) as subscriber_relation
-        , cast(group_id as {{ dbt.type_string() }}) as group_id
-        , cast(group_name as {{ dbt.type_string() }}) as group_name
+       , cast(group_id as {{ dbt.type_string() }}) as group_id
+       , cast(group_name as {{ dbt.type_string() }}) as group_name
+       , cast(normalized_state_name as {{ dbt.type_string() }}) as normalized_state_name
+       , cast(fips_state_code as {{ dbt.type_string() }}) as fips_state_code
+       , cast(fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
        , cast(data_source as {{ dbt.type_string() }}) as data_source
        , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('normalized_input__eligibility') }}

--- a/models/input_layer/input_layer__eligibility.yml
+++ b/models/input_layer/input_layer__eligibility.yml
@@ -409,7 +409,7 @@ models:
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - relationships:
               to: ref('reference_data__ansi_fips_state')
-              field: ANSI_FIPS_STATE_ABBREVIATION
+              field: ansi_fips_state_abbreviation
               tags: ['tuva_dqi_sev_5', 'dqi']
               config:
                 severity: warn

--- a/models/input_layer/input_layer__eligibility.yml
+++ b/models/input_layer/input_layer__eligibility.yml
@@ -407,6 +407,13 @@ models:
               config:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
+          - relationships:
+              to: ref('reference_data__ansi_fips_state')
+              field: ANSI_FIPS_STATE_ABBREVIATION
+              tags: ['tuva_dqi_sev_5', 'dqi']
+              config:
+                severity: warn
+                enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
       - name: zip_code
         description: '{{ doc("zip_code") }}'
         tests:

--- a/models/input_layer/input_layer__patient.yml
+++ b/models/input_layer/input_layer__patient.yml
@@ -181,6 +181,13 @@ models:
               config:
                 severity: warn
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
+          - relationships:
+              to: ref('reference_data__ansi_fips_state')
+              field: ANSI_FIPS_STATE_ABBREVIATION
+              tags: ['tuva_dqi_sev_5', 'dqi']
+              config:
+                severity: warn
+                enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
       - name: zip_code
         description: '{{ doc("zip_code") }}'
         tests:

--- a/models/input_layer/input_layer__patient.yml
+++ b/models/input_layer/input_layer__patient.yml
@@ -183,7 +183,7 @@ models:
                 enabled: "{{ ((target.type != 'fabric') and var('enable_input_layer_testing', true)) | as_bool }}"
           - relationships:
               to: ref('reference_data__ansi_fips_state')
-              field: ANSI_FIPS_STATE_ABBREVIATION
+              field: ansi_fips_state_abbreviation
               tags: ['tuva_dqi_sev_5', 'dqi']
               config:
                 severity: warn


### PR DESCRIPTION
Also fixes a linting issue

## Describe your changes
Normalization of state in the input layer to set expectations around state codes.

## How has this been tested?
Ran on local. Will see if fabric can handle referential integrity test in the CI

## Reviewer focus
Making sure CI works, and nothing breaks


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [X] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [X] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [X] (New models) I have added the variable `tuva_last_run` to the final output



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added state metadata to eligibility outputs: normalized_state_name, fips_state_code, and fips_state_abbreviation (propagated through staging and core).
- Tests
  - Introduced data quality checks validating state values against ANSI FIPS reference in eligibility and patient input layers (warning severity, toggleable).
- Documentation
  - Documented the new eligibility fields and adjusted nearby formatting.
- Style
  - Standardized SQL formatting and made joins explicitly LEFT OUTER in immunization logic; no impact on results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->