### PR TITLE
Update seed paths v0.15 & fix doc-generate workflow

### DIFF
--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dbt-core and Snowflake adapter
         run: |
           python -m pip install --upgrade pip
-          pip install dbt-core==1.8.6 dbt-snowflake
+          pip install dbt-core==1.9.4 dbt-snowflake
 
       # --- Setup dbt Profile ---
       - name: Create dbt profiles directory in working directory

--- a/.github/workflows/generate_and_deploy_dbt_docs.yml
+++ b/.github/workflows/generate_and_deploy_dbt_docs.yml
@@ -88,7 +88,7 @@ jobs:
         run: dbt debug --profiles-dir .dbt
 
       - name: dbt-build
-        run: dbt build --profiles-dir .dbt
+        run: dbt build --full-refresh --profiles-dir .dbt
 
       - name: dbt-docs-generate
         run: dbt docs generate --profiles-dir .dbt

--- a/ci_testing/dbt_project.yml
+++ b/ci_testing/dbt_project.yml
@@ -66,7 +66,7 @@ seeds:
     eligibility_seed:
       +post-hook: "{{ the_tuva_project.load_seed('tuva-public-resources/versioned_ci_testing_data/0.15.0','eligibility.csv',headers=true) }}"
     immunization_seed:
-      +post-hook: "{{ the_tuva_project.load_seed('tuva-public-resources/versioned_tuva_synthetic_data/0.15.0','immunization.csv',headers=true) }}"
+      +post-hook: "{{ the_tuva_project.load_seed('tuva-public-resources/versioned_ci_testing_data/0.15.0','immunization.csv',headers=true) }}"
     lab_result_seed:
       +post-hook: "{{ the_tuva_project.load_seed('tuva-public-resources/versioned_ci_testing_data/0.15.0','lab_result.csv',headers=true) }}"
     medical_claim_seed:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -77,23 +77,23 @@ seeds:
   the_tuva_project:
     clinical_concept_library:
       clinical_concept_library__clinical_concepts:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','tuva_clinical_concepts.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','tuva_clinical_concepts.csv',compression=true,null_marker=true) }}"
       clinical_concept_library__coding_systems:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','tuva_coding_systems.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','tuva_coding_systems.csv',compression=true,null_marker=true) }}"
       clinical_concept_library__value_set_members:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','tuva_value_set_members.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','tuva_value_set_members.csv',compression=true,null_marker=true) }}"
 
     reference_data:
       reference_data__code_type:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','code_type.csv',compression=true,null_marker=true) }}"
       reference_data__ansi_fips_state:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','ansi_fips_state.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','ansi_fips_state.csv',compression=true,null_marker=true) }}"
       reference_data__calendar:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','calendar.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','calendar.csv',compression=true,null_marker=true) }}"
       reference_data__fips_county:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','fips_county.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','fips_county.csv',compression=true,null_marker=true) }}"
       reference_data__ssa_fips_state:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','ssa_fips_state.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','ssa_fips_state.csv',compression=true,null_marker=true) }}"
       reference_data__svi_us_county:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/reference-data/SVI','SVI_US_county.csv',compression=true,null_marker=true) }}"
       reference_data__svi_us:
@@ -103,9 +103,9 @@ seeds:
       terminology__act_site:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','act_site.csv',compression=true,null_marker=true) }}"
       terminology__admit_source:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','admit_source.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','admit_source.csv',compression=true,null_marker=true) }}"
       terminology__admit_type:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','admit_type.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','admit_type.csv',compression=true,null_marker=true) }}"
       terminology__appointment_cancellation_reason:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','appointment_cancellation_reason.csv',compression=true,null_marker=true) }}"
       terminology__appointment_status:
@@ -113,37 +113,37 @@ seeds:
       terminology__appointment_type:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','appointment_type.csv',compression=true,null_marker=true) }}"
       terminology__apr_drg:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','apr_drg.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','apr_drg.csv',compression=true,null_marker=true) }}"
       terminology__bill_type:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','bill_type.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','bill_type.csv',compression=true,null_marker=true) }}"
       terminology__claim_type:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','claim_type.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','claim_type.csv',compression=true,null_marker=true) }}"
       terminology__cvx:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','cvx.csv',compression=true,null_marker=true) }}"
       terminology__ccs_services_procedures:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','ccs_services_procedures.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','ccs_services_procedures.csv',compression=true,null_marker=true) }}"
       terminology__discharge_disposition:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','discharge_disposition.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','discharge_disposition.csv',compression=true,null_marker=true) }}"
       terminology__encounter_type:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','encounter_type.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','encounter_type.csv',compression=true,null_marker=true) }}"
       terminology__ethnicity:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','ethnicity.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','ethnicity.csv',compression=true,null_marker=true) }}"
       terminology__gender:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','gender.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','gender.csv',compression=true,null_marker=true) }}"
       terminology__hcpcs_level_2:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','hcpcs_level_2.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','hcpcs_level_2.csv',compression=true,null_marker=true) }}"
       terminology__hcpcs_to_rbcs:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','hcpcs_to_rbcs.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','hcpcs_to_rbcs.csv',compression=true,null_marker=true) }}"
       terminology__icd_10_cm:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','icd_10_cm.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','icd_10_cm.csv',compression=true,null_marker=true) }}"
       terminology__icd_10_pcs:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','icd_10_pcs.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','icd_10_pcs.csv',compression=true,null_marker=true) }}"
       terminology__icd10_pcs_cms_ontology:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','icd_10_pcs_cms_ontology.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','icd_10_pcs_cms_ontology.csv',compression=true,null_marker=true) }}"
       terminology__icd_9_cm:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','icd_9_cm.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','icd_9_cm.csv',compression=true,null_marker=true) }}"
       terminology__icd_9_pcs:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','icd_9_pcs.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','icd_9_pcs.csv',compression=true,null_marker=true) }}"
       terminology__immunization_route_code:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','immunization_route_code.csv',compression=true,null_marker=true) }}"
       terminology__immunization_status_reason:
@@ -151,146 +151,146 @@ seeds:
       terminology__immunization_status:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','immunization_status.csv',compression=true,null_marker=true) }}"
       terminology__loinc:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','loinc.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','loinc.csv',compression=true,null_marker=true) }}"
       terminology__loinc_deprecated_mapping:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','loinc_deprecated_mapping.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','loinc_deprecated_mapping.csv',compression=true,null_marker=true) }}"
       terminology__mdc:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','mdc.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','mdc.csv',compression=true,null_marker=true) }}"
       terminology__medicare_dual_eligibility:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','medicare_dual_eligibility.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','medicare_dual_eligibility.csv',compression=true,null_marker=true) }}"
       terminology__medicare_orec:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','medicare_orec.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','medicare_orec.csv',compression=true,null_marker=true) }}"
       terminology__medicare_status:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','medicare_status.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','medicare_status.csv',compression=true,null_marker=true) }}"
       terminology__ms_drg_weights_los:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','ms_drg_weights_los.csv',compression=true,null_marker=true) }}"
       terminology__ms_drg:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','ms_drg.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','ms_drg.csv',compression=true,null_marker=true) }}"
       terminology__ndc:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','ndc.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','ndc.csv',compression=true,null_marker=true) }}"
       terminology__nitos:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','nitos.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','nitos.csv',compression=true,null_marker=true) }}"
       terminology__observation_type:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','observation_type.csv',compression=true,null_marker=true) }}"
       terminology__other_provider_taxonomy:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.14.18','other_provider_taxonomy.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.15.0','other_provider_taxonomy.csv',compression=true,null_marker=true) }}"
       terminology__payer_type:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','payer_type.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','payer_type.csv',compression=true,null_marker=true) }}"
       terminology__place_of_service:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','place_of_service.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','place_of_service.csv',compression=true,null_marker=true) }}"
       terminology__present_on_admission:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','present_on_admission.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','present_on_admission.csv',compression=true,null_marker=true) }}"
       terminology__provider:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.14.18','provider.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.15.0','provider.csv',compression=true,null_marker=true) }}"
       terminology__race:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','race.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','race.csv',compression=true,null_marker=true) }}"
       terminology__revenue_center:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','revenue_center.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','revenue_center.csv',compression=true,null_marker=true) }}"
       terminology__rxnorm_to_atc:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','rxnorm_to_atc.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','rxnorm_to_atc.csv',compression=true,null_marker=true) }}"
       terminology__rxnorm_brand_generic:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','rxnorm_brand_generic.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','rxnorm_brand_generic.csv',compression=true,null_marker=true) }}"
       terminology__snomed_ct:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','snomed_ct.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','snomed_ct.csv',compression=true,null_marker=true) }}"
       terminology__snomed_ct_transitive_closures:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','snomed_ct_transitive_closures.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','snomed_ct_transitive_closures.csv',compression=true,null_marker=true) }}"
       terminology__snomed_icd_10_map:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.14.18','snomed_icd_10_map.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','snomed_icd_10_map.csv',compression=true,null_marker=true) }}"
 
     value_sets:
       ccsr:
         ccsr__dxccsr_v2023_1_body_systems:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','dxccsr_v2023_1_body_systems.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','dxccsr_v2023_1_body_systems.csv',compression=true,null_marker=true) }}"
         ccsr__dxccsr_v2023_1_cleaned_map:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','dxccsr_v2023_1_cleaned_map.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','dxccsr_v2023_1_cleaned_map.csv',compression=true,null_marker=true) }}"
         ccsr__prccsr_v2023_1_cleaned_map:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','prccsr_v2023_1_cleaned_map.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','prccsr_v2023_1_cleaned_map.csv',compression=true,null_marker=true) }}"
       chronic_conditions:
         chronic_conditions__cms_chronic_conditions_hierarchy:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_chronic_conditions_hierarchy.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_chronic_conditions_hierarchy.csv',compression=true,null_marker=true) }}"
         chronic_conditions__tuva_chronic_conditions_hierarchy:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','tuva_chronic_conditions_hierarchy.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','tuva_chronic_conditions_hierarchy.csv',compression=true,null_marker=true) }}"
       cms_hcc:
         cms_hcc__adjustment_rates:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_adjustment_rates.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_adjustment_rates.csv',compression=true,null_marker=true) }}"
         cms_hcc__cpt_hcpcs:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_cpt_hcpcs.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_cpt_hcpcs.csv',compression=true,null_marker=true) }}"
         cms_hcc__demographic_factors:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_demographic_factors.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_demographic_factors.csv',compression=true,null_marker=true) }}"
         cms_hcc__disabled_interaction_factors:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_disabled_interaction_factors.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_disabled_interaction_factors.csv',compression=true,null_marker=true) }}"
         cms_hcc__disease_factors:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_disease_factors.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_disease_factors.csv',compression=true,null_marker=true) }}"
         cms_hcc__disease_hierarchy:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_disease_hierarchy.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_disease_hierarchy.csv',compression=true,null_marker=true) }}"
         cms_hcc__disease_interaction_factors:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_disease_interaction_factors.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_disease_interaction_factors.csv',compression=true,null_marker=true) }}"
         cms_hcc__enrollment_interaction_factors:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_enrollment_interaction_factors.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_enrollment_interaction_factors.csv',compression=true,null_marker=true) }}"
         cms_hcc__icd_10_cm_mappings:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_icd_10_cm_mappings.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_icd_10_cm_mappings.csv',compression=true,null_marker=true) }}"
         cms_hcc__payment_hcc_count_factors:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','cms_hcc_payment_hcc_count_factors.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','cms_hcc_payment_hcc_count_factors.csv',compression=true,null_marker=true) }}"
       data_quality:
         data_quality__crosswalk_field_info:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','data_quality_crosswalk_field_info.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','data_quality_crosswalk_field_info.csv',compression=true,null_marker=true) }}"
         data_quality__crosswalk_field_to_mart:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','data_quality_crosswalk_field_to_mart.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','data_quality_crosswalk_field_to_mart.csv',compression=true,null_marker=true) }}"
         data_quality__crosswalk_mart_to_outcome_measure:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','data_quality_crosswalk_mart_to_outcome_measure.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','data_quality_crosswalk_mart_to_outcome_measure.csv',compression=true,null_marker=true) }}"
         data_quality__crosswalk_measure_reasonable_ranges:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','data_quality_crosswalk_measure_reasonable_ranges.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','data_quality_crosswalk_measure_reasonable_ranges.csv',compression=true,null_marker=true) }}"
         data_quality__reference_mart_analytics:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','data_quality_reference_mart_analytics.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','data_quality_reference_mart_analytics.csv',compression=true,null_marker=true) }}"
       ed_classification:
         ed_classification__categories:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','ed_classification_categories.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','ed_classification_categories.csv',compression=true,null_marker=true) }}"
         ed_classification__icd_10_cm_to_ccs:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','icd_10_cm_to_ccs.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','icd_10_cm_to_ccs.csv',compression=true,null_marker=true) }}"
         ed_classification__johnston_icd10:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','johnston_icd10.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','johnston_icd10.csv',compression=true,null_marker=true) }}"
         ed_classification__johnston_icd9:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','johnston_icd9.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','johnston_icd9.csv',compression=true,null_marker=true) }}"
       hcc_suspecting:
         hcc_suspecting__clinical_concepts:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','hcc_suspecting_clinical_concepts.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','hcc_suspecting_clinical_concepts.csv',compression=true,null_marker=true) }}"
         hcc_suspecting__hcc_descriptions:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','hcc_suspecting_descriptions.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','hcc_suspecting_descriptions.csv',compression=true,null_marker=true) }}"
         hcc_suspecting__icd_10_cm_mappings:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','hcc_suspecting_icd_10_cm_mappings.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','hcc_suspecting_icd_10_cm_mappings.csv',compression=true,null_marker=true) }}"
       pharmacy:
         pharmacy__rxnorm_generic_available:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','rxnorm_generic_available.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','rxnorm_generic_available.csv',compression=true,null_marker=true) }}"
       quality_measures:
         quality_measures__concepts:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','quality_measures_concepts.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','quality_measures_concepts.csv',compression=true,null_marker=true) }}"
         quality_measures__measures:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','quality_measures_measures.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','quality_measures_measures.csv',compression=true,null_marker=true) }}"
         quality_measures__value_sets:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','quality_measures_value_set_codes.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','quality_measures_value_set_codes.csv',compression=true,null_marker=true) }}"
       readmissions:
         readmissions__acute_diagnosis_ccs:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','acute_diagnosis_ccs.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','acute_diagnosis_ccs.csv',compression=true,null_marker=true) }}"
         readmissions__acute_diagnosis_icd_10_cm:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','acute_diagnosis_icd_10_cm.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','acute_diagnosis_icd_10_cm.csv',compression=true,null_marker=true) }}"
         readmissions__always_planned_ccs_diagnosis_category:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','always_planned_ccs_diagnosis_category.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','always_planned_ccs_diagnosis_category.csv',compression=true,null_marker=true) }}"
         readmissions__always_planned_ccs_procedure_category:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','always_planned_ccs_procedure_category.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','always_planned_ccs_procedure_category.csv',compression=true,null_marker=true) }}"
         readmissions__exclusion_ccs_diagnosis_category:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','exclusion_ccs_diagnosis_category.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','exclusion_ccs_diagnosis_category.csv',compression=true,null_marker=true) }}"
         readmissions__icd_10_cm_to_ccs:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','icd_10_cm_to_ccs.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','icd_10_cm_to_ccs.csv',compression=true,null_marker=true) }}"
         readmissions__icd_10_pcs_to_ccs:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','icd_10_pcs_to_ccs.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','icd_10_pcs_to_ccs.csv',compression=true,null_marker=true) }}"
         readmissions__potentially_planned_ccs_procedure_category:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','potentially_planned_ccs_procedure_category.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','potentially_planned_ccs_procedure_category.csv',compression=true,null_marker=true) }}"
         readmissions__potentially_planned_icd_10_pcs:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','potentially_planned_icd_10_pcs.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','potentially_planned_icd_10_pcs.csv',compression=true,null_marker=true) }}"
         readmissions__specialty_cohort:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','specialty_cohort.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','specialty_cohort.csv',compression=true,null_marker=true) }}"
         readmissions__surgery_gynecology_cohort:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','surgery_gynecology_cohort.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','surgery_gynecology_cohort.csv',compression=true,null_marker=true) }}"
       service_categories:
         service_category__service_categories:
-          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.14.18','service_category__service_categories.csv',compression=true,null_marker=true) }}"
+          +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_value_sets/0.15.0','service_category__service_categories.csv',compression=true,null_marker=true) }}"


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

* Updates seed paths for 0.15 release for remaining seeds not updated in minor-release-v0.15 branch.
* Fixes issues with docs-generate workflow.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Data**
  * Bundled reference datasets (clinical concepts, terminology, value sets, related reference data) updated to v0.15.0.

* **Chores**
  * Seed configuration standardized to point at the new dataset release without changing file names or options.
  * CI tooling upgraded to a newer dbt-core release; automated builds now run with full-refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->