### PR TITLE
[Bug] Add missing eligibility fields for docs

### DIFF
--- a/integration_tests/docs_generate/models/_models.yml
+++ b/integration_tests/docs_generate/models/_models.yml
@@ -64,8 +64,12 @@ models:
         description: '{{ doc("group_id") }}'
       - name: group_name
         description: '{{ doc("group_name") }}'
+      - name: name_suffix
+        description: '{{ doc("name_suffix") }}'
       - name: first_name
         description: '{{ doc("first_name") }}'
+      - name: middle_name
+        description: '{{ doc("middle_name") }}'
       - name: last_name
         description: '{{ doc("last_name") }}'
       - name: social_security_number
@@ -82,6 +86,10 @@ models:
         description: '{{ doc("zip_code") }}'
       - name: phone
         description: '{{ doc("phone") }}'
+      - name: email
+        description: '{{ doc("email") }}'
+      - name: ethnicity
+        description: '{{ doc("ethnicity") }}'
       - name: data_source
         description: '{{ doc("data_source") }}'
       - name: file_name

--- a/integration_tests/docs_generate/models/eligibility.sql
+++ b/integration_tests/docs_generate/models/eligibility.sql
@@ -17,7 +17,9 @@ select
     , medicare_status_code
     , group_id
     , group_name
+    , name_suffix
     , first_name
+    , middle_name
     , last_name
     , social_security_number
     , subscriber_relation
@@ -26,6 +28,8 @@ select
     , state
     , zip_code
     , phone
+    , email
+    , ethnicity
     , data_source
     , file_name
     , file_date


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.

Add missing eligibility fields for docs:
* integration_tests/docs_generate/models/_models.yml
* integration_tests/docs_generate/models/eligibility.sql

Following changes from PR #1032  

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

Ran `dbt build --full-refresh` from the /integration_tests/docs_generate path.

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
