### PR TITLE
fix: renamed the seed column names

### DIFF
--- a/ci_testing/seeds/_seeds.yml
+++ b/ci_testing/seeds/_seeds.yml
@@ -54,11 +54,11 @@ seeds:
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         normalized_reason_description: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
-        cancellation_reason	varchar: |
+        cancellation_reason: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         source_cancellation_reason_code_type: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
-        source_cancellation_reason_code	varchar: |
+        source_cancellation_reason_code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         source_cancellation_reason_description: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}

--- a/integration_tests/seeds/_seeds.yml
+++ b/integration_tests/seeds/_seeds.yml
@@ -54,11 +54,11 @@ seeds:
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         normalized_reason_description: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
-        cancellation_reason	varchar: |
+        cancellation_reason: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         source_cancellation_reason_code_type: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
-        source_cancellation_reason_code	varchar: |
+        source_cancellation_reason_code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         source_cancellation_reason_description: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}


### PR DESCRIPTION
## Describe your changes
- The column naming convention for `appointment_seed` has been updated mentioned
  - `cancellation_reason varchar` to `cancellation_reason`
  - `source_cancellation_reason_code varchar` to `source_cancellation_reason_code`

## How has this been tested?
- The updates has been tested using dbt command `dbt seed` across: `Snowflake`, `RedShift`, `BigQuery`, and `Microsoft Fabric` 


## Reviewer focus
- Please focus on the updated column names for appointment seed in [_seed.yml](https://github.com/tuva-health/tuva/blob/main/ci_testing/seeds/_seeds.yml)


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
