### PR TITLE
Bug/undocumented fields in encounter table

### DIFF
--- a/dbt_doc_blocks/column_descriptions.md
+++ b/dbt_doc_blocks/column_descriptions.md
@@ -1,5 +1,5 @@
 {% docs _dbt_source_relation %}
-Indicates if the encounter is claim or clinical.
+dbt utils metadata column to indicate the source table from unioning tables together.
 {% enddocs %}
 
 {% docs accession_number %}

--- a/dbt_doc_blocks/column_descriptions.md
+++ b/dbt_doc_blocks/column_descriptions.md
@@ -1,3 +1,7 @@
+{% docs _dbt_source_relation %}
+Indicates if the encounter is claim or clinical.
+{% enddocs %}
+
 {% docs accession_number %}
 The lab order number from the source system.
 {% enddocs %}
@@ -1036,6 +1040,10 @@ The number of units for the particular revenue center code.
 
 {% docs sex %}
 The gender of the patient.
+{% enddocs %}
+
+{% docs snf_part_b_flag %}
+Indicates whether the inpatient medical service for Medicare covers under Part B or not. (1 for yes and 0 for no)
 {% enddocs %}
 
 {% docs social_security_number %}

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -293,6 +293,8 @@ models:
         - encounters
       materialized: table
     columns:
+    - name: _dbt_source_relation
+      description: '{{ doc("_dbt_source_relation") }}'
     - name: encounter_id
       description: '{{ doc("encounter_id") }}'
       tests:
@@ -363,6 +365,8 @@ models:
       description: '{{ doc("newborn_flag") }}'
     - name: nicu_flag
       description: '{{ doc("nicu_flag") }}'
+    - name: snf_part_b_flag
+      description: '{{ doc("snf_part_b_flag") }}'
     - name: primary_diagnosis_code_type
       description: '{{ doc("primary_diagnosis_code_type") }}'
       meta:


### PR DESCRIPTION
## Describe your changes
- The undocumented fields `_dbt_source_relation` and `snf_part_b_flag` added in yml file.
- Description for undocumented fields added in `dbt_doc_blocks` 


## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two columns to the encounter model: _dbt_source_relation (identifies claim vs. clinical encounters) and snf_part_b_flag (indicates if inpatient Medicare service is under Part B; 1=yes, 0=no).

- Documentation
  - Added user-facing documentation for the new columns, clarifying meanings and valid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->