### PR TITLE
 Enhancement/dbt cloud deprecation warnings

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -15,7 +15,7 @@ models:
     # enabled: "{{ target.name in ['prod','analytics'] }}"
 
 flags:
-  require_explicit_package_overrides_for_builtin_materializations: false # Needed for Elementary
+  require_explicit_package_overrides_for_builtin_materializations: true # Needed for Elementary
 
 vars:
     ## CCSR data mart vars


### PR DESCRIPTION
## Describe your changes
- The `require_explicit_package_overrides_for_builtin_materializations` has been set to `true`


## How has this been tested?
This has been tested using dbt command: `dbt build` across multiple Datawarehouse: `Snowflake`, `RedShift`, `BigQuery`, and `Microsoft Fabric`.


## Reviewer focus
Please focus on change on `dbt_project.yml` file and its underlying dependencies. 
According to our findings, as all the dbt materialization like `table`, `view`, `incremental` are specified in model config itself rather than in the model SQL file itself, no any macros are needed.  


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
