### PR TITLE
Provider Terminology data update - September

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -173,7 +173,7 @@ seeds:
       terminology__observation_type:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','observation_type.csv',compression=true,null_marker=true) }}"
       terminology__other_provider_taxonomy:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.15.0','other_provider_taxonomy.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.15.1','other_provider_taxonomy.csv',compression=true,null_marker=true) }}"
       terminology__payer_type:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','payer_type.csv',compression=true,null_marker=true) }}"
       terminology__place_of_service:
@@ -181,7 +181,7 @@ seeds:
       terminology__present_on_admission:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','present_on_admission.csv',compression=true,null_marker=true) }}"
       terminology__provider:
-        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.15.0','provider.csv',compression=true,null_marker=true) }}"
+        +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_provider_data/0.15.1','provider.csv',compression=true,null_marker=true) }}"
       terminology__race:
         +post-hook: "{{ load_seed(var('custom_bucket_name','tuva-public-resources') ~ '/versioned_terminology/0.15.0','race.csv',compression=true,null_marker=true) }}"
       terminology__revenue_center:


### PR DESCRIPTION
## Describe your changes
NPPES September data has been processed and seeds have been unloaded to S3.


## How has this been tested?
Ran `dbt seed`


## Reviewer focus
Please sync new seed before merging this PR from s3://tuva-public-resources-snowflake/versioned_provider_data/ to s3://tuva-public-resources/versioned_provider_data/0.15.1/ and kickoff CI tests.


## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Refreshed provider terminology reference data to version 0.15.1 (from 0.15.0).
  - Ensures the latest provider and taxonomy values are available in downstream builds and reports.
  - No functional or interface changes; this is a data version update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->