### PR TITLE
Databricks VARCHAR Data Type issue fix

### DIFF
--- a/integration_tests/seeds/_seeds.yml
+++ b/integration_tests/seeds/_seeds.yml
@@ -26,9 +26,9 @@ seeds:
         normalized_appointment_type_description: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         start_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
         end_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
         duration: integer
         location_id: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
@@ -73,7 +73,7 @@ seeds:
         file_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         ingest_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
 
   - name: eligibility_seed
     config:
@@ -146,7 +146,7 @@ seeds:
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         file_date: date
         ingest_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
 
   - name: immunization_seed
     config:
@@ -200,7 +200,7 @@ seeds:
         file_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         ingest_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
         
   - name: lab_result_seed
     config:
@@ -249,9 +249,9 @@ seeds:
         result: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         result_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
         collection_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
         source_units: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         normalized_units: |
@@ -275,7 +275,7 @@ seeds:
         file_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         ingest_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
         tuva_last_run: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
 
@@ -347,19 +347,19 @@ seeds:
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         paid_date: date
         paid_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         allowed_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         charge_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         coinsurance_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         copayment_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         deductible_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         total_cost_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         diagnosis_code_type: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_1: |
@@ -546,7 +546,7 @@ seeds:
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         file_date: date
         ingest_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
 
   - name: observation_seed
     config:
@@ -600,7 +600,7 @@ seeds:
         file_name: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         ingest_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
 
   - name: pharmacy_claim_seed
     config:
@@ -633,17 +633,17 @@ seeds:
         refills: integer
         paid_date: date
         paid_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         allowed_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         charge_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         coinsurance_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         copayment_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         deductible_amount: |
-          {%- if target.type in ("athena") -%} real {%- else -%} float {%- endif -%}
+          {%- if target.type in ("athena", "databricks") -%} real {%- else -%} float {%- endif -%}
         in_network_flag: integer
         data_source: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
@@ -651,7 +651,7 @@ seeds:
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         file_date: date
         ingest_datetime: |
-          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena") -%} timestamp {%- else -%} datetime {%- endif -%}
+          {%- if target.type in ("fabric") -%} datetime2(0) {%- elif target.type in ("athena", "databricks") -%} timestamp {%- else -%} datetime {%- endif -%}
 
   - name: provider_attribution_seed
     config:

--- a/macros/cross_database_utils/varchar.sql
+++ b/macros/cross_database_utils/varchar.sql
@@ -1,0 +1,11 @@
+{% macro varchar() -%}
+    {{ adapter.dispatch('varchar')() }}
+{%- endmacro %}
+
+{% macro default__varchar() -%}
+    VARCHAR
+{%- endmacro %}
+
+{% macro databricks__varchar() -%}
+    VARCHAR(255)
+{%- endmacro %}

--- a/models/data_quality/data_quality__exploratory_charts.sql
+++ b/models/data_quality/data_quality__exploratory_charts.sql
@@ -23,25 +23,25 @@ with medical_paid_amount_vs_end_date_matrix as (
          , cast(date_trunc(ilmc.paid_date, MONTH) as STRING)        as x_axis
          , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)    as chart_filter
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('month', ilmc.paid_date) as VARCHAR)      as x_axis
-         , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('month', ilmc.paid_date) as {{ varchar() }})      as x_axis
+         , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)    as y_axis
-         , cast(datetrunc(month, ilmc.paid_date) as VARCHAR)         as x_axis
-         , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)     as chart_filter
+         , cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})    as y_axis
+         , cast(datetrunc(month, ilmc.paid_date) as {{ varchar() }})         as x_axis
+         , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})     as chart_filter
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)      as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})      as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)      as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})      as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as chart_filter
          {% endif %}
          , sum(ilmc.paid_amount) as value
 
@@ -52,25 +52,25 @@ with medical_paid_amount_vs_end_date_matrix as (
            , cast(date_trunc(ilmc.paid_date, MONTH) as STRING)
            , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('month', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('month', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)
-           , cast(datetrunc(month, ilmc.paid_date) as VARCHAR)
-           , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)
+           cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})
+           , cast(datetrunc(month, ilmc.paid_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -88,25 +88,25 @@ with medical_paid_amount_vs_end_date_matrix as (
          , cast(date_trunc(ilmc.paid_date, MONTH) as STRING)        as x_axis
          , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)    as chart_filter
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('month', ilmc.paid_date) as VARCHAR)      as x_axis
-         , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('month', ilmc.paid_date) as {{ varchar() }})      as x_axis
+         , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)    as y_axis
-         , cast(datetrunc(month, ilmc.paid_date) as VARCHAR)         as x_axis
-         , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)     as chart_filter
+         , cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})    as y_axis
+         , cast(datetrunc(month, ilmc.paid_date) as {{ varchar() }})         as x_axis
+         , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})     as chart_filter
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)      as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})      as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)      as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})      as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as chart_filter
          {% endif %}
          , count(distinct ilmc.claim_id) as value
 
@@ -117,25 +117,25 @@ with medical_paid_amount_vs_end_date_matrix as (
            , cast(date_trunc(ilmc.paid_date, MONTH) as STRING)
            , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('month', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('month', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)
-           , cast(datetrunc(month, ilmc.paid_date) as VARCHAR)
-           , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)
+           cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})
+           , cast(datetrunc(month, ilmc.paid_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilmc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilmc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -150,26 +150,26 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilmc.claim_end_date, MONTH) as STRING)   as x_axis
          , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)    as chart_filter
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)    as x_axis
-         , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)     as chart_filter
+         , cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})    as x_axis
+         , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})     as chart_filter
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as chart_filter
          {% endif %}
          , sum(ilmc.paid_amount) as value
 
@@ -179,20 +179,20 @@ with medical_paid_amount_vs_end_date_matrix as (
            cast(date_trunc(ilmc.claim_end_date, MONTH) as STRING)
            , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)
-           , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)
+           cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -207,25 +207,25 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)   as x_axis
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR) as x_axis
+         , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)    as x_axis
+         , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})    as x_axis
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as chart_filter
          {% else %}
-         , cast(null as VARCHAR) as chart_filter
+         , cast(null as {{ varchar() }}) as chart_filter
          {% endif %}
          , sum(ilmc.paid_amount) as value
 
@@ -234,15 +234,15 @@ with medical_paid_amount_vs_end_date_matrix as (
     group by {% if target.type == 'bigquery' %}
            cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)
+           cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -257,31 +257,31 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilmc.claim_end_date, MONTH) as STRING)   as x_axis
          , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)    as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)    as x_axis
-         , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)     as chart_filter
+         , cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})    as x_axis
+         , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})     as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          , cast(count(distinct ilmc.claim_id) as DOUBLE) as value
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})  as chart_filter
          , cast(count(distinct ilmc.claim_id) as DECIMAL) as value
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% endif %}
 
@@ -291,20 +291,20 @@ with medical_paid_amount_vs_end_date_matrix as (
            cast(date_trunc(ilmc.claim_end_date, MONTH) as STRING)
            , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('month', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilmc.claim_end_date) as VARCHAR)
-           , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)
+           cast(datetrunc(month, ilmc.claim_end_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilmc.claim_end_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_end_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -319,31 +319,31 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)   as x_axis
          , cast(NULL as STRING)                      as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(NULL as VARCHAR)                      as chart_filter
+         , cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(NULL as {{ varchar() }})                      as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)    as x_axis
-         , cast(NULL as VARCHAR)             as chart_filter
+         , cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})    as x_axis
+         , cast(NULL as {{ varchar() }})             as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(NULL as VARCHAR)                      as chart_filter
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(NULL as {{ varchar() }})                      as chart_filter
          , cast(count(distinct ilmc.claim_id) as DOUBLE) as value
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(NULL as VARCHAR)                      as chart_filter
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(NULL as {{ varchar() }})                      as chart_filter
          , cast(count(distinct ilmc.claim_id) as DECIMAL) as value
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR) as x_axis
-         , cast(null as VARCHAR) as chart_filter
+         , cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }}) as x_axis
+         , cast(null as {{ varchar() }}) as chart_filter
          , cast(count(distinct ilmc.claim_id) as NUMERIC) as value
          {% endif %}
 
@@ -352,15 +352,15 @@ with medical_paid_amount_vs_end_date_matrix as (
     group by {% if target.type == 'bigquery' %}
            cast(date_trunc(ilmc.claim_end_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('year', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('year', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(year, ilmc.claim_end_date) as VARCHAR)
+           cast(datetrunc(year, ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('YEAR', ilmc.claim_end_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilmc.claim_end_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -379,25 +379,25 @@ with medical_paid_amount_vs_end_date_matrix as (
          , cast(date_trunc(ilpc.paid_date, MONTH) as STRING)                as x_axis
          , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)           as chart_filter
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR)        as y_axis
-         , cast(date_trunc('month', ilpc.paid_date) as VARCHAR)              as x_axis
-         , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)         as chart_filter
+         , cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }})        as y_axis
+         , cast(date_trunc('month', ilpc.paid_date) as {{ varchar() }})              as x_axis
+         , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})         as chart_filter
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)           as y_axis
-         , cast(datetrunc(month, ilpc.paid_date) as VARCHAR)                 as x_axis
-         , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)            as chart_filter
+         , cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})           as y_axis
+         , cast(datetrunc(month, ilpc.paid_date) as {{ varchar() }})                 as x_axis
+         , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})            as chart_filter
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)        as y_axis
-         , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)              as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)         as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})        as y_axis
+         , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})              as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})         as chart_filter
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)        as y_axis
-         , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)              as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)         as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})        as y_axis
+         , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})              as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})         as chart_filter
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as chart_filter
          {% endif %}
          , sum(ilpc.paid_amount) as value
 
@@ -408,25 +408,25 @@ with medical_paid_amount_vs_end_date_matrix as (
            , cast(date_trunc(ilpc.paid_date, MONTH) as STRING)
            , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('month', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('month', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)
-           , cast(datetrunc(month, ilpc.paid_date) as VARCHAR)
-           , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)
+           cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})
+           , cast(datetrunc(month, ilpc.paid_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -444,25 +444,25 @@ with medical_paid_amount_vs_end_date_matrix as (
          , cast(date_trunc(ilpc.paid_date, MONTH) as STRING)                as x_axis
          , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)           as chart_filter
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR)        as y_axis
-         , cast(date_trunc('month', ilpc.paid_date) as VARCHAR)              as x_axis
-         , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)         as chart_filter
+         , cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }})        as y_axis
+         , cast(date_trunc('month', ilpc.paid_date) as {{ varchar() }})              as x_axis
+         , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})         as chart_filter
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)           as y_axis
-         , cast(datetrunc(month, ilpc.paid_date) as VARCHAR)                 as x_axis
-         , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)            as chart_filter
+         , cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})           as y_axis
+         , cast(datetrunc(month, ilpc.paid_date) as {{ varchar() }})                 as x_axis
+         , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})            as chart_filter
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)        as y_axis
-         , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)              as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)         as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})        as y_axis
+         , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})              as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})         as chart_filter
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)        as y_axis
-         , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)              as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)         as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})        as y_axis
+         , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})              as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})         as chart_filter
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as y_axis
-         , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as y_axis
+         , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as chart_filter
          {% endif %}
          , count(distinct ilpc.claim_id) as value
 
@@ -473,25 +473,25 @@ with medical_paid_amount_vs_end_date_matrix as (
            , cast(date_trunc(ilpc.paid_date, MONTH) as STRING)
            , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('month', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('month', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)
-           , cast(datetrunc(month, ilpc.paid_date) as VARCHAR)
-           , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)
+           cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})
+           , cast(datetrunc(month, ilpc.paid_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('MONTH', ilpc.paid_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('MONTH', ilpc.paid_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -506,26 +506,26 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilpc.dispensing_date, MONTH) as STRING)   as x_axis
          , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)    as chart_filter
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)    as x_axis
-         , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)     as chart_filter
+         , cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})    as x_axis
+         , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})     as chart_filter
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})  as chart_filter
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})  as chart_filter
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as chart_filter
          {% endif %}
          , sum(ilpc.paid_amount) as value
 
@@ -535,20 +535,20 @@ with medical_paid_amount_vs_end_date_matrix as (
            cast(date_trunc(ilpc.dispensing_date, MONTH) as STRING)
            , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)
-           , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)
+           cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -563,25 +563,25 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)   as x_axis
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR) as x_axis
+         , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)    as x_axis
+         , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})    as x_axis
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as chart_filter
          {% else %}
-         , cast(null as VARCHAR) as chart_filter
+         , cast(null as {{ varchar() }}) as chart_filter
          {% endif %}
          , sum(ilpc.paid_amount) as value
 
@@ -590,16 +590,16 @@ with medical_paid_amount_vs_end_date_matrix as (
     group by {% if target.type == 'bigquery' %}
            cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)
-           , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)
+           cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -614,31 +614,31 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilpc.dispensing_date, MONTH) as STRING)   as x_axis
          , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)    as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})  as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)    as x_axis
-         , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)     as chart_filter
+         , cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})    as x_axis
+         , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})     as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})  as chart_filter
          , cast(count(distinct ilpc.claim_id) as DOUBLE) as value
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)  as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})  as chart_filter
          , cast(count(distinct ilpc.claim_id) as DECIMAL) as value
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% endif %}
 
@@ -648,20 +648,20 @@ with medical_paid_amount_vs_end_date_matrix as (
            cast(date_trunc(ilpc.dispensing_date, MONTH) as STRING)
            , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('month', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(month, ilpc.dispensing_date) as VARCHAR)
-           , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)
+           cast(datetrunc(month, ilpc.dispensing_date) as {{ varchar() }})
+           , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilpc.dispensing_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilpc.dispensing_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -676,31 +676,31 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)   as x_axis
          , cast(NULL as STRING)                       as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(NULL as VARCHAR)                       as chart_filter
+         , cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(NULL as {{ varchar() }})                       as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)    as x_axis
-         , cast(NULL as VARCHAR)                       as chart_filter
+         , cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})    as x_axis
+         , cast(NULL as {{ varchar() }})                       as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(NULL as VARCHAR)                      as chart_filter
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(NULL as {{ varchar() }})                      as chart_filter
          , cast(count(distinct ilpc.claim_id) as DOUBLE) as value
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(NULL as VARCHAR)                       as chart_filter
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(NULL as {{ varchar() }})                       as chart_filter
          , cast(count(distinct ilpc.claim_id) as DECIMAL) as value
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR) as x_axis
-         , cast(null as VARCHAR) as chart_filter
+         , cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }}) as x_axis
+         , cast(null as {{ varchar() }}) as chart_filter
          , cast(count(distinct ilpc.claim_id) as NUMERIC) as value
          {% endif %}
 
@@ -709,15 +709,15 @@ with medical_paid_amount_vs_end_date_matrix as (
     group by {% if target.type == 'bigquery' %}
            cast(date_trunc(ilpc.dispensing_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('year', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('year', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'fabric' %}
-           cast(datetrunc(year, ilpc.dispensing_date) as VARCHAR)
+           cast(datetrunc(year, ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('YEAR', ilpc.dispensing_date) as VARCHAR)
+           cast(date_trunc('YEAR', ilpc.dispensing_date) as {{ varchar() }})
            {% endif %}
 )
 
@@ -731,32 +731,32 @@ with medical_paid_amount_vs_end_date_matrix as (
         'claim_start_date' as x_axis_description,
         'claim_year' as filter_description,
         'percentage_of_claims_with_eligibility' as sum_description,
-        cast(null as VARCHAR) as y_axis,
+        cast(null as {{ varchar() }}) as y_axis,
         total.claim_month as x_axis,
         total.claim_year as chart_filter,
         cast(coalesce(with_elig.claims_with_elig, 0) * 100.0 /
             nullif(total.total_claims, 0) as NUMERIC) as value
     from (
         select
-            cast(datetrunc(month, claim_start_date) as VARCHAR) as claim_month,
-            cast(datetrunc(year, claim_start_date) as VARCHAR) as claim_year,
+            cast(datetrunc(month, claim_start_date) as {{ varchar() }}) as claim_month,
+            cast(datetrunc(year, claim_start_date) as {{ varchar() }}) as claim_year,
             count(distinct claim_id) as total_claims
         from {{ ref('input_layer__medical_claim') }}
         group by
-            cast(datetrunc(month, claim_start_date) as VARCHAR),
-            cast(datetrunc(year, claim_start_date) as VARCHAR)
+            cast(datetrunc(month, claim_start_date) as {{ varchar() }}),
+            cast(datetrunc(year, claim_start_date) as {{ varchar() }})
     ) as total
     left join (
         select
-            cast(datetrunc(month, mc.claim_start_date) as VARCHAR) as claim_month,
-            cast(datetrunc(year, mc.claim_start_date) as VARCHAR) as claim_year,
+            cast(datetrunc(month, mc.claim_start_date) as {{ varchar() }}) as claim_month,
+            cast(datetrunc(year, mc.claim_start_date) as {{ varchar() }}) as claim_year,
             count(distinct mc.claim_id) as claims_with_elig
         from {{ ref('input_layer__medical_claim') }} as mc
         inner join {{ ref('input_layer__eligibility') }} as e
             on mc.person_id = e.person_id
         group by
-            cast(datetrunc(month, mc.claim_start_date) as VARCHAR),
-            cast(datetrunc(year, mc.claim_start_date) as VARCHAR)
+            cast(datetrunc(month, mc.claim_start_date) as {{ varchar() }}),
+            cast(datetrunc(year, mc.claim_start_date) as {{ varchar() }})
     ) as with_elig
     on total.claim_month = with_elig.claim_month
     and total.claim_year = with_elig.claim_year
@@ -773,17 +773,17 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as y_axis
          {% else %}
-         , cast(null as VARCHAR) as y_axis
+         , cast(null as {{ varchar() }}) as y_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(ilmc.claim_start_date, MONTH) as STRING) as x_axis
          , cast(date_trunc(ilmc.claim_start_date, YEAR) as STRING) as chart_filter
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('month', ilmc.claim_start_date) as VARCHAR) as x_axis
-         , cast(date_trunc('year', ilmc.claim_start_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('month', ilmc.claim_start_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('year', ilmc.claim_start_date) as {{ varchar() }}) as chart_filter
          {% else %} -- for databricks, athena, snowflake
-         , cast(date_trunc('MONTH', ilmc.claim_start_date) as VARCHAR) as x_axis
-         , cast(date_trunc('YEAR', ilmc.claim_start_date) as VARCHAR) as chart_filter
+         , cast(date_trunc('MONTH', ilmc.claim_start_date) as {{ varchar() }}) as x_axis
+         , cast(date_trunc('YEAR', ilmc.claim_start_date) as {{ varchar() }}) as chart_filter
          {% endif %}
          {% if target.type in ('bigquery', 'postgres', 'duckdb', 'snowflake', 'redshift') %}
          , cast(count(distinct case when ile.person_id is not null then ilmc.claim_id end) * 100.0 /
@@ -804,17 +804,17 @@ with medical_paid_amount_vs_end_date_matrix as (
            cast(date_trunc(ilmc.claim_start_date, MONTH) as STRING)
            , cast(date_trunc(ilmc.claim_start_date, YEAR) as STRING)
            {% elif target.type in ('postgres', 'duckdb') %}
-           cast(date_trunc('month', ilmc.claim_start_date) as VARCHAR)
-           , cast(date_trunc('year', ilmc.claim_start_date) as VARCHAR)
+           cast(date_trunc('month', ilmc.claim_start_date) as {{ varchar() }})
+           , cast(date_trunc('year', ilmc.claim_start_date) as {{ varchar() }})
            {% elif target.type == 'databricks' %}
-           cast(date_trunc('MONTH', ilmc.claim_start_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_start_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_start_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_start_date) as {{ varchar() }})
            {% elif target.type == 'athena' %}
-           cast(date_trunc('MONTH', ilmc.claim_start_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_start_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_start_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_start_date) as {{ varchar() }})
            {% else %} -- snowflake and redshift
-           cast(date_trunc('MONTH', ilmc.claim_start_date) as VARCHAR)
-           , cast(date_trunc('YEAR', ilmc.claim_start_date) as VARCHAR)
+           cast(date_trunc('MONTH', ilmc.claim_start_date) as {{ varchar() }})
+           , cast(date_trunc('YEAR', ilmc.claim_start_date) as {{ varchar() }})
            {% endif %}
 )
 {% endif %}
@@ -947,20 +947,20 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(acm.date_month, YEAR) as STRING) as x_axis
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('year', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('year', acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(year, acm.date_month) as VARCHAR) as x_axis
+         , cast(datetrunc(year, acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as chart_filter
          {% else %}
-         , cast(null as VARCHAR) as chart_filter
+         , cast(null as {{ varchar() }}) as chart_filter
          {% endif %}
          , cast(sum(acm.paid_amount) / nullif(tpy.total_yearly_paid, 0) * 100 as NUMERIC) as value
 
@@ -984,15 +984,15 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          cast(date_trunc(acm.date_month, YEAR) as STRING)
          {% elif target.type in ('postgres', 'duckdb') %}
-         cast(date_trunc('year', acm.date_month) as VARCHAR)
+         cast(date_trunc('year', acm.date_month) as {{ varchar() }})
          {% elif target.type == 'fabric' %}
-         cast(datetrunc(year, acm.date_month) as VARCHAR)
+         cast(datetrunc(year, acm.date_month) as {{ varchar() }})
          {% elif target.type == 'databricks' %}
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% elif target.type == 'athena' %}
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% else %} -- snowflake and redshift
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% endif %}
          , tpy.total_yearly_paid
 )
@@ -1009,20 +1009,20 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(acm.date_month, YEAR) as STRING) as x_axis
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('year', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('year', acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(year, acm.date_month) as VARCHAR) as x_axis
+         , cast(datetrunc(year, acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as chart_filter
          {% else %}
-         , cast(null as VARCHAR) as chart_filter
+         , cast(null as {{ varchar() }}) as chart_filter
          {% endif %}
          , cast(sum(acm.paid_amount) / nullif(tpy.total_yearly_paid, 0) * 100 as NUMERIC) as value
 
@@ -1046,15 +1046,15 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          cast(date_trunc(acm.date_month, YEAR) as STRING)
          {% elif target.type in ('postgres', 'duckdb') %}
-         cast(date_trunc('year', acm.date_month) as VARCHAR)
+         cast(date_trunc('year', acm.date_month) as {{ varchar() }})
          {% elif target.type == 'fabric' %}
-         cast(datetrunc(year, acm.date_month) as VARCHAR)
+         cast(datetrunc(year, acm.date_month) as {{ varchar() }})
          {% elif target.type == 'databricks' %}
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% elif target.type == 'athena' %}
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% else %} -- snowflake and redshift
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% endif %}
          , tpy.total_yearly_paid
 )
@@ -1071,20 +1071,20 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          , cast(date_trunc(acm.date_month, YEAR) as STRING) as x_axis
          {% elif target.type in ('postgres', 'duckdb') %}
-         , cast(date_trunc('year', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('year', acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'fabric' %}
-         , cast(datetrunc(year, acm.date_month) as VARCHAR) as x_axis
+         , cast(datetrunc(year, acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'databricks' %}
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% elif target.type == 'athena' %}
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% else %} -- snowflake and redshift
-         , cast(date_trunc('YEAR', acm.date_month) as VARCHAR) as x_axis
+         , cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }}) as x_axis
          {% endif %}
          {% if target.type == 'bigquery' %}
          , cast(null as STRING) as chart_filter
          {% else %}
-         , cast(null as VARCHAR) as chart_filter
+         , cast(null as {{ varchar() }}) as chart_filter
          {% endif %}
          , cast(sum(acm.paid_amount) / nullif(tpy.total_yearly_paid, 0) * 100 as NUMERIC) as value
 
@@ -1108,15 +1108,15 @@ with medical_paid_amount_vs_end_date_matrix as (
          {% if target.type == 'bigquery' %}
          cast(date_trunc(acm.date_month, YEAR) as STRING)
          {% elif target.type in ('postgres', 'duckdb') %}
-         cast(date_trunc('year', acm.date_month) as VARCHAR)
+         cast(date_trunc('year', acm.date_month) as {{ varchar() }})
          {% elif target.type == 'fabric' %}
-         cast(datetrunc(year, acm.date_month) as VARCHAR)
+         cast(datetrunc(year, acm.date_month) as {{ varchar() }})
          {% elif target.type == 'databricks' %}
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% elif target.type == 'athena' %}
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% else %} -- snowflake and redshift
-         cast(date_trunc('YEAR', acm.date_month) as VARCHAR)
+         cast(date_trunc('YEAR', acm.date_month) as {{ varchar() }})
          {% endif %}
          , tpy.total_yearly_paid
 )

--- a/models/hcc_suspecting/intermediate/hcc_suspecting__int_observation_suspects.sql
+++ b/models/hcc_suspecting/intermediate/hcc_suspecting__int_observation_suspects.sql
@@ -34,7 +34,8 @@ with conditions as (
     select
           person_id
         , observation_date
-        {% if target.type == 'fabric' or target.type == 'duckdb' %}
+        {# {% if target.type == 'fabric' or target.type == 'duckdb' %} #}
+        {% if target.type in ['fabric', 'duckdb', 'databricks'] %}
          , TRY_CAST(result AS {{ dbt.type_numeric() }}) AS result
         {% else %}
         , CAST(result as {{ dbt.type_numeric() }}) as result

--- a/tests/generic/test_warn_if_null_percentage_above_zero.sql
+++ b/tests/generic/test_warn_if_null_percentage_above_zero.sql
@@ -55,11 +55,11 @@ validation_errors AS (
         {% if target.type == 'bigquery' %}
             CAST(ROUND(null_percentage_raw, 2) AS STRING) AS null_percentage_formatted
         {% elif target.type == 'fabric' %}
-            CAST(CAST(ROUND(null_percentage_raw, 2) AS DECIMAL(5, 2)) AS VARCHAR) AS null_percentage_formatted
+            CAST(CAST(ROUND(null_percentage_raw, 2) AS DECIMAL(5, 2)) AS {{ varchar() }}) AS null_percentage_formatted
         {% elif target.type in ('databricks', 'duckdb', 'athena') %}
             CAST(CAST(ROUND(null_percentage_raw, 2) AS DECIMAL(5, 2)) AS STRING) AS null_percentage_formatted
         {% else %}
-            CAST(CAST(ROUND(null_percentage_raw, 2) AS DECIMAL(5, 2)) AS VARCHAR) AS null_percentage_formatted
+            CAST(CAST(ROUND(null_percentage_raw, 2) AS DECIMAL(5, 2)) AS {{ varchar() }}) AS null_percentage_formatted
         {% endif %}
     FROM calculation
 )
@@ -69,11 +69,11 @@ SELECT
     {% if target.type == 'bigquery' %}
         CONCAT('Column `{{ column_name }}` in model `{{ table_name }}` has ', null_percentage_formatted, '% NULL values (', CAST(null_rows AS STRING), '/', CAST(total_rows AS STRING), ' rows).') AS error_description,
     {% elif target.type == 'fabric' %}
-        CONCAT('Column `{{ column_name }}` in model `{{ table_name }}` has ', null_percentage_formatted, '% NULL values (', CAST(null_rows AS VARCHAR), '/', CAST(total_rows AS VARCHAR), ' rows).') AS error_description,
+        CONCAT('Column `{{ column_name }}` in model `{{ table_name }}` has ', null_percentage_formatted, '% NULL values (', CAST(null_rows AS {{ varchar() }}), '/', CAST(total_rows AS {{ varchar() }}), ' rows).') AS error_description,
     {% elif target.type in ('databricks', 'duckdb', 'athena', 'snowflake', 'redshift') %}
-        'Column `{{ column_name }}` in model `{{ table_name }}` has ' || null_percentage_formatted || '% NULL values (' || CAST(null_rows AS VARCHAR) || '/' || CAST(total_rows AS VARCHAR) || ' rows).' AS error_description,
+        'Column `{{ column_name }}` in model `{{ table_name }}` has ' || null_percentage_formatted || '% NULL values (' || CAST(null_rows AS {{ varchar() }}) || '/' || CAST(total_rows AS {{ varchar() }}) || ' rows).' AS error_description,
     {% else %}
-        'Column `{{ column_name }}` in model `{{ table_name }}` has ' || null_percentage_formatted || '% NULL values (' || CAST(null_rows AS VARCHAR) || '/' || CAST(total_rows AS VARCHAR) || ' rows).' AS error_description,
+        'Column `{{ column_name }}` in model `{{ table_name }}` has ' || null_percentage_formatted || '% NULL values (' || CAST(null_rows AS {{ varchar() }}) || '/' || CAST(total_rows AS {{ varchar() }}) || ' rows).' AS error_description,
     {% endif %}
     '{{ query_to_find_nulls }}' AS query_to_find_nulls
 FROM validation_errors


### PR DESCRIPTION
## Describe your changes
In reference to the issue [#1042](https://github.com/tuva-health/tuva/issues/1042), the VARCHAR Data Type issue has been fixed.  
A new macro named `varchar.sql` has been added to standardize VARCHAR usage and improve consistency across models.

## How has this been tested?
- Ran `dbt run` and confirm successful model builds.
- Run `dbt test` and confirm no failures related to **VARCHAR**.
- Verified that the new `varchar.sql` macro is correctly applied in models that use **VARCHAR** fields.
- Manually reviewed compiled SQL to confirm correct data type handling (for e.g: **VARCHAR(255)** for Databricks and **VARCHAR** for other warehouses).


## Reviewer focus
- Confirm that the new macro `varchar.sql` is correctly implemented and referenced where needed.
- Confirm that running `dbt run` and `dbt test` does not result in any failures.


## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
