### PR TITLE
update input_layer__medical_claim.yml unique value count test so null…

### DIFF
--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -481,7 +481,7 @@ models:
         tests:
           - the_tuva_project.expect_column_unique_value_count_to_be_between:
               description: A claim should not have multiple bill type codes within the same claim id.
-              min_value: 1
+              min_value: 0
               max_value: 1
               tags: ['tuva_dqi_sev_2', 'dqi', 'dqi_cms_chronic_conditions']
               group_by: [claim_id]


### PR DESCRIPTION
… values don't raise an exception

## Describe your changes
Closes #1080 

Updated input_layer__medical_claim.yml line 484, change "min_value: 1" to "min_value: 0".

## How has this been tested?
Compared build where min value = 1 and received 2,912,700 exceptions to a build where min value = 0 and received 1,943 exceptions.  Manually ran exception code to confirm that including null values also returns 2,912,700 exceptions and excluding nulls matched the test count of 1,943 exceptions.


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.

Confirm the change to input_layer__medical_claim.yml runs as expected and does not cause any new issues.


## Checklist before requesting a review
- [ X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [ ] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Relaxed validation for medical claims to allow records without a bill type code, preventing false validation failures.
  - Improves data ingestion reliability and reduces unnecessary error flags for edge cases.
- Documentation
  - None
- Refactor
  - None
- Style
  - None
- Tests
  - None
- Chores
  - None
- Revert
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->