### PR TITLE
fix: deduplicate source tables before joins in adhras_long

### DIFF
--- a/models/quality_measures/intermediate/adh-ras_medication_adherence_for_hypertension/quality_measures__int_adhras_long.sql
+++ b/models/quality_measures/intermediate/adh-ras_medication_adherence_for_hypertension/quality_measures__int_adhras_long.sql
@@ -3,7 +3,7 @@
    )
 }}
 
-with denominator as (
+with denominator_ranked as (
 
     select
           person_id
@@ -13,7 +13,49 @@ with denominator as (
         , measure_name
         , measure_version
         , denominator_flag
+        , row_number() over (
+            partition by
+                  person_id
+                , performance_period_begin
+                , performance_period_end
+                , measure_id
+                , measure_name
+            order by
+                case when performance_period_end is null then 1 else 0 end
+                , performance_period_end desc
+          ) as rn
     from {{ ref('quality_measures__int_adhras_denominator') }}
+
+)
+
+, denominator as (
+
+    select
+          person_id
+        , performance_period_begin
+        , performance_period_end
+        , measure_id
+        , measure_name
+        , measure_version
+        , denominator_flag
+    from denominator_ranked
+    where rn = 1
+
+)
+
+, numerator_ranked as (
+
+    select
+          person_id
+        , evidence_date
+        , evidence_value
+        , row_number() over (
+            partition by person_id
+            order by
+                case when evidence_date is null then 1 else 0 end
+                , evidence_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_adhras_numerator') }}
 
 )
 
@@ -23,7 +65,24 @@ with denominator as (
           person_id
         , evidence_date
         , evidence_value
-    from {{ ref('quality_measures__int_adhras_numerator') }}
+    from numerator_ranked
+    where rn = 1
+
+)
+
+, exclusions_ranked as (
+
+    select
+          person_id
+        , exclusion_date
+        , exclusion_reason
+        , row_number() over (
+            partition by person_id
+            order by
+                case when exclusion_date is null then 1 else 0 end
+                , exclusion_date desc
+          ) as rn
+    from {{ ref('quality_measures__int_adhras_exclusions') }}
 
 )
 
@@ -33,7 +92,8 @@ with denominator as (
           person_id
         , exclusion_date
         , exclusion_reason
-    from {{ ref('quality_measures__int_adhras_exclusions') }}
+    from exclusions_ranked
+    where rn = 1
 
 )
 
@@ -41,24 +101,14 @@ with denominator as (
 
     select
           denominator.person_id
+        , 1 as denominator_flag
         , case
-            when denominator.person_id is not null
-            then 1
-            else null
-          end as denominator_flag
-        , case
-            when numerator.person_id is not null and denominator.person_id is not null
-            then 1
-            when denominator.person_id is not null
-            then 0
-            else null
+            when numerator.person_id is not null then 1
+            else 0
           end as numerator_flag
         , case
-            when exclusions.person_id is not null and denominator.person_id is not null
-            then 1
-            when denominator.person_id is not null
-            then 0
-            else null
+            when exclusions.person_id is not null then 1
+            else 0
           end as exclusion_flag
         , numerator.evidence_date
         , numerator.evidence_value
@@ -69,45 +119,11 @@ with denominator as (
         , denominator.measure_id
         , denominator.measure_name
         , denominator.measure_version
-        , (row_number() over (
-            partition by
-                  denominator.person_id
-                , denominator.performance_period_begin
-                , denominator.performance_period_end
-                , denominator.measure_id
-                , denominator.measure_name
-              order by
-                  case when numerator.evidence_date is null then 1 else 0 end
-                  , numerator.evidence_date desc
-                , case when exclusions.exclusion_date is null then 1 else 0 end
-                  , exclusions.exclusion_date desc
-          )) as rn
     from denominator
-        left outer join numerator
+        left join numerator
             on denominator.person_id = numerator.person_id
-        left outer join exclusions
+        left join exclusions
             on denominator.person_id = exclusions.person_id
-
-)
-
-, deduped as (
-
-    select
-          person_id
-        , denominator_flag
-        , numerator_flag
-        , exclusion_flag
-        , evidence_date
-        , evidence_value
-        , exclusion_date
-        , exclusion_reason
-        , performance_period_begin
-        , performance_period_end
-        , measure_id
-        , measure_name
-        , measure_version
-    from measure_flags
-    where rn = 1
 
 )
 
@@ -127,7 +143,7 @@ with denominator as (
         , cast(measure_id as {{ dbt.type_string() }}) as measure_id
         , cast(measure_name as {{ dbt.type_string() }}) as measure_name
         , cast(measure_version as {{ dbt.type_string() }}) as measure_version
-    from deduped
+    from measure_flags
 
 )
 

--- a/models/quality_measures/intermediate/adh-ras_medication_adherence_for_hypertension/quality_measures__int_adhras_long.sql
+++ b/models/quality_measures/intermediate/adh-ras_medication_adherence_for_hypertension/quality_measures__int_adhras_long.sql
@@ -120,9 +120,9 @@ with denominator_ranked as (
         , denominator.measure_name
         , denominator.measure_version
     from denominator
-        left join numerator
+        left outer join numerator
             on denominator.person_id = numerator.person_id
-        left join exclusions
+        left outer join exclusions
             on denominator.person_id = exclusions.person_id
 
 )


### PR DESCRIPTION
Prevents Cartesian explosion by deduplicating denominator, numerator, and exclusions tables before joining. Reduces runtime from 1+ hours to minutes on datasets with multiple pharmacy claims per person.

## Describe your changes
This PR optimizes the `quality_measures__int_adhras_long.sql` model to prevent performance degradation on production-scale datasets. 

**Problem:** The original implementation joined three tables (`denominator`, `numerator`, `exclusions`) on `person_id` only, without prior deduplication. When patients have multiple pharmacy claims (common in real-world scenarios), this creates a Cartesian product that explodes the intermediate result set to 100M+ rows before a complex `ROW_NUMBER()` window function deduplicates back down to the final output.

**Solution:** Added deduplication CTEs for all three source tables before joining:
- `denominator`: Deduplicates by `person_id`, `performance_period_begin`, `performance_period_end`, `measure_id`, `measure_name` (keeps most recent period)
- `numerator`: Deduplicates by `person_id` (keeps most recent `evidence_date`)
- `exclusions`: Deduplicates by `person_id` (keeps most recent `exclusion_date`)

This eliminates the Cartesian explosion while maintaining identical business logic and output.

## How has this been tested?
Tested on Redshift with production-scale pharmacy claims data:

**Before optimization:**
- Runtime: 1+ hours

**After optimization:**
- Runtime: <5 minutes


## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
* Deduplication logic: Verify that the ⁠ROW_NUMBER() partition and order by clauses maintain the same business logic as the original implementation
* Flag logic simplification: Confirm that simplified ⁠numerator_flag and ⁠exclusion_flag logic (1/0 instead of 1/0/null) produces equivalent results
* ANSI SQL compliance: Ensure the query syntax works across all supported data warehouses
* Output equivalence: Validate that the final result set is identical to the original implementation

## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [NA] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
