### PR TITLE
Performance improvements for `claims_preprocessing.member_months`

### DIFF
--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
@@ -18,13 +18,6 @@ with stg_eligibility as (
   from {{ ref('normalized_input__eligibility') }} as elig
 )
 
-, enrollment_start_and_end_dates as (
-    select
-        min(enrollment_start_date) as date_lower_bound
-        , max(enrollment_end_date) as date_upper_bound
-    from stg_eligibility
-)
-
 , month_start_and_end_dates as (
   select
     {{ concat_custom(["year",
@@ -32,13 +25,11 @@ with stg_eligibility as (
     , min(full_date) as month_start_date
     , max(full_date) as month_end_date
   from {{ ref('reference_data__calendar') }} as c
-  inner join enrollment_start_and_end_dates as d
-    on c.full_date between d.date_lower_bound and d.date_upper_bound
   group by year, month, year_month
 )
 
-, deduplicated as (
-select distinct
+, joined as (
+select
   a.person_id
   , a.member_id
   , b.year_month
@@ -62,4 +53,4 @@ select
     , data_source
     ) as member_month_key
 , *
-from deduplicated
+from joined


### PR DESCRIPTION
## Describe your changes
previously we had a select distinct dense_rank in here, and we were also including most rows from the reference data calendar. This PR adds some filtering and breaks out the distinct and window function for runtime speed improvements. resolves #1089


## How has this been tested?
dbt build --select claims_enrollment__member_months

With ~100M rows, runtime is improved by ~2x

tested to make sure `member_month_key` assignment was working as expected by previous model:
```sql
select *
from current_state as prod
left join future_state as dev
on prod.member_month_key = dev.member_month_key
where prod.person_id <> dev.person_id
or prod.member_id <> dev.member_id
or prod.year_month <> dev.year_month
or prod.payer <> dev.payer
or prod.data_source <> dev.data_source
```

## Reviewer focus
Performance improvements, any concerns with break(s) to business logic


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [NA] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “last run” timestamp to the member-months dataset.
  * Month generation now aligns with enrollment start and end dates per member.

* **Refactor**
  * Simplified unique key generation for member-months using deterministic ordering.
  * Streamlined deduplication and date handling for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->