### PR TITLE
Bug/person id crosswalk missing tuva last run

### DIFF
--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -1159,6 +1159,8 @@ models:
         description: '{{ doc("plan") }}'
       - name: data_source
         description: '{{ doc("data_source") }}'
+      - name: tuva_last_run
+        description: '{{ doc("tuva_last_run") }}'
 
   - name: core__pharmacy_claim
     description: >

--- a/models/core/final/core__person_id_crosswalk.sql
+++ b/models/core/final/core__person_id_crosswalk.sql
@@ -13,6 +13,7 @@ select distinct
     , cast(payer as {{ dbt.type_string() }}) as payer
     , cast({{ quote_column('plan') }} as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
     , cast(data_source as {{ dbt.type_string() }}) as data_source
+    , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__eligibility') }}
 union all
 select distinct
@@ -22,6 +23,7 @@ select distinct
     , cast(null as {{ dbt.type_string() }}) as payer
     , cast(null as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
     , cast(data_source as {{ dbt.type_string() }}) as data_source
+    , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('input_layer__patient') }}
 
 {% elif var('clinical_enabled', var('tuva_marts_enabled',False)) == true -%}
@@ -33,6 +35,7 @@ select distinct
     , cast(null as {{ dbt.type_string() }}) as payer
     , cast(null as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
     , cast(data_source as {{ dbt.type_string() }}) as data_source
+    , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('input_layer__patient') }}
 
 {% elif var('claims_enabled', var('tuva_marts_enabled',False)) == true -%}
@@ -44,6 +47,7 @@ select distinct
     , cast(payer as {{ dbt.type_string() }}) as payer
     , cast({{ quote_column('plan') }} as {{ dbt.type_string() }}) as {{ quote_column('plan') }}
     , cast(data_source as {{ dbt.type_string() }}) as data_source
+    , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__eligibility') }}
 
 {%- endif %}


### PR DESCRIPTION
## Describe your changes
`tuva_last_run` has been added to `core__person_id_crosswalk` table with datatype of `timestamp`.


## How has this been tested?
To verify the change, `dbt build -s +core__person_id_crosswalk` command was ran over the data warehouses. 


## Reviewer focus
Please focus on the `core__person_id_crosswalk` model. 

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tuva_last_run timestamp field to the appointment dataset, exposing the pipeline’s last execution time.
  * Added tuva_last_run to the person ID crosswalk outputs across all generation paths, ensuring consistent run metadata.
  * Existing fields remain unchanged; schemas are expanded only by this additional column for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->