### PR TITLE
Cast tuva_last_run to timestamp

### DIFF
--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -42,7 +42,7 @@ select
   , cast(elig.ethnicity as {{ dbt.type_string() }}) as ethnicity
   , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
   , {{ try_to_cast_date('elig.file_date', 'YYYY-MM-DD') }} as file_date
-  , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
+  , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_eligibility') }} as elig
 left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
   on elig.person_id_key = date_norm.person_id_key

--- a/models/core/staging/core__stg_claims_eligibility.sql
+++ b/models/core/staging/core__stg_claims_eligibility.sql
@@ -48,5 +48,5 @@ select
        , cast(fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
        , cast(data_source as {{ dbt.type_string() }}) as data_source
        , {{ try_to_cast_date('file_date', 'YYYY-MM-DD') }} as file_date
-       , '{{ var('tuva_last_run') }}' as tuva_last_run
+       , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__eligibility') }}

--- a/models/core/staging/core__stg_claims_member_months.sql
+++ b/models/core/staging/core__stg_claims_member_months.sql
@@ -24,7 +24,7 @@ select
   , a.payer
   , a.{{ quote_column('plan') }}
   , a.data_source
-  , '{{ var('tuva_last_run') }}' as tuva_last_run
+  , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 
   , b.payer_attributed_provider
   , b.payer_attributed_provider_practice

--- a/models/core/staging/core__stg_claims_pharmacy_claim.sql
+++ b/models/core/staging/core__stg_claims_pharmacy_claim.sql
@@ -48,7 +48,7 @@ select
        , enroll.member_month_key
        , cast(pharm.data_source as {{ dbt.type_string() }}) as data_source
        , {{ try_to_cast_date('pharm.file_date', 'YYYY-MM-DD') }} as file_date
-       , '{{ var('tuva_last_run') }}' as tuva_last_run
+       , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__pharmacy_claim') }} as pharm
 left outer join {{ ref('claims_enrollment__flag_rx_claims_with_enrollment') }} as enroll
   on pharm.claim_id = enroll.claim_id


### PR DESCRIPTION
## Describe your changes
Datatype of `tuva_last_run` fields in core tables: `eligibility`, `member_months`, and `pharmacy_claim` has been has been casted to timestamp


## How has this been tested?
To verify the updates following commands has been used:
 - `dbt build -s +core__eligibility`
 - `dbt build -s +core__member_months`
 - `dbt build -s +core__pharmacy_claim`


## Reviewer focus
Please focus on the core models where the datatype for field `tuva_last_run` has been updated to `timestamp` which was formerly set to `varchar`. 

## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the tuva_last_run field to use a proper timestamp, ensuring accurate time-based filtering, sorting, and comparisons across eligibility, member months, and pharmacy claims data.
* **Refactor**
  * Standardized timestamp casting for tuva_last_run in staging and normalized inputs to improve data consistency and downstream compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->