### PR TITLE
Remove unsupported data type (databricks)

### DIFF
--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -767,7 +767,6 @@ models:
       description: '{{ doc("revenue_center_description") }}'
     - name: service_unit_quantity
       description: '{{ doc("service_unit_quantity") }}'
-      data_type: number
     - name: hcpcs_code
       description: '{{ doc("hcpcs_code") }}'
       meta:


### PR DESCRIPTION
## Describe your changes
`number` is an unsupported data type in databricks. Because we are passing `data_type: number` for `service_unit_quantity`, we are seeing failures when trying to build core medical claim for all Tuva versions older than 0.14.17.


## How has this been tested?
`select cast(1 as number)` in dbr


## Reviewer focus
data type change / any pushback on this change


## Checklist before requesting a review
- [x] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated schema by removing an explicit data type annotation for a quantity field in the medical claims dataset. The field now relies on inferred typing from the data warehouse. No changes to column availability, naming, or descriptions. This may slightly affect how the value is cast or formatted in downstream queries, exports, or BI tools, but no data values or calculations were otherwise modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->