### PR TITLE
Add ingest_datetime through to core and convert file_date datatype to datetime

### DIFF
--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -41,7 +41,8 @@ select
   , cast(elig.email as {{ dbt.type_string() }}) as email
   , cast(elig.ethnicity as {{ dbt.type_string() }}) as ethnicity
   , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
-  , {{ try_to_cast_date('elig.file_date', 'YYYY-MM-DD') }} as file_date
+  , cast(elig.file_date as {{ dbt.type_timestamp() }}) as file_date
+  , cast(elig.ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_eligibility') }} as elig
 left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__medical_claim.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__medical_claim.sql
@@ -74,7 +74,8 @@ select
     {% endfor %}
     , cast(med.data_source as {{ dbt.type_string() }}) as data_source
     , cast(med.in_network_flag as int) as in_network_flag
-    , {{ try_to_cast_date('med.file_date', 'YYYY-MM-DD') }} as file_date
+    , cast(med.file_date as {{ dbt.type_timestamp() }}) as file_date
+    , cast(med.ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_medical_claim') }} as med
 left outer join {{ ref('normalized_input__int_admit_source_final') }} as ad_source

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__pharmacy_claim.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__pharmacy_claim.sql
@@ -49,7 +49,8 @@ select
     , cast(deductible_amount as {{ dbt.type_numeric() }}) as deductible_amount
     , cast(in_network_flag as int) as in_network_flag
     , cast(data_source as {{ dbt.type_string() }}) as data_source
-    , {{ try_to_cast_date('pharm.file_date', 'YYYY-MM-DD') }} as file_date
+    , cast(pharm.file_date as {{ dbt.type_timestamp() }}) as file_date
+    , cast(pharm.ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_pharmacy_claim') }} as pharm
 left outer join {{ ref('terminology__provider') }} as pres

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -276,6 +276,8 @@ models:
         - not_null
     - name: file_date
       description: '{{ doc("file_date") }}'
+    - name: ingest_datetime
+      description: '{{ doc("ingest_datetime") }}'
     - name: tuva_last_run
       description: '{{ doc("tuva_last_run") }}'
 
@@ -843,6 +845,8 @@ models:
       description: '{{ doc("data_source") }}'
     - name: file_date
       description: '{{ doc("file_date") }}'
+    - name: ingest_datetime
+      description: '{{ doc("ingest_datetime") }}'
     - name: tuva_last_run
       description: '{{ doc("tuva_last_run") }}'
 
@@ -1251,6 +1255,8 @@ models:
         description: '{{ doc("data_source") }}'
       - name: file_date
         description: '{{ doc("file_date") }}'
+      - name: ingest_datetime
+        description: '{{ doc("ingest_datetime") }}'
       - name: tuva_last_run
         description: '{{ doc("tuva_last_run") }}'
 

--- a/models/core/staging/core__stg_claims_eligibility.sql
+++ b/models/core/staging/core__stg_claims_eligibility.sql
@@ -47,6 +47,7 @@ select
        , cast(fips_state_code as {{ dbt.type_string() }}) as fips_state_code
        , cast(fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
        , cast(data_source as {{ dbt.type_string() }}) as data_source
-       , {{ try_to_cast_date('file_date', 'YYYY-MM-DD') }} as file_date
+       , cast(file_date as {{ dbt.type_timestamp() }}) as file_date
+       , cast(ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
        , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('normalized_input__eligibility') }}

--- a/models/core/staging/core__stg_claims_medical_claim.sql
+++ b/models/core/staging/core__stg_claims_medical_claim.sql
@@ -105,7 +105,8 @@ select
     end as int) as enrollment_flag
     , enroll.member_month_key
     , cast(med.data_source as {{ dbt.type_string() }}) as data_source
-    , {{ try_to_cast_date('med.file_date', 'YYYY-MM-DD') }} as file_date
+    , cast(med.file_date as {{ dbt.type_timestamp() }}) as file_date
+    , cast(med.ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('normalized_input__medical_claim') }} as med
 inner join {{ ref('service_category__service_category_grouper') }} as srv_group

--- a/models/core/staging/core__stg_claims_pharmacy_claim.sql
+++ b/models/core/staging/core__stg_claims_pharmacy_claim.sql
@@ -47,7 +47,8 @@ select
        end as int) as enrollment_flag
        , enroll.member_month_key
        , cast(pharm.data_source as {{ dbt.type_string() }}) as data_source
-       , {{ try_to_cast_date('pharm.file_date', 'YYYY-MM-DD') }} as file_date
+       , cast(pharm.file_date as {{ dbt.type_timestamp() }}) as file_date
+       , cast(pharm.ingest_datetime as {{ dbt.type_timestamp() }}) as ingest_datetime
        , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('normalized_input__pharmacy_claim') }} as pharm
 left outer join {{ ref('claims_enrollment__flag_rx_claims_with_enrollment') }} as enroll


### PR DESCRIPTION
## Describe your changes
This PR introduces an `ingest_datetime` field to the relevant models/tables and updates the `file_date` field datatype to `datetime`. 

These modifications enhance data traceability and ensure consistent datetime formatting for ingestion and file dates.

## How has this been tested?
- Ran `dbt build -f` across all the warehouses(Snowflake, BigQuery, Fabric, Redshift).
- Existing data pipelines were executed to verify that the conversion of file_date to datetime does not break compatibility or downstream processes.
- Manual validation of data types in output tables was performed to confirm **datetime** formats.

## Reviewer focus
- Please review the implementation of the `ingest_datetime` field for consistency and placement.
- Verify that the datatype change for `file_date` is correctly applied everywhere it is referenced.
- Manually verify if the datatype of `file_date` is **datetime**.

## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3Uzank3d2duNHBmdmRwZ2g5cGgwMDlqb3B4cXd0Ymw4aWZsMXpveSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/joSNxeswxuc74Juo8X/giphy.gif)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ingest_datetime column to eligibility, medical, and pharmacy claim datasets, including staging and core outputs.

* **Refactor**
  * Standardized file_date to a timestamp across claims datasets for consistent typing and downstream compatibility. No changes to other fields or logic.

* **Documentation**
  * Updated model schemas to include ingest_datetime and its description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->