### PR TITLE
Test for negative values for the numeric fields in input layer claims tables

### DIFF
--- a/models/input_layer/input_layer__medical_claim.yml
+++ b/models/input_layer/input_layer__medical_claim.yml
@@ -603,9 +603,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -826,9 +826,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -848,9 +848,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -870,9 +870,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -892,9 +892,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -914,9 +914,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -936,9 +936,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn

--- a/models/input_layer/input_layer__pharmacy_claim.yml
+++ b/models/input_layer/input_layer__pharmacy_claim.yml
@@ -185,9 +185,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -205,9 +205,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -272,9 +272,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ var('enable_input_layer_testing', true) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -294,9 +294,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -316,9 +316,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -338,9 +338,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -360,9 +360,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn
@@ -382,9 +382,9 @@ models:
               config:
                 severity: warn
                 enabled: "{{ (var('enable_input_layer_testing', true)) | as_bool }}"
-          - dbt_expectations.expect_column_values_to_be_between:
+          - the_tuva_project.expect_column_values_to_be_between:
               min_value: 0
-              max_value: null
+              strictly: false
               tags: ['tuva_dqi_sev_3', 'dqi']
               config:
                 severity: warn


### PR DESCRIPTION
## Describe your changes
This PR adds automated tests to check for negative values in columns typically included in ADR (Automated Data Review) for input layer claims tables as mentioned in the [issue](https://github.com/tuva-health/tuva/issues/1057). The expectation is that ADR logic is handled upstream, so negative financials and related quantities should not appear in the input layer. 
New tests have been added for the following columns (across **medical_claim** and **pharmacy_claim** tables):
`deductible_amount`
`coinsurance_amount`
`copayment_amount`
`paid_amount`
`allowed_amount`
`service_unit_quantity`
`quantity`
`days_supply`

These tests use `dbt_expectations.expect_column_values_to_be_between` to ensure values are not negative. Failing tests will highlight ADR issues or claims unsuitable for downstream processes.

## How has this been tested?
- Ran the new dbt expectation tests and confirmed that rows with negative values are flagged.
- Verified that valid (non-negative) records pass all tests.

## Reviewer focus
- Review the column selection and logic for the new tests.
- Confirm that **dbt-expectations** are used correctly and efficiently.
- Ensure that the tests do not flag valid records.

## Checklist before requesting a review
- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added non-negativity checks for many numeric fields across medical and pharmacy claim datasets (quantities, days supply, paid/charge/allowed amounts, coinsurance, copayment, deductible, total cost).
  * Checks enforce minimum value 0 with no upper bound, use the existing enablement flag, and are tagged for targeted DQI runs.
  * Failures surface as warnings when enabled, increasing data quality coverage without changing existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->