### PR TITLE
Only run tuva hooks when tuva nodes selected

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -56,7 +56,6 @@ vars:
 
     ## Set this variable to true if you want legacy data quality models to build
     enable_legacy_data_quality: false
-
 on-run-start:
   - "{{ log_invocation_start() }}"
 on-run-end:

--- a/macros/processing_flow/log_warning_for_seeds.sql
+++ b/macros/processing_flow/log_warning_for_seeds.sql
@@ -1,5 +1,6 @@
 -- macros/log_warning_for_seeds.sql
 {% macro log_warning_for_seeds() %}
+
     {% set seeds = get_selected_seeds() %}
 
     {% for seed in seeds %}


### PR DESCRIPTION
## Problem being solved
Our organization (Color Health) recently began using Tuva – thank you all for the hard work to get us such a great head start on doing health care data analysis!

We have many frequently-run dbt jobs that do not touch Tuva models. We've been running into collisions where two jobs are trying to a Tuva hook at the same time. We use BigQuery and see the following error when this happens: `Could not serialize access to table <BQ_PROJECT>:metadata.tuva_invocations due to concurrent update`. 

Because the vast majority of these jobs are unrelated to Tuva, and we'd like for the Tuva hooks to only run when they're relevant.

## Describe your changes

This PR implements a check on the resources being targeted by a dbt operation and only runs Tuva's `on-run-start` hook if Tuva resources are selected. I based this implementation on the the `get_selected_seeds` macro.

I added a new macro `is_tuva_selected` that checks whether any of the nodes belong to the Tuva Project (package name of `the_tuva_project` or `tuva`, as in the `get_selected_seeds` except excluding `integration_tests`.)

Then check whether a Tuva resource is included using `is_tuva_selected` in the `log_invocation_start` macro. If not, we just log "No Tuva resources selected, skipping invocation tracking". If there is a Tuva node included, then the hook proceeds as normal.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.

I tested by installing the Tuva package using this branch in `packages.yml` in our dbt repo:
```yml
  - git: https://github.com/seamus-mckinsey/tuva
    revision: only-run-tuva-hooks-when-tuva-nodes-selected
```

Comparison of behavior when Tuva resource is selected vs not:
```bash
-- selecting the pharmacy input and one layer downstream
.venv ❯ dbt build -s pharmacy_claim+1 | grep tuva                                          
19:37:20  2 of 2 START hook: the_tuva_project.on-run-start.1 ............................. [RUN]
19:37:20  2 of 2 OK hook: the_tuva_project.on-run-start.1 ................................ [OK in 8.55s]
19:44:33  2 of 2 START hook: the_tuva_project.on-run-end.1 ............................... [RUN]
19:44:33  2 of 2 OK hook: the_tuva_project.on-run-end.1 .................................. [OK in 0.04s]


-- selecting something unrelated
.venv ❯ dbt build -s sites | grep tuva -i
19:44:21  No Tuva resources selected, skipping invocation tracking
19:44:21  2 of 2 START hook: the_tuva_project.on-run-start.1 ............................. [RUN]
19:44:21  2 of 2 OK hook: the_tuva_project.on-run-start.1 ................................ [OK in 0.02s]
19:44:33  2 of 2 START hook: the_tuva_project.on-run-end.1 ............................... [RUN]
19:44:33  2 of 2 OK hook: the_tuva_project.on-run-end.1 .................................. [OK in 0.04s]
```
Note how in the second one (selecting a non-Tuva resource), there is a message "No Tuva resources selected, skipping invocation tracking" logged and the hook runs in 20 ms vs 8.5s.

## Reviewer focus
Ensure this change to hook behavior is safe. I wanted to make as small a change as possible so only changed the on-run-start hook, but perhaps there's benefit to changing on-run-end hooks as well.

## Checklist before requesting a review
- [ ] I have added at least one Github label to this PR (bug, enhancement, breaking change,...) 
> I'm not able to add a label - I don't see the gear icon or label dropdown
- [x] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [ ] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [ ] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [ ] (New models) I have added the variable `tuva_last_run` to the final output
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel
![](https://media.tenor.com/kaGOc1y84h0AAAAi/sonic-dance.gif)


## Loom link
