### PR TITLE
Check disable dbt invocation elementary variable

### DIFF
--- a/macros/metadata/tuva_invocations.sql
+++ b/macros/metadata/tuva_invocations.sql
@@ -50,6 +50,12 @@
 
 
 {% macro log_invocation_start() %}
+
+    {# Check if invocation autoupload is disabled #}
+    {% if var('disable_dbt_invocation_autoupload', false) %}
+        {% do log("Invocation autoupload is disabled, skipping invocation tracking", info=true) %}
+        {% do return('') %}
+    {% endif %}
     {# Check if Tuva resources are selected #}
     {% if not the_tuva_project.is_tuva_selected() %}
         {% do log("No Tuva resources selected, skipping invocation tracking", info=true) %}


### PR DESCRIPTION
## Describe your changes

Added support for the `disable_dbt_invocation_autoupload` variable to the `log_invocation_start()` macro, allowing users to disable Tuva's invocation tracking independently from Elementary's other features.

This change addresses an issue where the `tuva_invocations` table was being created even when users needed to disable Elementary or route it to a different database. The new variable provides a clean way to skip invocation tracking without breaking Tuva's data quality features.

**Key changes:**
- Added a check at the beginning of `log_invocation_start()` macro to respect the `disable_dbt_invocation_autoupload` variable
- Defaults to `false` to maintain backward compatibility
- Includes informative logging when invocation tracking is skipped

## How has this been tested?

**Test 1: Variable set to `true`**
```yaml
# dbt_project.yml
vars:
  disable_dbt_invocation_autoupload: true
```
Run `dbt run` and verify:
- No `tuva_invocations` table is created
- Log message appears: "Invocation autoupload is disabled, skipping invocation tracking"
- Tuva data quality features continue to work normally

**Test 2: Variable set to `false` or not set**
```yaml
# dbt_project.yml
vars:
  disable_dbt_invocation_autoupload: false
```
Run `dbt run` and verify:
- `tuva_invocations` table is created as expected
- Normal invocation tracking behavior is preserved

**Test 3: Command line override**
```bash
dbt run --vars '{disable_dbt_invocation_autoupload: true}'
```
Verify invocation tracking is skipped for this specific run.

## Reviewer focus

Please review:
1. The placement of the disable check at the beginning of the macro (before any other logic executes)
2. The default value of `false` to ensure backward compatibility
3. The log message clarity and info level
4. Whether the variable naming convention (`disable_dbt_invocation_autoupload`) aligns with Elementary's conventions

## Checklist before requesting a review

- [X] I have added at least one Github label to this PR (bug, enhancement, breaking change,...)
- [X] My code follows [style guidelines](https://thetuvaproject.com/contributing/style-guide)
- [NA] (New models) [YAML files](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/hcc_suspecting_models.yml) are categorized by sub folder and models listed in alphabetical order
- [NA] (New models) I have added a [config](https://github.com/tuva-health/tuva/blob/main/models/hcc_suspecting/final/hcc_suspecting__list.sql) to each new model to enable it for claims and/or clinical data
- [NA] (New models) I have added the variable `tuva_last_run` to the final output
- [NA] (Optional) I have recorded a Loom to explain this PR

## (Optional) Gif of how this PR makes you feel

![relief](https://media.giphy.com/media/3o7aCWJavAgtBzLWrS/giphy.gif)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration flag to control automatic invocation tracking and uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->