### PR TITLE
Fixed Redshift / Snowflake Discrepancy

### DIFF
--- a/macros/cross_database_utils/least.sql
+++ b/macros/cross_database_utils/least.sql
@@ -1,0 +1,13 @@
+{% macro least(a, b) %}
+  {{ return(adapter.dispatch('least', 'macros')(a, b)) }}
+{% endmacro %}
+
+{% macro default__least(a, b) %}
+  case
+    when {{ a }} is null and {{ b }} is null then null
+    when {{ a }} is null then {{ b }}
+    when {{ b }} is null then {{ a }}
+    when {{ a }} <= {{ b }} then {{ a }}
+    else {{ b }}
+  end
+{% endmacro %}

--- a/models/quality_measures/intermediate/adh-ras_medication_adherence_for_hypertension/quality_measures__int_adhras_numerator.sql
+++ b/models/quality_measures/intermediate/adh-ras_medication_adherence_for_hypertension/quality_measures__int_adhras_numerator.sql
@@ -165,8 +165,8 @@ or use the current rx_fill_date
       , dispensing_date
       , days_supply
       , adjusted_fill_date
-      , least(
-            {{ dbt.dateadd (
+      , {{ least(
+            dbt.dateadd (
                 datepart = "day"
               , interval = -1
               , from_date_or_timestamp =
@@ -175,9 +175,9 @@ or use the current rx_fill_date
                       , interval = "days_supply"
                       , from_date_or_timestamp = "adjusted_fill_date"
               )
-            ) }}
-          , performance_period_end
-      ) as actual_end_date
+            )
+          , "performance_period_end"
+      ) }} as actual_end_date
     from adjusted_fill_dates
     inner join performance_end
       on adjusted_fill_dates.adjusted_fill_date <= performance_end.performance_period_end

--- a/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_numerator.sql
+++ b/models/quality_measures/intermediate/adh-statins_medication_adherence_for_cholestrol/quality_measures__int_adh_statins_numerator.sql
@@ -165,8 +165,8 @@ or use the current rx_fill_date
       , dispensing_date
       , days_supply
       , adjusted_fill_date
-      , least(
-            {{ dbt.dateadd (
+      , {{ least(
+            dbt.dateadd (
                 datepart = "day"
               , interval = -1
               , from_date_or_timestamp =
@@ -175,9 +175,9 @@ or use the current rx_fill_date
                       , interval = "days_supply"
                       , from_date_or_timestamp = "adjusted_fill_date"
               )
-            ) }}
-          , performance_period_end
-      ) as actual_end_date
+            )
+          , "performance_period_end"
+      ) }} as actual_end_date
     from adjusted_fill_dates
     inner join performance_end
       on adjusted_fill_dates.adjusted_fill_date <= performance_end.performance_period_end

--- a/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
+++ b/models/quality_measures/intermediate/adh_diabetes/quality_measures__int_adh_diabetes_numerator.sql
@@ -161,8 +161,8 @@ order by dispensing_date) as previous_ndc
       , dispensing_date
       , days_supply
       , adjusted_start_date
-      , least(
-            {{ dbt.dateadd (
+      , {{ least(
+            dbt.dateadd (
                 datepart = "day"
               , interval = -1
               , from_date_or_timestamp =
@@ -171,9 +171,9 @@ order by dispensing_date) as previous_ndc
                       , interval = "days_supply"
                       , from_date_or_timestamp = "adjusted_start_date"
               )
-            ) }}
-          , performance_period_end
-      ) as final_end_date
+            )
+          , "performance_period_end"
+      ) }} as final_end_date
     from adjusted_fills
     inner join performance_end
       on adjusted_fills.adjusted_start_date <= performance_end.performance_period_end


### PR DESCRIPTION
ADH quality measures were getting different numerator results across two platforms due to issue w/ LEAST() function.  Created a macro to fix this issue.