### PR TITLE
Fix observation staging for claims-only logic

### DIFF
--- a/models/fhir_preprocessing/staging/fhir_preprocessing__stg_core__observation.sql
+++ b/models/fhir_preprocessing/staging/fhir_preprocessing__stg_core__observation.sql
@@ -43,6 +43,8 @@ select
     , data_source
 from {{ ref('core__observation') }}
 
+{% elif var('claims_enabled', var('tuva_marts_enabled',False)) == true -%}
+
 select {% if target.type == 'fabric' %} top 0 {% else %}{% endif %}
       cast(null as {{ dbt.type_string() }} ) as observation_id
     , cast(null as {{ dbt.type_string() }} ) as person_id


### PR DESCRIPTION
# Summary of changes
Added missing elif logic in observation staging model for claims-only logic.

# Testing notes
Ran `dbt build --full-refresh` in integration_tests with `claims_enabled: true` and with `claims_enabled: true && clinical_enabled: true`