### PR TITLE
Fix member-month keying and joins for EMPI

### DIFF
--- a/dbt_doc_blocks/column_descriptions.md
+++ b/dbt_doc_blocks/column_descriptions.md
@@ -567,7 +567,7 @@ Identifier that links a patient to a particular insurance product or health plan
 {% enddocs %}
 
 {% docs member_month_key %}
-The unique combination of person_id, year_month, payer, plan, and data source.
+The unique combination of person_id, member_id, year_month, payer, plan, and data source.
 {% enddocs %}
 
 {% docs middle_name %}

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
@@ -44,13 +44,16 @@ inner join month_start_and_end_dates as b
 )
 
 select
-  row_number() over (
-    order by
-      person_id
-    , year_month
-    , payer
-    , {{ quote_column('plan') }}
-    , data_source
-    ) as member_month_key
+  cast(
+    {{ dbt_utils.generate_surrogate_key([
+        'person_id',
+        'member_id',
+        'year_month',
+        'payer',
+        quote_column('plan'),
+        'data_source'
+    ]) }}
+    as {{ dbt.type_string() }}
+  ) as member_month_key
 , *
 from joined

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_dates_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_dates_normalize.sql
@@ -9,6 +9,7 @@ select distinct
     elig.person_id
   , {{ concat_custom([
         "elig.person_id",
+        "coalesce(cast(elig.member_id as " ~ dbt.type_string() ~ "),'')",
         "coalesce(elig.data_source,'')",
         "coalesce(elig.payer,'')",
         "coalesce(elig." ~ quote_column('plan') ~ ",'')",

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
@@ -9,6 +9,7 @@ select distinct
     elig.person_id
     , {{ concat_custom([
         "elig.person_id",
+        "coalesce(cast(elig.member_id as " ~ dbt.type_string() ~ "),'')",
         "coalesce(elig.data_source,'')",
         "coalesce(elig.payer,'')",
         "coalesce(elig." ~ quote_column('plan') ~ ",'')",

--- a/models/claims_preprocessing/normalized_input/staging/normalized_input__stg_eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/staging/normalized_input__stg_eligibility.sql
@@ -9,6 +9,7 @@ select
       person_id
     , {{ concat_custom([
         "person_id",
+        "coalesce(cast(member_id as " ~ dbt.type_string() ~ "),'')",
         "coalesce(data_source,'')",
         "coalesce(payer,'')",
         "coalesce(" ~ quote_column('plan') ~ ",'')",

--- a/models/core/staging/core__stg_claims_member_months.sql
+++ b/models/core/staging/core__stg_claims_member_months.sql
@@ -37,6 +37,7 @@ select
 from final_before_attribution_fields as a
 left outer join {{ ref('financial_pmpm__stg_provider_attribution') }} as b
 on a.person_id = b.person_id
+and a.member_id = b.member_id
 and a.year_month = b.year_month
 and a.payer = b.payer
 and a.{{ quote_column('plan') }} = b.{{ quote_column('plan') }}

--- a/models/data_quality/dqi/mart_review/final/mart_review__member_months.sql
+++ b/models/data_quality/dqi/mart_review/final/mart_review__member_months.sql
@@ -15,6 +15,7 @@ select m.*
     ]) }} as patient_data_source_key
 from {{ ref('core__member_months') }} as m
 left outer join {{ ref('financial_pmpm__pmpm_prep') }} as p on m.person_id = p.person_id
+    and m.member_id = p.member_id
     and m.data_source = p.data_source
     and m.year_month = p.year_month
     and m.payer = p.payer

--- a/models/financial_pmpm/final/financial_pmpm__pmpm_prep.sql
+++ b/models/financial_pmpm/final/financial_pmpm__pmpm_prep.sql
@@ -6,6 +6,7 @@
 with combine as (
   select
       a.person_id
+    , a.member_id
     , a.year_month
     , a.payer
     , a.{{ quote_column('plan') }}
@@ -100,24 +101,28 @@ with combine as (
   from {{ ref('core__member_months') }} as a
   left outer join {{ ref('financial_pmpm__service_category_1_paid_pivot') }} as b
     on a.person_id = b.person_id
+    and a.member_id = b.member_id
     and a.year_month = b.year_month
     and a.payer = b.payer
     and a.{{ quote_column('plan') }} = b.{{ quote_column('plan') }}
     and a.data_source = b.data_source
   left outer join {{ ref('financial_pmpm__service_category_2_paid_pivot') }} as c
     on a.person_id = c.person_id
+    and a.member_id = c.member_id
     and a.year_month = c.year_month
     and a.payer = c.payer
     and a.{{ quote_column('plan') }} = c.{{ quote_column('plan') }}
     and a.data_source = c.data_source
   left outer join {{ ref('financial_pmpm__service_category_1_allowed_pivot') }} as d
     on a.person_id = d.person_id
+    and a.member_id = d.member_id
     and a.year_month = d.year_month
     and a.payer = d.payer
     and a.{{ quote_column('plan') }} = d.{{ quote_column('plan') }}
     and a.data_source = d.data_source
   left outer join {{ ref('financial_pmpm__service_category_2_allowed_pivot') }} as e
     on a.person_id = e.person_id
+    and a.member_id = e.member_id
     and a.year_month = e.year_month
     and a.payer = e.payer
     and a.{{ quote_column('plan') }} = e.{{ quote_column('plan') }}

--- a/models/financial_pmpm/financial_pmpm_models.yml
+++ b/models/financial_pmpm/financial_pmpm_models.yml
@@ -17,6 +17,7 @@ models:
           arguments:
             combination_of_columns:
               - person_id
+              - member_id
               - year_month
               - payer
               - data_source
@@ -26,6 +27,8 @@ models:
     columns:
       - name: person_id
         description: Unique identifier for each patient in the dataset.
+      - name: member_id
+        description: '{{ doc("member_id") }}'
       - name: year_month
         description: Unique year-month of in the dataset computed from eligibility.
       - name: payer

--- a/models/financial_pmpm/intermediate/financial_pmpm__patient_spend_with_service_categories.sql
+++ b/models/financial_pmpm/intermediate/financial_pmpm__patient_spend_with_service_categories.sql
@@ -6,6 +6,7 @@
 with claims_with_service_categories as (
   select
       person_id
+    , member_id
     , payer
     , {{ quote_column('plan') }}
     , service_category_1
@@ -20,6 +21,7 @@ with claims_with_service_categories as (
 , medical_claims_year_month as (
   select
       person_id
+    , member_id
     , payer
     , {{ quote_column('plan') }}
     , service_category_1
@@ -37,6 +39,7 @@ with claims_with_service_categories as (
 , rx_claims as (
   select
       person_id
+    , member_id
     , payer
     , {{ quote_column('plan') }}
     , 'pharmacy' as service_category_1
@@ -51,6 +54,7 @@ with claims_with_service_categories as (
 , rx_claims_year_month as (
   select
       person_id
+    , member_id
     , payer
     , {{ quote_column('plan') }}
     , service_category_1
@@ -77,6 +81,7 @@ from rx_claims_year_month
 
 select
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -89,6 +94,7 @@ select
   from combine_medical_and_rx
 group by
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}

--- a/models/financial_pmpm/intermediate/financial_pmpm__service_category_1_allowed_pivot.sql
+++ b/models/financial_pmpm/intermediate/financial_pmpm__service_category_1_allowed_pivot.sql
@@ -6,6 +6,7 @@
 with service_cat_1 as (
   select
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -15,6 +16,7 @@ with service_cat_1 as (
   from {{ ref('financial_pmpm__patient_spend_with_service_categories') }}
   group by
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -24,6 +26,7 @@ with service_cat_1 as (
 
 select
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}
@@ -41,6 +44,7 @@ select
 from service_cat_1
 group by
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}

--- a/models/financial_pmpm/intermediate/financial_pmpm__service_category_1_paid_pivot.sql
+++ b/models/financial_pmpm/intermediate/financial_pmpm__service_category_1_paid_pivot.sql
@@ -6,6 +6,7 @@
 with service_cat_1 as (
   select
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -15,6 +16,7 @@ with service_cat_1 as (
   from {{ ref('financial_pmpm__patient_spend_with_service_categories') }}
   group by
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -24,6 +26,7 @@ with service_cat_1 as (
 
 select
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}
@@ -41,6 +44,7 @@ select
 from service_cat_1
 group by
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}

--- a/models/financial_pmpm/intermediate/financial_pmpm__service_category_2_allowed_pivot.sql
+++ b/models/financial_pmpm/intermediate/financial_pmpm__service_category_2_allowed_pivot.sql
@@ -6,6 +6,7 @@
 with service_cat_2 as (
   select
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -15,6 +16,7 @@ with service_cat_2 as (
   from {{ ref('financial_pmpm__patient_spend_with_service_categories') }}
   group by
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -24,6 +26,7 @@ with service_cat_2 as (
 
 select
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}
@@ -71,6 +74,7 @@ select
 from service_cat_2
 group by
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}

--- a/models/financial_pmpm/intermediate/financial_pmpm__service_category_2_paid_pivot.sql
+++ b/models/financial_pmpm/intermediate/financial_pmpm__service_category_2_paid_pivot.sql
@@ -6,6 +6,7 @@
 with service_cat_2 as (
   select
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -15,6 +16,7 @@ with service_cat_2 as (
   from {{ ref('financial_pmpm__patient_spend_with_service_categories') }}
   group by
     person_id
+  , member_id
   , year_month
   , payer
   , {{ quote_column('plan') }}
@@ -24,6 +26,7 @@ with service_cat_2 as (
 
 select
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}
@@ -71,6 +74,7 @@ select
 from service_cat_2
 group by
   person_id
+, member_id
 , year_month
 , payer
 , {{ quote_column('plan') }}

--- a/models/financial_pmpm/staging/financial_pmpm__stg_medical_claim.sql
+++ b/models/financial_pmpm/staging/financial_pmpm__stg_medical_claim.sql
@@ -6,6 +6,7 @@
 
 select
     person_id
+    , member_id
     , claim_id
     , claim_line_number
     , claim_start_date

--- a/models/financial_pmpm/staging/financial_pmpm__stg_pharmacy_claim.sql
+++ b/models/financial_pmpm/staging/financial_pmpm__stg_pharmacy_claim.sql
@@ -6,6 +6,7 @@
 
 select
     person_id
+    , member_id
     , dispensing_date
     , paid_date
     , paid_amount

--- a/models/financial_pmpm/staging/financial_pmpm__stg_provider_attribution.sql
+++ b/models/financial_pmpm/staging/financial_pmpm__stg_provider_attribution.sql
@@ -7,6 +7,7 @@
 
 select
       cast(person_id as {{ dbt.type_string() }}) as person_id
+    , cast(member_id as {{ dbt.type_string() }}) as member_id
     , cast(year_month as {{ dbt.type_string() }}) as year_month
     , cast(payer as {{ dbt.type_string() }}) as payer
     , {{ quote_column('plan') }}
@@ -27,6 +28,7 @@ from {{ ref('input_layer__provider_attribution') }}
 {% if target.type == 'fabric' %}
 select top 0
       cast(null as {{ dbt.type_string() }} ) person_id
+    , cast(null as {{ dbt.type_string() }} ) as member_id
     , cast(null as {{ dbt.type_string() }} ) as year_month
     , cast(null as {{ dbt.type_string() }} ) as payer
     , cast(null as {{ dbt.type_string() }} ) as {{ quote_column('plan') }}
@@ -43,6 +45,7 @@ select top 0
 {% else %}
 select
       cast(null as {{ dbt.type_string() }} ) person_id
+    , cast(null as {{ dbt.type_string() }} ) as member_id
     , cast(null as {{ dbt.type_string() }} ) as year_month
     , cast(null as {{ dbt.type_string() }} ) as payer
     , cast(null as {{ dbt.type_string() }} ) as {{ quote_column('plan') }}

--- a/models/input_layer/input_layer__provider_attribution.sql
+++ b/models/input_layer/input_layer__provider_attribution.sql
@@ -14,6 +14,7 @@ from {{ ref('provider_attribution') }}
 {% if target.type == 'fabric' %}
 select top 0
       cast(null as {{ dbt.type_string() }} ) as person_id
+    , cast(null as {{ dbt.type_string() }} ) as member_id
     , cast(null as {{ dbt.type_string() }} ) as patient_id
     , cast(null as {{ dbt.type_string() }} ) as year_month
     , cast(null as {{ dbt.type_string() }} ) as payer
@@ -31,6 +32,7 @@ select top 0
 {% else %}
 select
       cast(null as {{ dbt.type_string() }} ) as person_id
+    , cast(null as {{ dbt.type_string() }} ) as member_id
     , cast(null as {{ dbt.type_string() }} ) as patient_id
     , cast(null as {{ dbt.type_string() }} ) as year_month
     , cast(null as {{ dbt.type_string() }} ) as payer

--- a/models/input_layer/input_layer__provider_attribution.yml
+++ b/models/input_layer/input_layer__provider_attribution.yml
@@ -27,6 +27,7 @@ models:
           arguments:
             combination_of_columns:
               - person_id
+              - member_id
               - payer
               - '{{ ''"plan"'' if (target.type == ''fabric'') else ''plan'' }}'
               - year_month
@@ -90,6 +91,29 @@ models:
         config:
           meta:
             data_type: varchar
+      - name: member_id
+        description: '{{ doc("member_id") }}'
+        tests:
+          - the_tuva_project.expect_column_to_exist:
+              config:
+                severity: warn
+                enabled: '{{ (var(''enable_input_layer_testing'', true)) | as_bool }}'
+                tags:
+                  - tuva_dqi_sev_1
+                  - dqi
+                  - dqi_financial_pmpm
+          - not_null:
+              config:
+                severity: error
+                enabled: '{{ var(''enable_input_layer_testing'', true) | as_bool }}'
+                tags:
+                  - tuva_dqi_sev_1
+                  - dqi
+                  - dqi_financial_pmpm
+        config:
+          meta:
+            data_type: varchar
+            is_primary_key: true
       - name: year_month
         description: Unique year-month in the dataset computed from eligibility.
         tests:


### PR DESCRIPTION
- Include member_id in eligibility key normalization to prevent EMPI collisions.
- Make member_month_key deterministic and include member_id in the key grain.
- Add member_id to PMPM/provider attribution joins and related grouping/tests.