### PR TITLE
Isolate Databricks CI schemas per run to prevent Delta write conflicts

### DIFF
--- a/.github/workflows/dbt_v1.10.15_databricks_build_full_refresh.yml
+++ b/.github/workflows/dbt_v1.10.15_databricks_build_full_refresh.yml
@@ -5,6 +5,10 @@ on:
       - main
   workflow_dispatch: # Allows manual trigger from UI
 
+concurrency:
+  group: databricks-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dbt_run:
     runs-on: ubuntu-latest
@@ -19,6 +23,7 @@ jobs:
       DBT_DATABRICKS_CI_HTTP_PATH: ${{ secrets.DBT_DATABRICKS_CI_HTTP_PATH }}
       DBT_DATABRICKS_CI_TOKEN: ${{ secrets.DBT_DATABRICKS_CI_TOKEN }}
       DBT_DATABRICKS_CI_CATALOG: ${{ secrets.DBT_DATABRICKS_CI_CATALOG }}
+      DBT_DATABRICKS_CI_SCHEMA: ci_${{ github.run_id }}
 
     steps:
       - uses: actions/checkout@v4

--- a/integration_tests/profiles/databricks/profiles.yml
+++ b/integration_tests/profiles/databricks/profiles.yml
@@ -7,7 +7,7 @@ default:
         http_path: "{{ env_var('DBT_DATABRICKS_CI_HTTP_PATH') }}"
         token: "{{ env_var('DBT_DATABRICKS_CI_TOKEN') }}"
         catalog: "{{ env_var('DBT_DATABRICKS_CI_CATALOG') }}"
-        schema: default
+        schema: "{{ env_var('DBT_DATABRICKS_CI_SCHEMA', 'default') }}"
         threads: 8
         connect_timeout: 60
         connect_retries: 3


### PR DESCRIPTION
Concurrent CI runs targeting the same Delta schema cause DELTA_METADATA_CHANGED errors when two dbt processes race on CREATE OR REPLACE TABLE.

- Set DBT_DATABRICKS_CI_SCHEMA to ci_<run_id> for unique schemas per run
- Update Databricks profile to read schema from env var (defaults to 'default' for local dev)
- Add concurrency group to cancel stale runs on the same ref

Fixes #1225