### PR TITLE
Cast tuva_last_run to timestamp in core__stg_claims_pharmacy_claim

### DIFF
--- a/models/core/staging/core__stg_claims_pharmacy_claim.sql
+++ b/models/core/staging/core__stg_claims_pharmacy_claim.sql
@@ -52,7 +52,7 @@
        , cast(pharm.data_source as {{ dbt.type_string() }}) as data_source
        , {{ try_to_cast_date('pharm.file_date', 'YYYY-MM-DD') }} as file_date
        , cast(pharm.file_name as {{ dbt.type_string() }}) as file_name
-       , '{{ var('tuva_last_run') }}' as tuva_last_run
+       , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 {%- endset %}
 
 {%- set tuva_extension_columns -%}


### PR DESCRIPTION
Regression from PR #1191 left tuva_last_run as a bare varchar in pharmacy_claim while eligibility and member_months were already fixed.

Fixes #1065