### PR TITLE
Strip decimal points from ICD codes before DQI terminology lookups

### DIFF
--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_diagnosis_code_1.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_diagnosis_code_1.sql
@@ -13,7 +13,7 @@ unique_field as (
         , {{ concat_custom(["diagnosis_code_1", "'|'", "coalesce(term.short_description, '')"]) }} as field
         , data_source
     from base
-    left outer join {{ ref('terminology__icd_10_cm') }} as term on base.diagnosis_code_1 = term.icd_10_cm
+    left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(base.diagnosis_code_1, '.', '') = term.icd_10_cm
 ),
 
 claim_grain as (
@@ -61,5 +61,5 @@ select distinct -- to bring to claim_id grain
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
 left outer join claim_grain as cg on m.claim_id = cg.claim_id and m.data_source = cg.data_source
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.diagnosis_code_1 = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.diagnosis_code_1, '.', '') = term.icd_10_cm
 left outer join claim_agg as agg on m.claim_id = agg.claim_id and m.data_source = agg.data_source

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_diagnosis_code_2.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_diagnosis_code_2.sql
@@ -13,7 +13,7 @@ unique_field as (
         , {{ concat_custom(["diagnosis_code_2", "'|'", "coalesce(term.short_description, '')"]) }} as field
         , data_source
     from base
-    left outer join {{ ref('terminology__icd_10_cm') }} as term on base.diagnosis_code_2 = term.icd_10_cm
+    left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(base.diagnosis_code_2, '.', '') = term.icd_10_cm
 ),
 
 claim_grain as (
@@ -60,5 +60,5 @@ select distinct -- to bring to claim_id grain
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
 left outer join claim_grain as cg on m.claim_id = cg.claim_id and m.data_source = cg.data_source
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.diagnosis_code_2 = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.diagnosis_code_2, '.', '') = term.icd_10_cm
 left outer join claim_agg as agg on m.claim_id = agg.claim_id and m.data_source = agg.data_source

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_diagnosis_code_3.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_diagnosis_code_3.sql
@@ -13,7 +13,7 @@ unique_field as (
         , {{ concat_custom(["diagnosis_code_3", "'|'", "coalesce(term.short_description, '')"]) }} as field
         , data_source
     from base
-    left outer join {{ ref('terminology__icd_10_cm') }} as term on base.diagnosis_code_3 = term.icd_10_cm
+    left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(base.diagnosis_code_3, '.', '') = term.icd_10_cm
 ),
 
 claim_grain as (
@@ -60,5 +60,5 @@ select distinct -- to bring to claim_id grain
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
 left outer join claim_grain as cg on m.claim_id = cg.claim_id and m.data_source = cg.data_source
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.diagnosis_code_3 = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.diagnosis_code_3, '.', '') = term.icd_10_cm
 left outer join claim_agg as agg on m.claim_id = agg.claim_id and m.data_source = agg.data_source

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_procedure_code_1.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_procedure_code_1.sql
@@ -12,7 +12,7 @@ unique_field as (
         , {{ concat_custom(["procedure_code_1", "'|'", "coalesce(term.description, '')"]) }} as field
         , data_source
     from base
-    left outer join {{ ref('terminology__icd_10_pcs') }} as term on base.procedure_code_1 = term.icd_10_pcs
+    left outer join {{ ref('terminology__icd_10_pcs') }} as term on replace(base.procedure_code_1, '.', '') = term.icd_10_pcs
 ),
 
 claim_grain as (
@@ -59,5 +59,5 @@ select distinct -- to bring to claim_id grain
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
 left outer join claim_grain as cg on m.claim_id = cg.claim_id and m.data_source = cg.data_source
-left outer join {{ ref('terminology__icd_10_pcs') }} as term on m.procedure_code_1 = term.icd_10_pcs
+left outer join {{ ref('terminology__icd_10_pcs') }} as term on replace(m.procedure_code_1, '.', '') = term.icd_10_pcs
 left outer join claim_agg as agg on m.claim_id = agg.claim_id and m.data_source = agg.data_source

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_procedure_code_2.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_procedure_code_2.sql
@@ -12,7 +12,7 @@ unique_field as (
         , {{ concat_custom(["procedure_code_2", "'|'", "coalesce(term.description, '')"]) }} as field
         , data_source
     from base
-    left outer join {{ ref('terminology__icd_10_pcs') }} as term on base.procedure_code_1 = term.icd_10_pcs
+    left outer join {{ ref('terminology__icd_10_pcs') }} as term on replace(base.procedure_code_1, '.', '') = term.icd_10_pcs
 ),
 
 claim_grain as (
@@ -59,5 +59,5 @@ select distinct -- to bring to claim_id grain
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
 left outer join claim_grain as cg on m.claim_id = cg.claim_id and m.data_source = cg.data_source
-left outer join {{ ref('terminology__icd_10_pcs') }} as term on m.procedure_code_2 = term.icd_10_pcs
+left outer join {{ ref('terminology__icd_10_pcs') }} as term on replace(m.procedure_code_2, '.', '') = term.icd_10_pcs
 left outer join claim_agg as agg on m.claim_id = agg.claim_id and m.data_source = agg.data_source

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_procedure_code_3.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/institutional/data_quality__institutional_procedure_code_3.sql
@@ -12,7 +12,7 @@ unique_field as (
         , {{ concat_custom(["procedure_code_3", "'|'", "coalesce(term.description, '')"]) }} as field
         , data_source
     from base
-    left outer join {{ ref('terminology__icd_10_pcs') }} as term on base.procedure_code_3 = term.icd_10_pcs
+    left outer join {{ ref('terminology__icd_10_pcs') }} as term on replace(base.procedure_code_3, '.', '') = term.icd_10_pcs
 ),
 
 claim_grain as (
@@ -59,5 +59,5 @@ select distinct -- to bring to claim_id grain
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
 left outer join claim_grain as cg on m.claim_id = cg.claim_id and m.data_source = cg.data_source
-left outer join {{ ref('terminology__icd_10_pcs') }} as term on m.procedure_code_3 = term.icd_10_pcs
+left outer join {{ ref('terminology__icd_10_pcs') }} as term on replace(m.procedure_code_3, '.', '') = term.icd_10_pcs
 left outer join claim_agg as agg on m.claim_id = agg.claim_id and m.data_source = agg.data_source

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/professional/data_quality__professional_diagnosis_code_1.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/professional/data_quality__professional_diagnosis_code_1.sql
@@ -30,4 +30,4 @@ select
     , {{ concat_custom(["m.diagnosis_code_1", "'|'", "coalesce(term.short_description, '')"]) }} as field_value
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.diagnosis_code_1 = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.diagnosis_code_1, '.', '') = term.icd_10_cm

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/professional/data_quality__professional_diagnosis_code_2.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/professional/data_quality__professional_diagnosis_code_2.sql
@@ -30,4 +30,4 @@ select
     , {{ concat_custom(["m.diagnosis_code_2", "'|'", "coalesce(term.short_description, '')"]) }} as field_value
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.diagnosis_code_2 = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.diagnosis_code_2, '.', '') = term.icd_10_cm

--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/professional/data_quality__professional_diagnosis_code_3.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/professional/data_quality__professional_diagnosis_code_3.sql
@@ -30,4 +30,4 @@ select
     , {{ concat_custom(["m.diagnosis_code_3", "'|'", "coalesce(term.short_description, '')"]) }} as field_value
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from base as m
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.diagnosis_code_3 = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.diagnosis_code_3, '.', '') = term.icd_10_cm

--- a/models/data_quality/dqi/intermediate/atomic_checks/clinical/condition/data_quality__condition_normalized_code.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/clinical/condition/data_quality__condition_normalized_code.sql
@@ -19,4 +19,4 @@ select
     , cast(normalized_code as {{ dbt.type_string() }}) as field_value
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('condition') }} as m
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.normalized_code = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.normalized_code, '.', '') = term.icd_10_cm

--- a/models/data_quality/dqi/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_primary_diagnosis_code.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/clinical/encounter/data_quality__encounter_primary_diagnosis_code.sql
@@ -19,4 +19,4 @@ select
     , cast(primary_diagnosis_code as {{ dbt.type_string() }}) as field_value
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('encounter') }} as m
-left outer join {{ ref('terminology__icd_10_cm') }} as term on m.primary_diagnosis_code = term.icd_10_cm
+left outer join {{ ref('terminology__icd_10_cm') }} as term on replace(m.primary_diagnosis_code, '.', '') = term.icd_10_cm

--- a/models/data_quality/dqi/intermediate/atomic_checks/clinical/procedure/data_quality__procedure_normalized_code.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/clinical/procedure/data_quality__procedure_normalized_code.sql
@@ -40,7 +40,7 @@ with icd9 as (
            else null end as invalid_reason
     , cast(normalized_code as {{ dbt.type_string() }}) as field_value
 from {{ ref('procedure') }} as m
-left outer join {{ ref('terminology__icd_10_pcs') }} as term on m.normalized_code = term.icd_10_pcs
+left outer join {{ ref('terminology__icd_10_pcs') }} as term on replace(m.normalized_code, '.', '') = term.icd_10_pcs
 where
     m.normalized_code_type = 'icd_10_pcs'
 )

--- a/models/data_quality/intermediate/data_quality__dx_and_px.sql
+++ b/models/data_quality/intermediate/data_quality__dx_and_px.sql
@@ -323,9 +323,9 @@ with unpivot_diagnosis as(
         end as invalid_diagnosis
     from unpivot_diagnosis dx
     left join {{ ref('terminology__icd_10_cm') }} icd10
-        on dx.diagnosis_code = icd10.icd_10_cm
+        on replace(dx.diagnosis_code, '.', '') = icd10.icd_10_cm
     left join {{ ref('terminology__icd_9_cm') }} icd9
-        on dx.diagnosis_code = icd9.icd_9_cm
+        on replace(dx.diagnosis_code, '.', '') = icd9.icd_9_cm
     where diagnosis_column = 'DIAGNOSIS_CODE_1'
     and diagnosis_code is not null
     )x
@@ -366,9 +366,9 @@ with unpivot_diagnosis as(
         end as invalid_diagnosis
     from unpivot_diagnosis dx
     left join {{ ref('terminology__icd_10_cm') }} icd10
-        on dx.diagnosis_code = icd10.icd_10_cm
+        on replace(dx.diagnosis_code, '.', '') = icd10.icd_10_cm
     left join {{ ref('terminology__icd_9_cm') }} icd9
-    on dx.diagnosis_code = icd9.icd_9_cm
+    on replace(dx.diagnosis_code, '.', '') = icd9.icd_9_cm
     where diagnosis_column <> 'DIAGNOSIS_CODE_1'
     and diagnosis_code is not null
     )x
@@ -392,9 +392,9 @@ with unpivot_diagnosis as(
         end as invalid_procedure
     from unpivot_procedure px
     left join {{ ref('terminology__icd_10_pcs') }} icd10
-        on px.procedure_code = icd10.icd_10_pcs
+        on replace(px.procedure_code, '.', '') = icd10.icd_10_pcs
     left join {{ ref('terminology__icd_9_pcs') }} icd9
-    on px.procedure_code = icd9.icd_9_pcs
+    on replace(px.procedure_code, '.', '') = icd9.icd_9_pcs
     where px.procedure_code is not null
     )x
     where invalid_procedure = 1


### PR DESCRIPTION
DQI validates raw diagnosis/procedure codes against terminology tables that store codes without decimals. Codes with decimals (e.g., J06.9) fail the lookup and are incorrectly flagged as invalid. Apply replace() to strip decimals before joining, matching the existing pattern in claims_preprocessing normalized_input.

Affects legacy DQI, DQI atomic checks for institutional/professional diagnosis codes 1-3, procedure codes 1-3, and clinical encounter/ condition/procedure checks (22 join conditions across 13 files).

Fixes #995