### PR TITLE
Filter CMS-HCC eligibility staging to Medicare records only (#1145)

### DIFF
--- a/models/cms_hcc/staging/cms_hcc__stg_core__eligibility.sql
+++ b/models/cms_hcc/staging/cms_hcc__stg_core__eligibility.sql
@@ -15,3 +15,5 @@ select distinct
     , data_source
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from {{ ref('core__eligibility') }}
+where lower(payer_type) = 'medicare'
+   or payer_type is null


### PR DESCRIPTION
Coverage month calculation for New vs Continuing enrollment status was counting all payer types (commercial, Medicaid, etc.), inflating months and incorrectly classifying members as Continuing.  Filter to payer_type = 'medicare' (with null fallback for backwards compat).