### PR TITLE
Include source_code_type in procedure_id to prevent PK violations (#1114)

### DIFF
--- a/models/core/staging/core__stg_claims_procedure.sql
+++ b/models/core/staging/core__stg_claims_procedure.sql
@@ -17,6 +17,8 @@
         "'_'",
         "unpivot_cte.procedure_sequence_id",
         "'_'",
+        "CAST(COALESCE(unpivot_cte.source_code_type, 'unknown') AS " ~ dbt.type_string() ~ ")",
+        "'_'",
         "unpivot_cte.source_code",
         "case when unpivot_cte.modifier_1 is not null then CONCAT('_', unpivot_cte.modifier_1) else '' end",
         "case when unpivot_cte.modifier_2 is not null then CONCAT('_', unpivot_cte.modifier_2) else '' end",


### PR DESCRIPTION
When claim lines have inconsistent procedure_code_type values (e.g., 'icd-10-pcs' on one line and NULL on another), the unpivot produces duplicate rows with different source_code_type but identical procedure_id.  Adding source_code_type to the procedure_id construction ensures uniqueness.