### PR TITLE
Include source_code_type in condition_id to prevent PK violations (#1110)

### DIFF
--- a/models/core/staging/core__stg_claims_condition.sql
+++ b/models/core/staging/core__stg_claims_condition.sql
@@ -18,6 +18,8 @@
         "'_'",
         "CAST(unpivot_cte.diagnosis_rank AS " ~ dbt.type_string() ~ ")",
         "'_'",
+        "CAST(COALESCE(unpivot_cte.source_code_type, 'unknown') AS " ~ dbt.type_string() ~ ")",
+        "'_'",
         "CAST(unpivot_cte.source_code AS " ~ dbt.type_string() ~ ")",
     ]), api.Column.translate_type("string"))
  }} as condition_id


### PR DESCRIPTION
When claim lines have inconsistent diagnosis_code_type values (e.g., 'icd-10-cm' on one line and NULL on another), the intermediate model produces duplicate rows with different source_code_type but identical condition_id.  Adding source_code_type to the condition_id construction ensures uniqueness.