### PR TITLE
Fix OREC/disabled model classification per CMS SAS DISABL/ORIGDS logic (#1002)

### DIFF
--- a/models/cms_hcc/intermediate/cms_hcc__int_members.sql
+++ b/models/cms_hcc/intermediate/cms_hcc__int_members.sql
@@ -247,17 +247,33 @@ with stg_eligibility as (
             else 'Non'
           end as dual_status
         /*
-           The CMS-HCC model does not have factors for ESRD for these edge-cases,
-           we default to 'Aged'. When OREC is missing, latest Medicare status is
-           used, if available.
+           CMS SAS: DISABL = (AGEF < 65 & OREC ne "0")
+           Members under 65 with non-aged OREC use the Disabled community
+           model (CND/CFD/CPD).  Members 65+ always use the Aged community
+           model (CNA/CFA/CPA), regardless of OREC.
+
+           When OREC is missing, latest Medicare status is used as a proxy.
         */
         , case
             when original_reason_entitlement_code in ('0', '2') then 'Aged'
+            when original_reason_entitlement_code in ('1', '3') and payment_year_age >= 65 then 'Aged'
             when original_reason_entitlement_code in ('1', '3') then 'Disabled'
             when original_reason_entitlement_code is null and medicare_status_code in ('10', '11', '31') then 'Aged'
+            when original_reason_entitlement_code is null and medicare_status_code in ('20', '21') and payment_year_age >= 65 then 'Aged'
             when original_reason_entitlement_code is null and medicare_status_code in ('20', '21') then 'Disabled'
             when coalesce(original_reason_entitlement_code, medicare_status_code) is null then 'Aged'
           end as orec
+        /*
+           CMS SAS: ORIGDS = (OREC = '1') * (DISABL = 0)
+           Originally disabled: member entered Medicare through disability
+           (OREC = 1) but has since turned 65.  These members use the Aged
+           model but receive an additional interaction factor.
+        */
+        , case
+            when original_reason_entitlement_code = '1' and payment_year_age >= 65 then 'Yes'
+            when original_reason_entitlement_code is null and medicare_status_code in ('20', '21') and payment_year_age >= 65 then 'Yes'
+            else 'No'
+          end as originally_disabled_flag
         /* Defaulting everyone to non-institutional until logic is added */
         , case when enrollment_status = 'Institutional' then 'Yes' else 'No' end as institutional_status
         , enrollment_status_default
@@ -306,6 +322,7 @@ with stg_eligibility as (
         , cast(dual_status as {{ dbt.type_string() }}) as dual_status
         , cast(orec as {{ dbt.type_string() }}) as orec
         , cast(institutional_status as {{ dbt.type_string() }}) as institutional_status
+        , cast(originally_disabled_flag as {{ dbt.type_string() }}) as originally_disabled_flag
         {% if target.type == 'fabric' %}
             , cast(enrollment_status_default as bit) as enrollment_status_default
             , cast(medicaid_dual_status_default as bit) as medicaid_dual_status_default
@@ -334,6 +351,7 @@ select
     , dual_status
     , orec
     , institutional_status
+    , originally_disabled_flag
     , enrollment_status_default
     , medicaid_dual_status_default
     , orec_default

--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_demographic_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_demographic_factors.sql
@@ -13,26 +13,8 @@ with members as (
         , age_group
         , medicaid_status
         , dual_status
-        /* HACK: Adhoc fix for new enrollees and <65 years old. They are being given coefficient = 0, but really should be given what is currently listed as 'Aged'.
-        However, 'Aged' is an incorrect label here and should be updated to null given the labels in the SAS code look like this: NE_NMCAID_NORIGDIS_NEF0_34.
-        The SAS code NE_NMCAID_NORIGDIS_NEF0_34 simply says 'New Enrollee, Not Medicaid, Not Originally Disabled, Female, 0-34'. Not Originally Disabled != Aged.
-        Here is the definition for originally disabled per the SAS code:
-            %* disabled;
-            DISABL = (&AGEF < 65 & &OREC ne "0");
-            %* originally disabled;
-            ORIGDS  = (&OREC = '1')*(DISABL = 0);
-        This means that < 65 is just disabled and not originally disabled.
-        All in all, this is a hack to use the correct coefficient for New enrolles < 65. The correct coefficient is 'Aged'. However, the seed file needs to be
-        updated for these members so there is a coefficient value instead of 0.
-       */
-        , case
-            when enrollment_status = 'New' and age_group = '0-34' then 'Aged'
-            when enrollment_status = 'New' and age_group = '35-44' then 'Aged'
-            when enrollment_status = 'New' and age_group = '45-54' then 'Aged'
-            when enrollment_status = 'New' and age_group = '55-59' then 'Aged'
-            when enrollment_status = 'New' and age_group = '60-64' then 'Aged'
-            else orec
-         end as orec
+        , orec
+        , originally_disabled_flag
         , institutional_status
         , enrollment_status_default
         , medicaid_dual_status_default
@@ -82,6 +64,11 @@ with members as (
 
 )
 
+/*
+    NE seed uses orec to distinguish ORIGDIS vs NORIGDIS:
+      - 'Disabled' in seed = originally disabled (OREC=1, age 65+)
+      - 'Aged' in seed = not originally disabled (everyone else)
+*/
 , new_enrollees as (
     select
           members.person_id
@@ -92,6 +79,7 @@ with members as (
         , members.medicaid_status
         , members.dual_status
         , members.orec
+        , members.originally_disabled_flag
         , members.institutional_status
         , members.enrollment_status_default
         , members.medicaid_dual_status_default
@@ -110,7 +98,10 @@ with members as (
         and members.gender = seed_demographic_factors.gender
         and members.age_group = seed_demographic_factors.age_group
         and members.medicaid_status = seed_demographic_factors.medicaid_status
-        and members.orec = seed_demographic_factors.orec
+        and case
+                when members.originally_disabled_flag = 'Yes' then 'Disabled'
+                else 'Aged'
+            end = seed_demographic_factors.orec
     where members.enrollment_status = 'New'
 )
 
@@ -124,6 +115,7 @@ with members as (
         , members.medicaid_status
         , members.dual_status
         , members.orec
+        , members.originally_disabled_flag
         , members.institutional_status
         , members.enrollment_status_default
         , members.medicaid_dual_status_default
@@ -143,8 +135,7 @@ with members as (
         and members.age_group = seed_demographic_factors.age_group
         and members.medicaid_status = seed_demographic_factors.medicaid_status
         and members.dual_status = seed_demographic_factors.dual_status
-            /* THIS CARVE OUT EXISTS AS MEMBERS WITH OREC = DISABLED OVER 65 SHOULD GET THE AGED DEMO FACTOR. */
-        and case when members.age_group in ('65-69', '70-74', '75-79', '80-84', '85-89', '90-94', '>=95') then 'Aged' else members.orec end = seed_demographic_factors.orec
+        and members.orec = seed_demographic_factors.orec
         and members.institutional_status = seed_demographic_factors.institutional_status
     where members.enrollment_status = 'Continuing'
 )
@@ -160,6 +151,7 @@ with members as (
         , members.medicaid_status
         , members.dual_status
         , members.orec
+        , members.originally_disabled_flag
         , members.institutional_status
         , members.enrollment_status_default
         , members.medicaid_dual_status_default
@@ -199,6 +191,7 @@ with members as (
         , cast(dual_status as {{ dbt.type_string() }}) as dual_status
         , cast(orec as {{ dbt.type_string() }}) as orec
         , cast(institutional_status as {{ dbt.type_string() }}) as institutional_status
+        , cast(originally_disabled_flag as {{ dbt.type_string() }}) as originally_disabled_flag
         {% if target.type == 'fabric' %}
             , cast(enrollment_status_default as bit) as enrollment_status_default
             , cast(medicaid_dual_status_default as bit) as medicaid_dual_status_default
@@ -230,6 +223,7 @@ select
     , dual_status
     , orec
     , institutional_status
+    , originally_disabled_flag
     , enrollment_status_default
     , medicaid_dual_status_default
     , orec_default

--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_factors.sql
@@ -13,7 +13,7 @@ with demographics as (
         , age_group
         , medicaid_status
         , dual_status
-        , case when age_group in ('65-69', '70-74', '75-79', '80-84', '85-89', '90-94', '>=95') then 'Aged' else orec end as orec
+        , orec
         , institutional_status
         , model_version
         , payment_year

--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_interaction_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_interaction_factors.sql
@@ -13,7 +13,7 @@ with demographics as (
         , age_group
         , medicaid_status
         , dual_status
-        , case when age_group in ('65-69', '70-74', '75-79', '80-84', '85-89', '90-94', '>=95') then 'Aged' else orec end as orec
+        , orec
         , institutional_status
         , model_version
         , payment_year

--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_enrollment_interaction_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_enrollment_interaction_factors.sql
@@ -14,6 +14,7 @@ with demographics as (
         , medicaid_status
         , dual_status
         , orec
+        , originally_disabled_flag
         , institutional_status
         , model_version
         , payment_year
@@ -63,16 +64,7 @@ with demographics as (
             and demographics.institutional_status = seed_interaction_factors.institutional_status
             and demographics.model_version = seed_interaction_factors.model_version
     where demographics.institutional_status = 'No'
-        and demographics.orec = 'Disabled'
-        and demographics.age_group in (
-              '65-69'
-            , '70-74'
-            , '75-79'
-            , '80-84'
-            , '85-89'
-            , '90-94'
-            , '>=95'
-        )
+        and demographics.originally_disabled_flag = 'Yes'
 
 )
 

--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_hcc_count_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_hcc_count_factors.sql
@@ -11,7 +11,7 @@ with demographics as (
         , enrollment_status
         , medicaid_status
         , dual_status
-        , case when age_group in ('65-69', '70-74', '75-79', '80-84', '85-89', '90-94', '>=95') then 'Aged' else orec end as orec
+        , orec
         , institutional_status
         , model_version
         , payment_year


### PR DESCRIPTION
Make orec age-aware at the source in cms_hcc__int_members: members 65+ with disability OREC now correctly map to the Aged community model (CNA/CFA/CPA) instead of Disabled (CND/CFD/CPD).

Add originally_disabled_flag (OREC=1 + age>=65) and thread it through demographic_factors to enrollment_interaction_factors, replacing the scattered age-group hacks across 5 downstream factor models.

CMS SAS reference:
  DISABL = (AGEF < 65 & OREC ne "0")
  ORIGDS = (OREC = '1') * (DISABL = 0)