### PR TITLE
Convert latitude and longitude columns from float to numeric

### DIFF
--- a/models/core/staging/core__stg_claims_location.sql
+++ b/models/core/staging/core__stg_claims_location.sql
@@ -67,8 +67,8 @@ select
     , cast(practice_city as {{ dbt.type_string() }}) as city
     , cast(practice_state as {{ dbt.type_string() }}) as state
     , cast(practice_zip_code as {{ dbt.type_string() }}) as zip_code
-    , cast(null as {{ dbt.type_float() }}) as latitude
-    , cast(null as {{ dbt.type_float() }}) as longitude
+    , cast(null as {{ dbt.type_numeric() }}) as latitude
+    , cast(null as {{ dbt.type_numeric() }}) as longitude
     , cast(null as {{ dbt.type_string() }}) as data_source
     , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_timestamp() }}) as tuva_last_run
 from provider

--- a/models/core/staging/core__stg_claims_patient.sql
+++ b/models/core/staging/core__stg_claims_patient.sql
@@ -20,8 +20,8 @@
     , cast(state as {{ dbt.type_string() }}) as state
     , cast(zip_code as {{ dbt.type_string() }}) as zip_code
     , cast(null as {{ dbt.type_string() }}) as county
-    , cast(null as {{ dbt.type_float() }}) as latitude
-    , cast(null as {{ dbt.type_float() }}) as longitude
+    , cast(null as {{ dbt.type_numeric() }}) as latitude
+    , cast(null as {{ dbt.type_numeric() }}) as longitude
     , cast(phone as {{ dbt.type_string() }}) as phone
     , cast(email as {{ dbt.type_string() }}) as email
     , cast(ethnicity as {{ dbt.type_string() }}) as ethnicity

--- a/models/core/staging/core__stg_clinical_location.sql
+++ b/models/core/staging/core__stg_clinical_location.sql
@@ -14,8 +14,8 @@
     , cast(city as {{ dbt.type_string() }}) as city
     , cast(state as {{ dbt.type_string() }}) as state
     , cast(zip_code as {{ dbt.type_string() }}) as zip_code
-    , cast(latitude as {{ dbt.type_float() }}) as latitude
-    , cast(longitude as {{ dbt.type_float() }}) as longitude
+    , cast(latitude as {{ dbt.type_numeric() }}) as latitude
+    , cast(longitude as {{ dbt.type_numeric() }}) as longitude
 {%- endset -%}
 
 {%- set tuva_metadata_columns -%}

--- a/models/core/staging/core__stg_clinical_patient.sql
+++ b/models/core/staging/core__stg_clinical_patient.sql
@@ -20,8 +20,8 @@
     , cast(state as {{ dbt.type_string() }}) as state
     , cast(zip_code as {{ dbt.type_string() }}) as zip_code
     , cast(county as {{ dbt.type_string() }}) as county
-    , cast(latitude as {{ dbt.type_float() }}) as latitude
-    , cast(longitude as {{ dbt.type_float() }}) as longitude
+    , cast(latitude as {{ dbt.type_numeric() }}) as latitude
+    , cast(longitude as {{ dbt.type_numeric() }}) as longitude
     , cast(phone as {{ dbt.type_string() }}) as phone
     , cast(email as {{ dbt.type_string() }}) as email
     , cast(ethnicity as {{ dbt.type_string() }}) as ethnicity


### PR DESCRIPTION
Replace dbt.type_float() with dbt.type_numeric() for latitude and longitude columns in patient and location staging models. Floating point types introduce rounding artifacts for coordinate values; numeric/decimal types preserve exact precision needed for geospatial accuracy.

Fixes #794