### PR TITLE
Remove ESRD enrollment_status override that excludes OREC=2/3 members

### DIFF
--- a/models/cms_hcc/intermediate/cms_hcc__int_members.sql
+++ b/models/cms_hcc/intermediate/cms_hcc__int_members.sql
@@ -230,7 +230,7 @@ with stg_eligibility as (
         , payment_year
         , collection_start_date
         , collection_end_date
-        , case when original_reason_entitlement_code in ('2', '3') then 'ESRD' else enrollment_status end as enrollment_status
+        , enrollment_status
         , case
             when gender = 'female' then 'Female'
             when gender = 'male' then 'Male'


### PR DESCRIPTION
Members with original_reason_entitlement_code '2' (ESRD) or '3' (ESRD + disability) had their enrollment_status overridden to 'ESRD', which doesn't match any demographic factor seed rows, causing these members to be completely excluded from CMS-HCC Part C scoring.

OREC indicates why a beneficiary was originally entitled to Medicare, not whether they should receive Part C risk scores. The CMS SAS reference code uses OREC only to compute DISABL and ORIGDS flags, which are already handled correctly by the orec column mapping.

Fixes #1234