### PR TITLE
Relax disease/interaction/hcc-count factor seed joins for institutional model

### DIFF
--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_factors.sql
@@ -109,12 +109,17 @@ with demographics as (
     from demographics_with_hccs
         inner join seed_disease_factors
             on demographics_with_hccs.enrollment_status = seed_disease_factors.enrollment_status
-            and demographics_with_hccs.medicaid_status = seed_disease_factors.medicaid_status
-            and demographics_with_hccs.dual_status = seed_disease_factors.dual_status
-            and demographics_with_hccs.orec = seed_disease_factors.orec
             and demographics_with_hccs.institutional_status = seed_disease_factors.institutional_status
             and demographics_with_hccs.hcc_code = seed_disease_factors.hcc_code
             and demographics_with_hccs.model_version = seed_disease_factors.model_version
+            and (
+                demographics_with_hccs.institutional_status = 'Yes'
+                or (
+                    demographics_with_hccs.medicaid_status = seed_disease_factors.medicaid_status
+                    and demographics_with_hccs.dual_status = seed_disease_factors.dual_status
+                    and demographics_with_hccs.orec = seed_disease_factors.orec
+                )
+            )
 
 )
 

--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_interaction_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_disease_interaction_factors.sql
@@ -98,12 +98,17 @@ with demographics as (
     from demographics_with_hccs
         inner join seed_interaction_factors as interactions_code_1
             on demographics_with_hccs.enrollment_status = interactions_code_1.enrollment_status
-            and demographics_with_hccs.medicaid_status = interactions_code_1.medicaid_status
-            and demographics_with_hccs.dual_status = interactions_code_1.dual_status
-            and demographics_with_hccs.orec = interactions_code_1.orec
             and demographics_with_hccs.institutional_status = interactions_code_1.institutional_status
             and demographics_with_hccs.hcc_code = interactions_code_1.hcc_code_1
             and demographics_with_hccs.model_version = interactions_code_1.model_version
+            and (
+                demographics_with_hccs.institutional_status = 'Yes'
+                or (
+                    demographics_with_hccs.medicaid_status = interactions_code_1.medicaid_status
+                    and demographics_with_hccs.dual_status = interactions_code_1.dual_status
+                    and demographics_with_hccs.orec = interactions_code_1.orec
+                )
+            )
 
 )
 

--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_hcc_count_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_hcc_count_factors.sql
@@ -126,12 +126,17 @@ with demographics as (
     from hcc_counts_normalized
         inner join seed_payment_hcc_count_factors
             on hcc_counts_normalized.enrollment_status = seed_payment_hcc_count_factors.enrollment_status
-            and hcc_counts_normalized.medicaid_status = seed_payment_hcc_count_factors.medicaid_status
-            and hcc_counts_normalized.dual_status = seed_payment_hcc_count_factors.dual_status
-            and hcc_counts_normalized.orec = seed_payment_hcc_count_factors.orec
             and hcc_counts_normalized.institutional_status = seed_payment_hcc_count_factors.institutional_status
             and hcc_counts_normalized.hcc_count_string = seed_payment_hcc_count_factors.payment_hcc_count
             and hcc_counts_normalized.model_version = seed_payment_hcc_count_factors.model_version
+            and (
+                hcc_counts_normalized.institutional_status = 'Yes'
+                or (
+                    hcc_counts_normalized.medicaid_status = seed_payment_hcc_count_factors.medicaid_status
+                    and hcc_counts_normalized.dual_status = seed_payment_hcc_count_factors.dual_status
+                    and hcc_counts_normalized.orec = seed_payment_hcc_count_factors.orec
+                )
+            )
 
 )
 


### PR DESCRIPTION
The CMS-HCC institutional (INS) model uses a single set of coefficients per HCC, without splitting by medicaid_status, dual_status, or orec. The existing joins required exact matches on all dimensions, which incorrectly excluded institutional members whose demographic values didn't match the seed rows. This adds conditional join logic that skips medicaid/dual/orec matching when institutional_status = 'Yes'.