### PR TITLE
Add dbt variable reference documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,62 @@ From there we recommend iterating with your preferred coding agent using [AGENTS
 Hello and welcome! Thank you so much for taking the time to contribute to the Tuva Project. People like you are helping to build a community of healthcare data practitioners that shares knowledge and tools. Whether it’s fixing a bug, submitting an idea, updating the docs, or sharing your healthcare knowledge, you can make an impact!
 
 In this guide, you will get an overview of the contribution workflow, from how to contribute, setting up your development environment, testing, and creating a pull request.
+
+## dbt Variables
+
+Tuva uses dbt variables (`var()`) to control which parts of the pipeline are enabled and to configure runtime behavior. Set these in your `dbt_project.yml` under the `vars:` key.
+
+### Data Source Enablement
+
+These variables control which input data types are active. Setting a group-level variable enables all marts in that group; individual mart variables override the group setting.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `claims_enabled` | `false` | Enable all claims-based marts |
+| `clinical_enabled` | `false` | Enable all clinical-based marts |
+| `tuva_marts_enabled` | `false` | Enable all marts (claims + clinical). Overridden by the more specific variables above. |
+
+### Individual Mart Enablement
+
+Each mart can be independently enabled or disabled. When not set, these inherit from `claims_enabled`, `clinical_enabled`, or `tuva_marts_enabled`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `claims_preprocessing_enabled` | Inherits | Claims preprocessing (encounters, service categories, normalized input) |
+| `ccsr_enabled` | Inherits | Clinical Classifications Software Refined (CCSR) |
+| `cms_chronic_conditions_enabled` | Inherits | CMS Chronic Conditions |
+| `tuva_chronic_conditions_enabled` | Inherits | Tuva Chronic Conditions |
+| `cms_hcc_enabled` | Inherits | CMS-HCC Risk Adjustment |
+| `ed_classification_enabled` | Inherits | ED Classification |
+| `financial_pmpm_enabled` | Inherits | Financial PMPM |
+| `hcc_suspecting_enabled` | `false` | HCC Suspecting |
+| `hcc_recapture_enabled` | `false` | HCC Recapture |
+| `quality_measures_enabled` | Inherits | Quality Measures (HEDIS/CQM) |
+| `readmissions_enabled` | Inherits | Readmissions |
+| `fhir_preprocessing_enabled` | `false` | FHIR Preprocessing |
+| `pqi_enabled` | Inherits | AHRQ Prevention Quality Indicators |
+| `provider_attribution_enabled` | Inherits | Provider Attribution |
+| `semantic_layer_enabled` | Inherits | Semantic Layer |
+| `brand_generic_enabled` | Inherits | Brand/Generic pharmacy analysis |
+
+### Runtime Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tuva_last_run` | Current UTC timestamp | Populates the `tuva_last_run` column in all output models. Automatically set to the dbt run start time. |
+| `cms_hcc_payment_year` | Current year | The CMS-HCC payment year for risk score calculation. |
+| `quality_measures_period_end` | Current year-end | End date of the quality measures reporting period. |
+| `record_type` | `"ip"` | CCSR record type: `"ip"` for inpatient, `"op"` for outpatient. |
+| `dxccsr_version` | `"’2023.1’"` | CCSR diagnosis mapping version. |
+| `prccsr_version` | `"’2023.1’"` | CCSR procedure mapping version. |
+
+### Infrastructure & Schema
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tuva_schema_prefix` | `None` | When set, all Tuva output schemas are prefixed with this value (e.g., `myprefix_core`). |
+| `custom_bucket_name` | `"tuva-public-resources"` | S3 bucket for seed data. Override to use a private bucket. |
+| `enable_input_layer_testing` | `true` | Run DQI data quality tests on the input layer. |
+| `enable_legacy_data_quality` | `false` | Build legacy (pre-DQI) data quality models. |
+| `enable_normalize_engine` | `false` | Enable the normalize engine for custom code mapping. Set to `"unmapped"` to list unmapped codes, or `true` to also integrate custom mappings. |
+| `provider_attribution_as_of_date` | None | Reference date for provider attribution calculations. |


### PR DESCRIPTION
Document all user-configurable dbt variables including data source enablement, individual mart toggles, runtime configuration, and infrastructure/schema settings.

Fixes #1097