### PR TITLE
Skip seed population check for non-build dbt commands

### DIFF
--- a/macros/processing_flow/log_warning_for_seeds.sql
+++ b/macros/processing_flow/log_warning_for_seeds.sql
@@ -1,6 +1,11 @@
 -- macros/log_warning_for_seeds.sql
 {% macro log_warning_for_seeds() %}
 
+    {%- set dbt_command = flags.WHICH -%}
+    {% if dbt_command not in ['seed', 'build', 'run'] %}
+        {% do return('') %}
+    {% endif %}
+
     {% set seeds = get_selected_seeds() %}
 
     {% for seed in seeds %}


### PR DESCRIPTION
The on-run-end hook log_warning_for_seeds() queries seed tables that may not exist yet, causing failures on dbt docs generate, compile, and parse. Guard with flags.WHICH to only run during seed/build/run.

Fixes #983