### PR TITLE
Accept CDT dental codes (Dxxxx) in DQI HCPCS validation

### DIFF
--- a/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_hcpcs_code.sql
+++ b/models/data_quality/dqi/intermediate/atomic_checks/claims/medical/data_quality__claim_hcpcs_code.sql
@@ -14,13 +14,13 @@ select
     , 'HCPCS_CODE' as field_name
     , case
           when term.hcpcs is not null then 'valid'
-          when m.hcpcs_code is not null and length(m.hcpcs_code) = 5 and substring(m.hcpcs_code, 1, 1) = 'D' then 'valid'
+          when m.hcpcs_code is not null and {{ the_tuva_project.length('m.hcpcs_code') }} = 5 and substring(m.hcpcs_code, 1, 1) = 'D' then 'valid'
           when m.hcpcs_code is not null then 'invalid'
           else 'null'
     end as bucket_name
     , case
         when m.hcpcs_code is not null and term.hcpcs is null
-            and not (length(m.hcpcs_code) = 5 and substring(m.hcpcs_code, 1, 1) = 'D')
+            and not ({{ the_tuva_project.length('m.hcpcs_code') }} = 5 and substring(m.hcpcs_code, 1, 1) = 'D')
             then 'HCPCS does not join to Terminology HCPCS_LEVEL_2 table'
         else null
      end as invalid_reason


### PR DESCRIPTION
CDT codes follow the pattern D followed by 4 characters and are valid procedure codes that cannot be added to the terminology table due to copyright. Recognize them as valid via pattern match so they are not flagged as invalid HCPCS codes.