### PR TITLE
Defer monthly collection date expansion in eligible conditions

### DIFF
--- a/models/cms_hcc/intermediate/cms_hcc__int_eligible_conditions.sql
+++ b/models/cms_hcc/intermediate/cms_hcc__int_eligible_conditions.sql
@@ -71,6 +71,23 @@ with medical_claims as (
 
 )
 
+/*
+    Aggregate monthly collection dates to yearly boundaries to avoid
+    expanding claims by up to 12x at this early stage. The monthly
+    grain is deferred to after the condition join where the dataset
+    is much smaller.
+*/
+, yearly_collection_dates as (
+
+    select
+          payment_year
+        , min(collection_start_date) as collection_start_date
+        , max(collection_end_date) as collection_end_date
+    from {{ ref('cms_hcc__int_monthly_collection_dates') }}
+    group by payment_year
+
+)
+
 , professional_claims as (
 
     select
@@ -84,12 +101,11 @@ with medical_claims as (
         , medical_claims.bill_type_code
         , medical_claims.hcpcs_code
         , dates.payment_year
-        , dates.collection_start_date
-        , dates.collection_end_date
+        , coalesce(medical_claims.claim_end_date, medical_claims.claim_start_date) as condition_date
     from medical_claims
         inner join cpt_hcpcs_list
             on medical_claims.hcpcs_code = cpt_hcpcs_list.hcpcs_cpt_code
-        inner join {{ ref('cms_hcc__int_monthly_collection_dates') }} as dates
+        inner join yearly_collection_dates as dates
             on coalesce(claim_end_date, claim_start_date) between dates.collection_start_date and dates.collection_end_date
             and cpt_hcpcs_list.collection_year + 1 = dates.payment_year
     where claim_type = 'professional'
@@ -108,10 +124,9 @@ with medical_claims as (
         , medical_claims.bill_type_code
         , medical_claims.hcpcs_code
         , dates.payment_year
-        , dates.collection_start_date
-        , dates.collection_end_date
+        , coalesce(medical_claims.claim_end_date, medical_claims.claim_start_date) as condition_date
     from medical_claims
-        inner join {{ ref('cms_hcc__int_monthly_collection_dates') }} as dates
+        inner join yearly_collection_dates as dates
             on coalesce(claim_end_date, claim_start_date) between dates.collection_start_date and dates.collection_end_date
     where claim_type = 'institutional'
         and substring(bill_type_code, 1, 2) in ('11', '41')
@@ -131,14 +146,11 @@ with medical_claims as (
         , medical_claims.bill_type_code
         , medical_claims.hcpcs_code
         , dates.payment_year
-        , dates.collection_start_date
-        , dates.collection_end_date
+        , coalesce(medical_claims.claim_end_date, medical_claims.claim_start_date) as condition_date
     from medical_claims
         inner join cpt_hcpcs_list
             on medical_claims.hcpcs_code = cpt_hcpcs_list.hcpcs_cpt_code
-        -- TODO: Review if this needs to be done here...likely can be done much later to avoid increasing number of rows by 12
-        -- this early on
-        inner join {{ ref('cms_hcc__int_monthly_collection_dates') }} as dates
+        inner join yearly_collection_dates as dates
             on coalesce(claim_end_date, claim_start_date) between dates.collection_start_date and dates.collection_end_date
             and cpt_hcpcs_list.collection_year + 1 = dates.payment_year
     where claim_type = 'institutional'
@@ -164,14 +176,36 @@ with medical_claims as (
         , eligible_claims.payer
         , eligible_claims.person_id
         , eligible_claims.payment_year
-        , eligible_claims.collection_start_date
-        , eligible_claims.collection_end_date
+        , eligible_claims.condition_date
         , conditions.code
     from eligible_claims
         inner join conditions
             on eligible_claims.claim_id = conditions.claim_id
             and eligible_claims.person_id = conditions.person_id
             and eligible_claims.payer = conditions.payer
+
+)
+
+/*
+    Expand to monthly grain after condition deduplication. Each condition
+    appears in all collection months where its claim date falls within
+    the cumulative collection window (condition_date <= collection_end_date).
+*/
+, eligible_conditions_monthly as (
+
+    select distinct
+          ec.claim_id
+        , ec.claim_line_number
+        , ec.payer
+        , ec.person_id
+        , ec.payment_year
+        , dates.collection_start_date
+        , dates.collection_end_date
+        , ec.code
+    from eligible_conditions as ec
+        inner join {{ ref('cms_hcc__int_monthly_collection_dates') }} as dates
+            on ec.payment_year = dates.payment_year
+            and ec.condition_date <= dates.collection_end_date
 
 )
 
@@ -186,7 +220,7 @@ with medical_claims as (
         , cast(payment_year as integer) as payment_year
         , cast(collection_start_date as date) as collection_start_date
         , cast(collection_end_date as date) as collection_end_date
-    from eligible_conditions
+    from eligible_conditions_monthly
 
 )
 


### PR DESCRIPTION
The monthly collection dates join was applied in each claim-type CTE (professional, inpatient, outpatient), expanding every claim by up to 12x before the condition join. This created unnecessarily large intermediate datasets.

Now claims join to yearly-aggregated collection dates (1 row per year) for initial eligibility filtering, and the monthly expansion is deferred to after the condition join where the dataset is much smaller. The output schema is unchanged so no downstream models are affected.

Closes #1122