### PR TITLE
Fix OREC=2 (ESRD) members under 65 incorrectly assigned Aged model

### DIFF
--- a/models/cms_hcc/intermediate/cms_hcc__int_members.sql
+++ b/models/cms_hcc/intermediate/cms_hcc__int_members.sql
@@ -259,9 +259,9 @@ with stg_eligibility as (
            When OREC is missing, latest Medicare status is used as a proxy.
         */
         , case
-            when original_reason_entitlement_code in ('0', '2') then 'Aged'
-            when original_reason_entitlement_code in ('1', '3') and payment_year_age >= 65 then 'Aged'
-            when original_reason_entitlement_code in ('1', '3') then 'Disabled'
+            when original_reason_entitlement_code = '0' then 'Aged'
+            when original_reason_entitlement_code in ('1', '2', '3') and payment_year_age >= 65 then 'Aged'
+            when original_reason_entitlement_code in ('1', '2', '3') then 'Disabled'
             when original_reason_entitlement_code is null and medicare_status_code in ('10', '11', '31') then 'Aged'
             when original_reason_entitlement_code is null and medicare_status_code in ('20', '21') and payment_year_age >= 65 then 'Aged'
             when original_reason_entitlement_code is null and medicare_status_code in ('20', '21') then 'Disabled'


### PR DESCRIPTION
Per CMS SAS: DISABL = (AGEF < 65 & OREC ne "0"). Any OREC other than '0' combined with age < 65 should select the Disabled model. OREC=2 (ESRD) was incorrectly grouped with OREC=0 as 'Aged', causing under-65 ESRD members to receive CNA/CFA/CPA instead of CND/CFD/CPD. The age>=65 override in int_demographic_factors already handles the transition to Aged for older members, so the base OREC column must reflect the pre-override disability logic.