### PR TITLE
Gate disabled interaction factors by DISABL flag

### DIFF
--- a/models/cms_hcc/intermediate/factors/cms_hcc__int_disabled_interaction_factors.sql
+++ b/models/cms_hcc/intermediate/factors/cms_hcc__int_disabled_interaction_factors.sql
@@ -10,6 +10,8 @@ with demographics as (
         , payer
         , enrollment_status
         , institutional_status
+        , orec
+        , age_group
         , model_version
         , payment_year
         , collection_start_date
@@ -54,6 +56,8 @@ with demographics as (
         , demographics.payer
         , demographics.enrollment_status
         , demographics.institutional_status
+        , demographics.orec
+        , demographics.age_group
         , demographics.model_version
         , demographics.payment_year
         , demographics.collection_start_date
@@ -87,6 +91,14 @@ with demographics as (
             and demographics_with_hccs.institutional_status = seed_interaction_factors.institutional_status
             and demographics_with_hccs.hcc_code = seed_interaction_factors.hcc_code
             and demographics_with_hccs.model_version = seed_interaction_factors.model_version
+    /*
+       CMS SAS: DISABL = (AGEF < 65 & OREC ne "0")
+       Disabled interaction factors only apply to members who are under 65
+       with a non-aged OREC. Members 65+ or with OREC=0 are not disabled
+       and should not receive these interaction coefficients.
+    */
+    where demographics_with_hccs.age_group not in ('65-69', '70-74', '75-79', '80-84', '85-89', '90-94', '>=95')
+      and demographics_with_hccs.orec != 'Aged'
 
 )
 


### PR DESCRIPTION
Institutional members with OREC=0 (Old Age) and age < 65 were incorrectly receiving disabled interaction coefficients (e.g. INS_DISABLED_HF_CHF, INS_DISABLED_PRESSURE_ULCER). Per CMS SAS: DISABL = (AGEF < 65 & OREC ne "0") — these factors should only apply when the member is both under 65 and has a non-aged OREC. Added orec and age_group to the demographics CTE and filtered the interaction join to exclude members where DISABL=0.