### PR TITLE
Switch CI to run/build command routing

### DIFF
--- a/.github/workflows/ci_mode_command.yml
+++ b/.github/workflows/ci_mode_command.yml
@@ -1,4 +1,4 @@
-name: CI Mode Command
+name: CI Command
 
 on:
   issue_comment:
@@ -11,8 +11,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  set_ci_mode:
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/ci ') }}
+  handle_ci_command:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/ci') }}
     runs-on: ubuntu-latest
     steps:
       - name: Parse command and authorize
@@ -22,41 +22,38 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const body = (context.payload.comment.body || "").trim();
-            const match = body.match(/^\/ci\s+(small|medium|large)\s*$/i);
+            const match = body.match(/^\/ci\s+(run|build)(?:-(snowflake|bigquery|databricks|fabric|redshift|duckdb))?\s*$/i);
+
             if (!match) {
-              core.setOutput("valid", "false");
               core.setOutput("allowed", "false");
-              core.setOutput("reason", "invalid");
-              core.setOutput("message", "Invalid command. Use `/ci small`, `/ci medium`, or `/ci large`.");
+              core.setOutput(
+                "message",
+                "Invalid command. Use `/ci run`, `/ci build`, or `/ci <run|build>-<snowflake|bigquery|databricks|fabric|redshift|duckdb>`."
+              );
               return;
             }
 
-            const mode = match[1].toLowerCase();
+            const operation = match[1].toLowerCase();
+            const target = (match[2] || "all").toLowerCase();
             const assoc = (context.payload.comment.author_association || "").toUpperCase();
             const isRepoCollaborator = ["OWNER", "MEMBER", "COLLABORATOR"].includes(assoc);
             const isMaintainer = ["OWNER", "MEMBER"].includes(assoc);
 
             if (!isRepoCollaborator) {
-              core.setOutput("valid", "true");
               core.setOutput("allowed", "false");
-              core.setOutput("reason", "permission");
-              core.setOutput("message", "You are not authorized to set CI mode on this repository.");
-              core.setOutput("mode", mode);
+              core.setOutput("message", "You are not authorized to run CI commands on this repository.");
               return;
             }
 
-            if (mode === "large" && !isMaintainer) {
-              core.setOutput("valid", "true");
+            if (operation === "build" && target === "all" && !isMaintainer) {
               core.setOutput("allowed", "false");
-              core.setOutput("reason", "large-restricted");
-              core.setOutput("message", "Only repository maintainers can run `/ci large`.");
-              core.setOutput("mode", mode);
+              core.setOutput("message", "Only repository maintainers can run `/ci build` (all warehouses).");
               return;
             }
 
-            core.setOutput("valid", "true");
             core.setOutput("allowed", "true");
-            core.setOutput("mode", mode);
+            core.setOutput("operation", operation);
+            core.setOutput("target", target);
 
       - name: Respond to invalid or unauthorized command
         if: ${{ steps.parse.outputs.allowed != 'true' }}
@@ -72,14 +69,14 @@ jobs:
               body: message
             });
 
-      - name: Set CI mode label and dispatch CI
+      - name: Dispatch CI workflow
         if: ${{ steps.parse.outputs.allowed == 'true' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const mode = `${{ steps.parse.outputs.mode }}`;
-            const desired = `ci:${mode}`;
+            const operation = `${{ steps.parse.outputs.operation }}`;
+            const target = `${{ steps.parse.outputs.target }}`;
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const repoFullName = `${owner}/${repo}`.toLowerCase();
@@ -88,24 +85,6 @@ jobs:
               owner,
               repo,
               pull_number: issue_number
-            });
-
-            const { data: existing } = await github.rest.issues.listLabelsOnIssue({
-              owner,
-              repo,
-              issue_number
-            });
-
-            const keep = existing
-              .map((l) => l.name)
-              .filter((name) => !/^ci:(small|medium|large)$/.test(name));
-            keep.push(desired);
-
-            await github.rest.issues.setLabels({
-              owner,
-              repo,
-              issue_number,
-              labels: keep
             });
 
             const headRepoFullName = (pr.head.repo?.full_name || "").toLowerCase();
@@ -118,13 +97,15 @@ jobs:
               ref: dispatchRef,
               inputs: {
                 pr_number: String(issue_number),
-                mode
+                operation,
+                target
               }
             });
 
+            const mode = `${operation}-${target}`;
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
-              body: `CI mode set to \`${mode}\` via \`${desired}\`. Triggered Tuva CI now (ref: \`${dispatchRef}\`).`
+              body: `Triggered Tuva CI with \`${mode}\` (ref: \`${dispatchRef}\`).`
             });

--- a/.github/workflows/dbt_ci_modes.yml
+++ b/.github/workflows/dbt_ci_modes.yml
@@ -4,21 +4,10 @@ run-name: >-
     github.event_name == 'workflow_dispatch' &&
     github.event.inputs.pr_number ||
     github.event.pull_request.number
-  }} / Mode: ${{
+  }} / ${{
     github.event_name == 'workflow_dispatch' &&
-    (github.event.inputs.mode == 'large' && 'Large' ||
-    github.event.inputs.mode == 'medium' && 'Medium' ||
-    'Small') ||
-    contains(join(github.event.pull_request.labels.*.name, ','), 'ci:large') && 'Large' ||
-    contains(join(github.event.pull_request.labels.*.name, ','), 'ci:medium') && 'Medium' ||
-    'Small'
-  }} / DW: ${{
-    ((github.event_name == 'workflow_dispatch' &&
-    (github.event.inputs.mode == 'large' || github.event.inputs.mode == 'medium')) ||
-    contains(join(github.event.pull_request.labels.*.name, ','), 'ci:large') ||
-    contains(join(github.event.pull_request.labels.*.name, ','), 'ci:medium')) &&
-    'All 6 Warehouses' ||
-    'Snowflake'
+    format('{0}-{1}', github.event.inputs.operation, github.event.inputs.target) ||
+    'run-snowflake'
   }}
 
 on:
@@ -27,51 +16,83 @@ on:
       - main
     types:
       - opened
-      - synchronize
-      - reopened
   workflow_dispatch:
     inputs:
       pr_number:
         description: Pull request number to run against
         required: true
         type: string
-      mode:
-        description: CI mode to run
+      operation:
+        description: CI operation to run
         required: true
         type: choice
+        default: run
         options:
-          - small
-          - medium
-          - large
+          - run
+          - build
+      target:
+        description: Warehouse target
+        required: true
+        type: choice
+        default: snowflake
+        options:
+          - all
+          - snowflake
+          - bigquery
+          - databricks
+          - fabric
+          - redshift
+          - duckdb
 
 permissions:
   contents: read
   pull-requests: read
 
 jobs:
-  resolve_mode:
-    name: Resolve CI Mode
+  resolve_request:
+    name: Resolve CI Request
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
-      mode: ${{ steps.resolve.outputs.mode }}
+      operation: ${{ steps.resolve.outputs.operation }}
+      target: ${{ steps.resolve.outputs.target }}
       adapter_matrix: ${{ steps.resolve.outputs.adapter_matrix }}
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
     steps:
-      - name: Resolve mode, labels, and large-mode guard
+      - name: Resolve operation, target, and guardrails
         id: resolve
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const eventName = context.eventName;
-            const isDispatch = eventName === "workflow_dispatch";
+            const isDispatch = context.eventName === "workflow_dispatch";
             const inputs = context.payload.inputs || {};
 
+            const validOperations = new Set(["run", "build"]);
+            const validTargets = new Set([
+              "all",
+              "snowflake",
+              "bigquery",
+              "databricks",
+              "fabric",
+              "redshift",
+              "duckdb"
+            ]);
+
+            const adaptersByTarget = {
+              all: ["snowflake", "bigquery", "databricks", "fabric", "redshift", "duckdb"],
+              snowflake: ["snowflake"],
+              bigquery: ["bigquery"],
+              databricks: ["databricks"],
+              fabric: ["fabric"],
+              redshift: ["redshift"],
+              duckdb: ["duckdb"]
+            };
+
             let prNumber;
-            let requestedMode = null;
-            let labels = [];
+            let operation;
+            let target;
 
             if (isDispatch) {
               const rawPrNumber = String(inputs.pr_number || "").trim();
@@ -79,52 +100,35 @@ jobs:
                 core.setFailed(`Invalid workflow_dispatch input pr_number: "${rawPrNumber}".`);
                 return;
               }
-
               prNumber = Number(rawPrNumber);
-              requestedMode = String(inputs.mode || "").trim().toLowerCase();
-              if (!["small", "medium", "large"].includes(requestedMode)) {
-                core.setFailed(`Invalid workflow_dispatch input mode: "${requestedMode}". Use one of small, medium, large.`);
+
+              operation = String(inputs.operation || "").trim().toLowerCase();
+              if (!validOperations.has(operation)) {
+                core.setFailed(`Invalid workflow_dispatch input operation: "${operation}".`);
                 return;
               }
 
-              const { data: pr } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: prNumber
-              });
-
-              if (pr.base.ref !== "main") {
-                core.setFailed(`PR #${prNumber} does not target main (targets ${pr.base.ref}).`);
+              target = String(inputs.target || "").trim().toLowerCase();
+              if (!validTargets.has(target)) {
+                core.setFailed(`Invalid workflow_dispatch input target: "${target}".`);
                 return;
               }
-
-              labels = (pr.labels || []).map((l) => l.name);
             } else {
               prNumber = context.payload.pull_request.number;
-              labels = (context.payload.pull_request.labels || []).map((l) => l.name);
+              operation = "run";
+              target = "snowflake";
             }
 
-            const ciLabels = labels.filter((name) => /^ci:(small|medium|large)$/.test(name));
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber
+            });
 
-            if (ciLabels.length > 1) {
-              core.setFailed(`Multiple CI mode labels found: ${ciLabels.join(", ")}. Keep only one of ci:small, ci:medium, ci:large.`);
+            if (pr.base.ref !== "main") {
+              core.setFailed(`PR #${prNumber} does not target main (targets ${pr.base.ref}).`);
               return;
             }
-
-            const mode = requestedMode || (ciLabels.length === 1 ? ciLabels[0].replace("ci:", "") : "small");
-            const adapters =
-              mode === "small"
-                ? ["snowflake"]
-                : ["snowflake", "bigquery", "databricks", "fabric", "redshift", "duckdb"];
-
-            const seedPrefixes = ["seeds/", "integration_tests/seeds/"];
-            const seedExact = new Set([
-              "dbt_project.yml",
-              "integration_tests/dbt_project.yml",
-              "integration_tests/seeds/_seeds.yml",
-              "integration_tests/models/_sources.yml",
-              "macros/cross_database_utils/load_seed.sql"
-            ]);
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner,
@@ -133,36 +137,49 @@ jobs:
               per_page: 100
             });
             const changed = files.map((f) => f.filename);
-            const requiresLarge = changed.some((path) =>
-              seedExact.has(path) || seedPrefixes.some((prefix) => path.startsWith(prefix))
+
+            const runGuardPrefixes = ["seeds/", "integration_tests/seeds/"];
+            const runGuardExact = new Set([
+              "dbt_project.yml",
+              "integration_tests/dbt_project.yml",
+              "integration_tests/seeds/_seeds.yml",
+              "integration_tests/models/_sources.yml",
+              "macros/cross_database_utils/load_seed.sql"
+            ]);
+
+            const requiresBuild = changed.some(
+              (path) =>
+                runGuardExact.has(path) ||
+                runGuardPrefixes.some((prefix) => path.startsWith(prefix))
             );
 
-            if (requiresLarge && mode !== "large") {
+            if (isDispatch && operation === "run" && requiresBuild) {
               const sample = changed
-                .filter((path) => seedExact.has(path) || seedPrefixes.some((prefix) => path.startsWith(prefix)))
+                .filter(
+                  (path) =>
+                    runGuardExact.has(path) ||
+                    runGuardPrefixes.some((prefix) => path.startsWith(prefix))
+                )
                 .slice(0, 8)
                 .join(", ");
+
               core.setFailed(
-                `This PR modifies seed/config/load-seed files (${sample}). Use /ci large so CI refreshes baseline schemas.`
+                `This PR changes seed/config files (${sample}). Use a build command (` +
+                  "`/ci build`, `/ci build-snowflake`, etc.) so CI runs `dbt build --full-refresh`."
               );
               return;
             }
 
-            core.info(`PR number: ${prNumber}`);
-            core.info(`Resolved CI mode: ${mode}`);
-            core.info(`Adapters: ${adapters.join(", ")}`);
-
             core.setOutput("pr_number", String(prNumber));
-            core.setOutput("mode", mode);
-            core.setOutput("adapter_matrix", JSON.stringify(adapters));
+            core.setOutput("operation", operation);
+            core.setOutput("target", target);
+            core.setOutput("adapter_matrix", JSON.stringify(adaptersByTarget[target]));
             core.setOutput("checkout_ref", `refs/pull/${prNumber}/merge`);
 
   run_dbt:
     name: >-
-      Mode: ${{
-        needs.resolve_mode.outputs.mode == 'small' && 'Small' ||
-        needs.resolve_mode.outputs.mode == 'medium' && 'Medium' ||
-        'Large'
+      ${{
+        needs.resolve_request.outputs.operation == 'build' && 'Build' || 'Run'
       }} / DW: ${{
         matrix.adapter == 'snowflake' && 'Snowflake' ||
         matrix.adapter == 'bigquery' && 'BigQuery' ||
@@ -172,14 +189,14 @@ jobs:
         matrix.adapter == 'duckdb' && 'DuckDB/MotherDuck' ||
         matrix.adapter
       }}
-    needs: resolve_mode
+    needs: resolve_request
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        adapter: ${{ fromJson(needs.resolve_mode.outputs.adapter_matrix) }}
+        adapter: ${{ fromJson(needs.resolve_request.outputs.adapter_matrix) }}
     concurrency:
-      group: ci-pr-${{ needs.resolve_mode.outputs.pr_number }}-${{ matrix.adapter }}
+      group: ci-pr-${{ needs.resolve_request.outputs.pr_number }}-${{ matrix.adapter }}
       cancel-in-progress: true
     env:
       PYTHON_VERSION: "3.10"
@@ -221,7 +238,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.resolve_mode.outputs.checkout_ref }}
+          ref: ${{ needs.resolve_request.outputs.checkout_ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -257,8 +274,7 @@ jobs:
               pip install dbt-core==${{ env.DBT_CORE_VERSION }} dbt-redshift
               ;;
             duckdb)
-              # MotherDuck currently supports DuckDB up to 1.4.4 in CI.
-              pip install dbt-core==${{ env.DBT_CORE_VERSION }} dbt-duckdb duckdb==1.4.4
+              pip install dbt-core==${{ env.DBT_CORE_VERSION }} dbt-duckdb
               ;;
             *)
               echo "Unsupported adapter: ${{ matrix.adapter }}" >&2
@@ -277,16 +293,16 @@ jobs:
       - name: Test connection
         run: dbt debug --project-dir ./integration_tests --profiles-dir ./integration_tests/profiles/${{ matrix.adapter }}
 
-      - name: Assert baseline seed schemas exist for run-only modes
-        if: ${{ needs.resolve_mode.outputs.mode != 'large' }}
+      - name: Assert baseline seed schemas exist for run modes
+        if: ${{ needs.resolve_request.outputs.operation == 'run' }}
         run: |
           dbt run-operation assert_ci_seed_baseline_ready \
             --project-dir ./integration_tests \
             --profiles-dir ./integration_tests/profiles/${{ matrix.adapter }}
 
-      - name: Run dbt (mode-aware)
+      - name: Execute dbt
         run: |
-          if [[ "${{ needs.resolve_mode.outputs.mode }}" == "large" ]]; then
+          if [[ "${{ needs.resolve_request.outputs.operation }}" == "build" ]]; then
             dbt build --full-refresh \
               --project-dir ./integration_tests \
               --profiles-dir ./integration_tests/profiles/${{ matrix.adapter }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,21 @@ Follow this workflow for all work in this repository unless the user explicitly 
 
 - Treat `integration_tests/profiles/*` as CI-only configuration. Do not use these files for local development runs.
 - Treat `.github/workflows/*` as CI-only pipeline definitions, not local runbooks.
+- Changes to `.github/workflows/*` are valid when the task is a CI workflow feature/fix.
+- Keep `.github/workflows/create-release.yml` intact unless release workflow changes are explicitly requested.
+- For docs changes under `docs/*`, run local docs build validation before push/PR.
 - Use local DuckDB for development unless the user explicitly asks for MotherDuck or another warehouse.
 - Run dbt from `integration_tests` using local profiles from `~/.dbt` (or `DBT_PROFILES_DIR` if set).
 - Set `TUVA_DBT_PROFILE` (or `DBT_PROFILE`) for local profile selection when needed.
 - Keep `integration_tests/dbt_project.yml` on `profile: default` before push.
+- For data model and seed feature/bug work, validate using the shipped synthetic seed data in `integration_tests/seeds/*` on local DuckDB (do not set `use_synthetic_data: false` unless explicitly requested).
+
+## Standard Local Docs Commands
+
+For docs changes (`docs/**`), run:
+
+- `cd docs && npm ci`
+- `cd docs && npm run build`
 
 ## Standard Local dbt Commands
 
@@ -43,7 +54,7 @@ Use the repo wrapper:
 - `scripts/dbt-local deps`
 - `scripts/dbt-local debug`
 - `scripts/dbt-local build --select <selector>`
-- `scripts/dbt-local build --full-refresh` before push
+- `scripts/dbt-local build --full-refresh --vars '{use_synthetic_data: true}'` before push for model/seed feature or bug work
 
 Equivalent explicit form:
 
@@ -53,16 +64,27 @@ Outside contributor bridge helper:
 
 - `scripts/outside-pr-bridge <pr-number>`
 
+## CI Command Workflows
+
+- Default on PR open: run `run-snowflake` (Snowflake-only `dbt run`).
+- Comment commands on PRs:
+  - `/ci run` runs `dbt run` across all supported warehouses.
+  - `/ci run-<warehouse>` runs `dbt run` on one warehouse.
+  - `/ci build` runs `dbt build --full-refresh` across all supported warehouses.
+  - `/ci build-<warehouse>` runs `dbt build --full-refresh` on one warehouse.
+- Supported warehouses: `snowflake`, `bigquery`, `databricks`, `fabric`, `redshift`, `duckdb`.
+- If a PR changes seed/config files that require a full refresh, use a build command (`/ci build*`) instead of a run command (`/ci run*`).
+
 ## Git and PR Workflow
 
 - Never commit directly to `main`.
 - Start every new feature/bug task from a clean, up-to-date `main`:
   - Preferred: `scripts/start-dev-branch <topic>`
-  - Equivalent manual flow: clean working tree -> `git fetch origin main` -> `git checkout main` -> `git pull --ff-only origin main` -> create `codex/<topic>` branch
-- Create branches using `codex/<topic>`.
+  - Equivalent manual flow: clean working tree -> `git fetch origin main` -> `git checkout main` -> `git pull --ff-only origin main` -> create a concise, descriptive feature branch
+- Use succinct, straightforward branch names and PR titles that clearly describe the change.
 - Make focused commits with clear messages.
 - Push branch and open PR to `main`.
-- Monitor CI checks until all required checks pass.
+- Monitor CI checks by default after opening a PR until all required checks pass.
 - If any check fails, troubleshoot, fix, push, and continue monitoring until green.
 - Never merge to `main`; the user merges.
 
@@ -71,6 +93,7 @@ Outside contributor bridge helper:
 - Do not modify `integration_tests/seeds/*` without explicit user approval.
 - If a change appears to require seed changes, stop and ask first.
 - If new synthetic columns/data are required, ask for explicit generation requirements first (for example expected date ranges).
+- Seed feature/bug work in top-level `seeds/*` is allowed, but must be validated via `integration_tests` + local DuckDB before push.
 
 ## SQL Portability Rules
 
@@ -93,8 +116,11 @@ For each user task:
 
 1. Restate goal briefly and start execution.
 2. Implement code changes directly.
-3. Validate with local dbt commands and report exact commands/results.
-4. Push/open PR and report PR/check status when requested.
+3. Validate locally by change type and report exact commands/results:
+   - docs changes: `cd docs && npm ci && npm run build`
+   - data model/seed changes: run `scripts/dbt-local` commands from `integration_tests` with local DuckDB and `use_synthetic_data: true`
+   - CI workflow changes: run available local workflow lint/syntax checks and confirm `/ci run|build[-warehouse]` behavior plus PR-open `run-snowflake` default
+4. Push/open PR and monitor CI until required checks are green by default, then report final status.
 
 ## Outside Contributor PR Workflow
 


### PR DESCRIPTION
## Summary
- replace CI mode labels with /ci run|build command routing
- support /ci run, /ci run-<warehouse>, /ci build, /ci build-<warehouse>
- default PR-open CI to run-snowflake
- keep release workflow unchanged
- update AGENTS context for command contract and PR monitoring defaults

## Validation
- parsed updated workflow YAML files locally with python + yaml.safe_load
