### PR TITLE
Fix docs dashboard links

### DIFF
--- a/docs/docs/dashboards.md
+++ b/docs/docs/dashboards.md
@@ -5,90 +5,77 @@ hide_title: false
 toc: false
 ---
 
-Dashboards run automatically on top of the Core Data Model and Data Marts.  The dashboards below are hosted by Tuva and run on synthetic datasets.  The code for these dashboards can be found [here](https://github.com/tuva-health/analytics_gallery).
+export const dashboards = [
+  {
+    title: 'Cost & Utilization Drivers',
+    image: '/img/cost_drivers.png',
+    href: 'https://app.fabric.microsoft.com/view?r=eyJrIjoiN2Y2YjNkYWEtY2ZkZi00ZGIxLTk4ODMtNmU2ZjMxYjM3YzUyIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9',
+    description:
+      'This dashboard demonstrates how you can use the Tuva service category, encounter, and condition groupers to drill into claims data to identify opportunities for improvement.',
+  },
+  {
+    title: 'Data Quality',
+    image: '/img/dqi.png',
+    href: 'https://app.fabric.microsoft.com/view?r=eyJrIjoiYTFhZWE0OWEtM2NjMi00ZGJlLTgxMjEtNmZmYmFiZmM5ODczIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9',
+    description:
+      'This dashboard demonstrates how you can use the Tuva data quality tables to profile and identify atomic-level data quality issues in raw claims data.',
+  },
+  {
+    title: 'Population Insights',
+    image: '/img/pop_insights.png',
+    href: 'https://app.fabric.microsoft.com/view?r=eyJrIjoiODc2MjNkMWQtNzFlOC00Njg1LWJiNTEtYTU3MTE1NDJlNDhmIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9',
+    description:
+      'This dashboard demonstrates how several data marts from Tuva can be used to profile your patient population looking at demographics, chronic disease burden, spend, utilization, and acute events.',
+  },
+  {
+    title: 'Quality Measures',
+    image: '/img/quality_measures.png',
+    href: 'https://app.fabric.microsoft.com/view?r=eyJrIjoiODdjMWI1NDEtZGMxYi00ZjIwLTgyNzctYTI0YTQzMzhkZjhiIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9',
+    description:
+      'This dashboard demonstrates how you can use the quality measures data mart to analyze clinical quality measures and care gaps.',
+  },
+  {
+    title: 'Risk-adjusted Benchmarks',
+    image: '/img/risk_adjusted_benchmarks.png',
+    href: 'https://app.fabric.microsoft.com/view?r=eyJrIjoiMDY2OWY2ZjEtYjFmYS00ZmU0LTk1YTItMTA1ODEyMjY4MWJmIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9',
+    description:
+      'This dashboard shows the expected values produced by the benchmarking mart and compares them to actual values for analysis.',
+  },
+];
 
+Dashboards run automatically on top of the Core Data Model and Data Marts. The dashboards below are hosted by Tuva and run on synthetic datasets. The code for these dashboards can be found [here](https://github.com/tuva-health/analytics_gallery).
 
-<div style={{ display: "flex", flexDirection: "column", gap: "50px" }}>
+<div style={{ display: 'flex', flexDirection: 'column', gap: '50px' }}>
+  {dashboards.map((dashboard) => (
+    <a
+      key={dashboard.title}
+      href={dashboard.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        color: 'inherit',
+        textDecoration: 'none',
+      }}
+    >
+      <img
+        src={dashboard.image}
+        alt={`${dashboard.title} thumbnail`}
+        style={{
+          width: '120px',
+          height: 'auto',
+          marginRight: '30px',
+          flexShrink: 0,
+        }}
+      />
 
-<div style={{ display: "flex", alignItems: "flex-start" }}> 
-    <a href="#" onClick={(e) => { window.open('https://app.powerbi.com/view?r=eyJrIjoiNzkwY2U3MzgtYzEzMC00NjM1LTlhYjItODIxYzNiYTJjY2Y5IiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9', '_blank'); e.preventDefault(); }}>
-      <img src="/img/cost_drivers.png" alt="Video Thumbnail" style={{ width: "120px", height: "auto", cursor: "pointer", marginRight: "30px"}} />
+      <div>
+        <h3 style={{ margin: '0 20px' }}>{dashboard.title}</h3>
+        <div style={{ margin: '5px 20px', fontSize: '0.9em', lineHeight: '1.4em' }}>
+          {dashboard.description}
+        </div>
+      </div>
     </a>
-
-  <div>
-    <h3 style={{ margin: "0 20px" }}>Cost & Utilization Drivers</h3>
-    <p style={{ margin: "5px 20px", fontSize: "0.9em", lineHeight: "1.4em" }}>
-      This dashboard demonstrates how you can use the Tuva service category, encounter, and condition groupers to drill into claims data to identify opportunities for improvement.
-    </p>
-  </div>
+  ))}
 </div>
-
-<div style={{ display: "flex", alignItems: "flex-start" }}> 
-    <a href="#" onClick={(e) => { window.open('https://app.powerbi.com/view?r=eyJrIjoiZDc2ODVlNmUtYmE2NC00ZmQ3LWI2MzYtOTEwNDM1YTQwOTcxIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9', '_blank'); e.preventDefault(); }}>
-      <img src="/img/dqi.png" alt="Video Thumbnail" style={{ width: "120px", height: "auto", cursor: "pointer", marginRight: "30px"}} />
-    </a>
-
-  <div>
-    <h3 style={{ margin: "0 20px" }}>Data Quality</h3>
-    <p style={{ margin: "5px 20px", fontSize: "0.9em", lineHeight: "1.4em" }}>
-      This dashboard demonstrates how you can use the Tuva data quality tables to profile and identify atomic-level data quality issues in raw claims data.
-    </p>
-  </div>
-</div>
-
-<div style={{ display: "flex", alignItems: "flex-start" }}> 
-    <a href="#" onClick={(e) => { window.open('https://app.powerbi.com/view?r=eyJrIjoiNmNmZmI3ZTUtZjhiMS00YjdlLTgxMjAtOTMyZjdjMDNiMjZkIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9', '_blank'); e.preventDefault(); }}>
-      <img src="/img/pop_insights.png" alt="Video Thumbnail" style={{ width: "120px", height: "auto", cursor: "pointer", marginRight: "30px"}} />
-    </a>
-
-  <div>
-    <h3 style={{ margin: "0 20px" }}>Population Insights</h3>
-    <p style={{ margin: "5px 20px", fontSize: "0.9em", lineHeight: "1.4em" }}>
-      This dashboard demonstrates how several data marts from Tuva can be used to profile your patient population looking at demographics, chronic disease burden, spend, utilization, and acute events.
-    </p>
-  </div>
-</div>
-
-<div style={{ display: "flex", alignItems: "flex-start" }}> 
-    <a href="#" onClick={(e) => { window.open('https://app.powerbi.com/view?r=eyJrIjoiY2UzNWMwZjYtOTI3Ny00M2I0LWI5ZmMtMTdiMjVhZTdhMjE3IiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9', '_blank'); e.preventDefault(); }}>
-      <img src="/img/quality_measures.png" alt="Video Thumbnail" style={{ width: "120px", height: "auto", cursor: "pointer", marginRight: "30px"}} />
-    </a>
-
-  <div>
-    <h3 style={{ margin: "0 20px" }}>Quality Measures</h3>
-    <p style={{ margin: "5px 20px", fontSize: "0.9em", lineHeight: "1.4em" }}>
-      This dashboard demonstrates how you can use the quality measures data mart to analyze clinical quality measures and care gaps.
-    </p>
-  </div>
-</div>
-
-<div style={{ display: "flex", alignItems: "flex-start" }}> 
-    <a href="#" onClick={(e) => { window.open('https://app.powerbi.com/view?r=eyJrIjoiMmM2ZmFiNzAtOTdlNC00NzViLWE0NzYtN2U1Y2E4ZjlmNTBjIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9', '_blank'); e.preventDefault(); }}>
-      <img src="/img/risk_adjusted_benchmarks.png" alt="Video Thumbnail" style={{ width: "120px", height: "auto", cursor: "pointer", marginRight: "30px"}} />
-    </a>
-
-  <div>
-    <h3 style={{ margin: "0 20px" }}>Risk-adjusted Benchmarks</h3>
-    <p style={{ margin: "5px 20px", fontSize: "0.9em", lineHeight: "1.4em" }}>
-      This dashboard shows the expected values produced by the benchmarking mart and compares them to actual values for analysis.
-    </p>
-  </div>
-</div>
-
-<div style={{ display: "flex", alignItems: "flex-start" }}> 
-    <a href="#" onClick={(e) => { window.open('https://app.powerbi.com/view?r=eyJrIjoiOGNmYjIzMTMtOTdlMC00OTk3LTgwMmItNmJlZTM4OGUwZmJlIiwidCI6ImJiM2M3Y2U1LTI2MjgtNGM5MS04Y2VmLTgwMTdjNjExNTk3OCIsImMiOjZ9', '_blank'); e.preventDefault(); }}>
-      <img src="/img/aco-analytics.png" alt="Video Thumbnail" style={{ width: "120px", height: "auto", cursor: "pointer", marginRight: "30px"}} />
-    </a>
-
-  <div>
-    <h3 style={{ margin: "0 20px" }}>Medicare ACO Analytics</h3>
-    <p style={{ margin: "5px 20px", fontSize: "0.9em", lineHeight: "1.4em" }}>
-      This dashboard demonstrates the type of analytics that are important for Medicare ACOs and other types of value-based care organizations.
-    </p>
-  </div>
-</div>
-
-</div>
-
-
-


### PR DESCRIPTION
## Summary
- replace broken Power BI dashboard URLs with the verified Fabric embed URLs for the five working dashboards
- remove the Medicare ACO Analytics card until a replacement link is available
- render dashboard cards as normal external anchors instead of relying on client-side window.open handlers

## Validation
- cd docs && npm ci
- cd docs && npm run build