### PR TITLE
Snapshot improvements

### DIFF
--- a/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
@@ -9,9 +9,9 @@
       "target_schema": schema_var
     , "alias": "patient_risk_factors_snapshot"
     , "tags": "cms_hcc"
-    , "strategy": "timestamp"
-    , "updated_at": "tuva_last_run"
-    , "unique_key": "person_id||payer||factor_type||risk_factor_description||model_version||payment_year||tuva_last_run"
+    , "strategy": "check"
+    , "check_cols": ["enrollment_status_default", "medicaid_dual_status_default", "orec_default", "institutional_status_default", "coefficient"]
+    , "unique_key": "person_id||payer||factor_type||risk_factor_description||model_version||payment_year"
     , "enabled": var('snapshots_enabled',False) == true and var('cms_hcc_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) == true | as_bool
     , "hard_deletes": "invalidate"
   })

--- a/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_factors_snapshot.sql
@@ -11,8 +11,9 @@
     , "tags": "cms_hcc"
     , "strategy": "timestamp"
     , "updated_at": "tuva_last_run"
-    , "unique_key": "person_id||model_version||payment_year||tuva_last_run"
+    , "unique_key": "person_id||payer||factor_type||risk_factor_description||model_version||payment_year||tuva_last_run"
     , "enabled": var('snapshots_enabled',False) == true and var('cms_hcc_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) == true | as_bool
+    , "hard_deletes": "invalidate"
   })
 }}
 

--- a/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
@@ -9,9 +9,9 @@
       "target_schema": schema_var
     , "alias": "patient_risk_scores_snapshot"
     , "tags": "cms_hcc"
-    , "strategy": "timestamp"
-    , "updated_at": "tuva_last_run"
-    , "unique_key": "person_id||payer||payment_risk_score||payment_risk_score_weighted_by_months||payment_year||tuva_last_run"
+    , "strategy": "check"
+    , "check_cols": ["v24_risk_score", "v28_risk_score", "blended_risk_score", "normalized_risk_score", "payment_risk_score", "payment_risk_score_weighted_by_months", "member_months"]
+    , "unique_key": "person_id||payer||payment_year"
     , "enabled": var('snapshots_enabled',False) == true and var('cms_hcc_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) == true | as_bool
     , "hard_deletes": "invalidate"
   })

--- a/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
+++ b/snapshots/cms_hcc/cms_hcc__patient_risk_scores_snapshot.sql
@@ -11,8 +11,9 @@
     , "tags": "cms_hcc"
     , "strategy": "timestamp"
     , "updated_at": "tuva_last_run"
-    , "unique_key": "person_id||payment_year||tuva_last_run"
+    , "unique_key": "person_id||payer||payment_risk_score||payment_risk_score_weighted_by_months||payment_year||tuva_last_run"
     , "enabled": var('snapshots_enabled',False) == true and var('cms_hcc_enabled',var('claims_enabled',var('tuva_marts_enabled',False))) == true | as_bool
+    , "hard_deletes": "invalidate"
   })
 }}
 

--- a/snapshots/quality_measures/quality_measures__summary_counts_snapshot.sql
+++ b/snapshots/quality_measures/quality_measures__summary_counts_snapshot.sql
@@ -9,9 +9,9 @@
       "target_schema": schema_var
     , "alias": "summary_counts_snapshot"
     , "tags": "quality_measures"
-    , "strategy": "timestamp"
-    , "updated_at": "tuva_last_run"
-    , "unique_key": "measure_id||measure_name||measure_version||performance_period_begin||performance_period_end||tuva_last_run"
+    , "strategy": "check"
+    , "check_cols": ["denominator_sum", "numerator_sum", "exclusion_sum", "performance_rate"]
+    , "unique_key": "measure_id||measure_name||measure_version||performance_period_begin||performance_period_end"
     , "enabled": var('snapshots_enabled',False) == true and var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) == true | as_bool
     , "hard_deletes": "invalidate"
   })

--- a/snapshots/quality_measures/quality_measures__summary_counts_snapshot.sql
+++ b/snapshots/quality_measures/quality_measures__summary_counts_snapshot.sql
@@ -13,6 +13,7 @@
     , "updated_at": "tuva_last_run"
     , "unique_key": "measure_id||measure_name||measure_version||performance_period_begin||performance_period_end||tuva_last_run"
     , "enabled": var('snapshots_enabled',False) == true and var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) == true | as_bool
+    , "hard_deletes": "invalidate"
   })
 }}
 

--- a/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
+++ b/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
@@ -9,9 +9,9 @@
       "target_schema": schema_var
     , "alias": "summary_long_snapshot"
     , "tags": "quality_measures"
-    , "strategy": "timestamp"
-    , "updated_at": "tuva_last_run"
-    , "unique_key": "person_id||denominator_flag||numerator_flag||exclusion_flag||evidence_date||exclusion_date||exclusion_reason||performance_period_begin||performance_period_end||measure_id||measure_name||measure_version||tuva_last_run"
+    , "strategy": "check"
+    , "check_cols": ["denominator_flag", "numerator_flag", "exclusion_flag", "performance_flag", "evidence_date", "evidence_value", "exclusion_date", "exclusion_reason"]
+    , "unique_key": "person_id||coalesce(measure_id, '')||coalesce(measure_name, '')||coalesce(measure_version, '')||coalesce(cast(performance_period_begin as varchar), '')||coalesce(cast(performance_period_end as varchar), '')"
     , "enabled": var('snapshots_enabled',False) == true and var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) == true | as_bool
     , "hard_deletes": "invalidate"
   })

--- a/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
+++ b/snapshots/quality_measures/quality_measures__summary_long_snapshot.sql
@@ -13,6 +13,7 @@
     , "updated_at": "tuva_last_run"
     , "unique_key": "person_id||denominator_flag||numerator_flag||exclusion_flag||evidence_date||exclusion_date||exclusion_reason||performance_period_begin||performance_period_end||measure_id||measure_name||measure_version||tuva_last_run"
     , "enabled": var('snapshots_enabled',False) == true and var('quality_measures_enabled',var('claims_enabled',var('clinical_enabled',var('tuva_marts_enabled',False)))) == true | as_bool
+    , "hard_deletes": "invalidate"
   })
 }}
 


### PR DESCRIPTION
# What's changed

This PR includes improvements to the snapshot config for CMS HCC and Quality Measures. This addresses bugs related to the snapshot strategy, long snapshot run times, and snapshot bloat.

- Updated the unique key logic for all snapshot models.
  - For the quality_measures__summary_long_snapshot, had to make additional changes to account for patient records with null measure data. The unique_key uses concatenation, and in Redshift, a NULL field in the concatenation evaluates to NULL. This means dbt was creating a new row every run for the patients with no measure data.
  - To keep these rows in the snapshot table for completeness, I added a coalesce to the fields used in the unique key, which ensures that a non-null key is created for these patients.
- Changed the hard_deletes setting from the default of "ignore" to "invalidate" to handle dropped records. We had many records left open-ended when the change was made to exclude non-medicare patients from the CMS HCC models.
- Changed snapshot strategy to "check" from "timestamp". This will ensure that only changes to key fields trigger a new record in the snapshot table rather than every dbt run.

# Testing notes

1) Ran `dbt build` in a clean database to populate all tables and `dbt snapshot` to capture the current state.
2) Manually modified a few rows in each table being snapshotted. 
3) Then ran `dbt snapshot` again to confirm the expected rows were invalidated, and new rows were created.
