### PR TITLE
Add data quality summary models

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -4,6 +4,8 @@
  * work well for content-centric websites.
  */
 
+/* Netlify deploy-preview trigger for PR validation. */
+
 /* You can override the default Infima variables here. */
 :root {
   /* --ifm-color-primary: #07405c; */

--- a/macros/data_quality/dq_summary_helpers.sql
+++ b/macros/data_quality/dq_summary_helpers.sql
@@ -1,0 +1,519 @@
+{% macro dq_expected_input_layer_models() %}
+    {% if not execute %}
+        {{ return([]) }}
+    {% endif %}
+
+    {% set models = [] %}
+    {% for graph_node in graph['nodes'].values() | sort(attribute='name') %}
+        {% if graph_node.resource_type == 'model'
+              and graph_node.package_name == 'the_tuva_project'
+              and graph_node.original_file_path.startswith('models/input_layer/')
+              and graph_node.name.startswith('input_layer__') %}
+            {% do models.append(graph_node) %}
+        {% endif %}
+    {% endfor %}
+    {{ return(models) }}
+{% endmacro %}
+
+{% macro dq_expected_final_marts() %}
+    {% if not execute %}
+        {{ return([]) }}
+    {% endif %}
+
+    {% set models = [] %}
+    {% for graph_node in graph['nodes'].values() | sort(attribute='name') %}
+        {% if graph_node.resource_type == 'model'
+              and graph_node.package_name == 'the_tuva_project'
+              and graph_node.original_file_path.startswith('models/data_marts/')
+              and '/final/' in graph_node.original_file_path %}
+            {% do models.append(graph_node) %}
+        {% endif %}
+    {% endfor %}
+    {{ return(models) }}
+{% endmacro %}
+
+{% macro dq_find_model_node(model_name) %}
+    {% if not execute %}
+        {{ return(none) }}
+    {% endif %}
+
+    {% for graph_node in graph['nodes'].values() %}
+        {% if graph_node.resource_type == 'model'
+              and graph_node.package_name == 'the_tuva_project'
+              and graph_node.name == model_name %}
+            {{ return(graph_node) }}
+        {% endif %}
+    {% endfor %}
+    {{ return(none) }}
+{% endmacro %}
+
+{% macro dq_actual_relation(node) %}
+    {% if node is none %}
+        {{ return(none) }}
+    {% endif %}
+
+    {{ return(
+        adapter.get_relation(
+            database=node.database,
+            schema=node.schema,
+            identifier=node.alias
+        )
+    ) }}
+{% endmacro %}
+
+{% macro dq_actual_columns(relation) %}
+    {% if relation is none %}
+        {{ return([]) }}
+    {% endif %}
+
+    {{ return(adapter.get_columns_in_relation(relation)) }}
+{% endmacro %}
+
+{% macro dq_has_column(columns, column_name) %}
+    {% set requested_name = column_name | lower %}
+    {% for column in columns %}
+        {% if column.name | lower == requested_name %}
+            {{ return(true) }}
+        {% endif %}
+    {% endfor %}
+    {{ return(false) }}
+{% endmacro %}
+
+{% macro dq_expected_columns(node) %}
+    {% set expected_columns = [] %}
+
+    {% for column in node.columns.values() | sort(attribute='name') %}
+        {% set meta = column.config.meta if column.config is not none and column.config.meta is not none else {} %}
+        {% do expected_columns.append(
+            {
+                'name': column.name | lower,
+                'data_type': meta.get('data_type'),
+                'is_primary_key': meta.get('is_primary_key', false)
+            }
+        ) %}
+    {% endfor %}
+
+    {{ return(expected_columns) }}
+{% endmacro %}
+
+{% macro dq_expected_pk_columns(node) %}
+    {% set pk_columns = [] %}
+
+    {% for column in dq_expected_columns(node) %}
+        {% if column['is_primary_key'] %}
+            {% do pk_columns.append(column['name']) %}
+        {% endif %}
+    {% endfor %}
+
+    {{ return(pk_columns) }}
+{% endmacro %}
+
+{% macro dq_source_key_sentinel() %}
+    {{ return('__dq_null__') }}
+{% endmacro %}
+
+{% macro dq_grouped_rowcount_sql(relation, group_cols=[]) %}
+    select
+        {% for column_name in group_cols %}
+            cast({{ quote_column(column_name) }} as {{ dbt.type_string() }}) as {{ column_name }},
+        {% endfor %}
+        cast(count(*) as {{ dbt.type_numeric() }}) as row_count
+    from {{ relation }}
+    {% if group_cols | length > 0 %}
+    group by
+        {% for _ in group_cols %}
+            {{ loop.index }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endmacro %}
+
+{% macro dq_source_row_count_sql(relation) %}
+    {% set actual_columns = dq_actual_columns(relation) %}
+
+    select
+          {% if dq_has_column(actual_columns, 'data_source') %}
+          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
+          {% else %}
+          '{{ dq_source_key_sentinel() }}'
+          {% endif %} as data_source_key
+        , cast(count(*) as {{ dbt.type_numeric() }}) as row_count
+    from {{ relation }}
+    {% if dq_has_column(actual_columns, 'data_source') %}
+    group by 1
+    {% endif %}
+{% endmacro %}
+
+{% macro dq_source_dimension_sql(relation) %}
+    {% set actual_columns = dq_actual_columns(relation) %}
+
+    {% if dq_has_column(actual_columns, 'data_source') %}
+        select distinct
+              coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+            , cast(data_source as {{ dbt.type_string() }}) as data_source
+        from {{ relation }}
+
+        union all
+
+        select
+              '{{ dq_source_key_sentinel() }}' as data_source_key
+            , cast(null as {{ dbt.type_string() }}) as data_source
+        where not exists (
+            select 1
+            from {{ relation }}
+        )
+    {% else %}
+        select
+              '{{ dq_source_key_sentinel() }}' as data_source_key
+            , cast(null as {{ dbt.type_string() }}) as data_source
+    {% endif %}
+{% endmacro %}
+
+{% macro dq_duplicate_pk_count_sql(relation, pk_cols) %}
+    {% set actual_columns = dq_actual_columns(relation) %}
+    {% set has_data_source = dq_has_column(actual_columns, 'data_source') %}
+
+    select
+          duplicate_groups.data_source_key
+        , cast(sum(duplicate_groups.duplicate_row_count) as {{ dbt.type_numeric() }}) as duplicate_pk_count
+    from (
+        select
+              {% if has_data_source %}
+              coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
+              {% else %}
+              '{{ dq_source_key_sentinel() }}'
+              {% endif %} as data_source_key
+            , cast(count(*) - 1 as {{ dbt.type_numeric() }}) as duplicate_row_count
+        from {{ relation }}
+        where
+            {% for pk_col in pk_cols %}
+                {{ quote_column(pk_col) }} is not null{% if not loop.last %} and {% endif %}
+            {% endfor %}
+        group by
+            {% if has_data_source %}
+                1,
+            {% endif %}
+            {% for pk_col in pk_cols %}
+                {{ quote_column(pk_col) }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+        having count(*) > 1
+    ) as duplicate_groups
+    group by duplicate_groups.data_source_key
+{% endmacro %}
+
+{% macro dq_pk_null_count_sql(relation, pk_cols) %}
+    {% set actual_columns = dq_actual_columns(relation) %}
+    {% set has_data_source = dq_has_column(actual_columns, 'data_source') %}
+
+    select
+          {% if has_data_source %}
+          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
+          {% else %}
+          '{{ dq_source_key_sentinel() }}'
+          {% endif %} as data_source_key
+        , cast(sum(
+            case
+                when
+                    {% for pk_col in pk_cols %}
+                        {{ quote_column(pk_col) }} is null{% if not loop.last %} or {% endif %}
+                    {% endfor %}
+                then 1
+                else 0
+            end
+          ) as {{ dbt.type_numeric() }}) as null_pk_count
+    from {{ relation }}
+    {% if has_data_source %}
+    group by 1
+    {% endif %}
+{% endmacro %}
+
+{% macro dq_base_type_family(type_string) %}
+    {% if type_string is none %}
+        {{ return('unknown') }}
+    {% endif %}
+
+    {% set normalized = type_string | lower | trim %}
+    {% set compact = normalized | replace(' ', '') %}
+    {% set base = normalized.split('(')[0] | trim %}
+
+    {% if base in ['varchar', 'nvarchar', 'string', 'text', 'char', 'character', 'character varying'] %}
+        {{ return('string') }}
+    {% elif base in ['int', 'integer', 'bigint', 'smallint', 'tinyint', 'int64'] %}
+        {{ return('integer') }}
+    {% elif base in ['boolean', 'bool', 'bit'] %}
+        {{ return('boolean') }}
+    {% elif base == 'date' %}
+        {{ return('date') }}
+    {% elif 'timestamp' in base or base in ['datetime', 'datetime2', 'smalldatetime'] %}
+        {{ return('timestamp') }}
+    {% elif base in ['number', 'numeric', 'decimal', 'float', 'float4', 'float8', 'double', 'double precision', 'real', 'float64', 'bignumeric'] %}
+        {% if '(' in compact and ')' in compact and ',' in compact %}
+            {% set scale = compact.split('(', 1)[1].split(')', 1)[0].split(',')[-1] | int %}
+            {% if scale == 0 %}
+                {{ return('integer') }}
+            {% endif %}
+        {% endif %}
+        {{ return('numeric') }}
+    {% else %}
+        {{ return(base) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro dq_type_family(type_string) %}
+    {{ return(adapter.dispatch('dq_type_family', 'the_tuva_project')(type_string)) }}
+{% endmacro %}
+
+{% macro dq_type_families_match(expected_type, actual_type) %}
+    {% set expected_family = dq_type_family(expected_type) %}
+    {% set actual_family = dq_type_family(actual_type) %}
+
+    {% if expected_family == actual_family %}
+        {{ return(true) }}
+    {% elif expected_family == 'boolean' and actual_family == 'integer' %}
+        {{ return(true) }}
+    {% elif expected_family == 'numeric' and actual_family == 'integer' %}
+        {{ return(true) }}
+    {% else %}
+        {{ return(false) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro default__dq_type_family(type_string) %}
+    {{ return(dq_base_type_family(type_string)) }}
+{% endmacro %}
+
+{% macro bigquery__dq_type_family(type_string) %}
+    {% if type_string is none %}
+        {{ return('unknown') }}
+    {% endif %}
+
+    {% set normalized = type_string | lower | trim %}
+    {% if normalized == 'bool' %}
+        {{ return('boolean') }}
+    {% elif normalized == 'bytes' %}
+        {{ return('string') }}
+    {% else %}
+        {{ return(dq_base_type_family(normalized)) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro fabric__dq_type_family(type_string) %}
+    {% if type_string is none %}
+        {{ return('unknown') }}
+    {% endif %}
+
+    {% set normalized = type_string | lower | trim %}
+    {% if normalized in ['nvarchar', 'varchar', 'char', 'nchar'] %}
+        {{ return('string') }}
+    {% else %}
+        {{ return(dq_base_type_family(normalized)) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro dq_representative_data_marts() %}
+    {% if not execute %}
+        {{ return([]) }}
+    {% endif %}
+
+    {% set representatives = [
+        {'data_mart_name': 'ahrq_measures', 'model_name': 'ahrq_measures__pqi_summary'},
+        {'data_mart_name': 'ccsr', 'model_name': 'ccsr__procedure_summary'},
+        {'data_mart_name': 'chronic_conditions', 'model_name': 'chronic_conditions__cms_chronic_conditions_wide'},
+        {'data_mart_name': 'cms_hcc', 'model_name': 'cms_hcc__patient_risk_scores'},
+        {'data_mart_name': 'ed_classification', 'model_name': 'ed_classification__summary'},
+        {'data_mart_name': 'financial_pmpm', 'model_name': 'financial_pmpm__pmpm_payer'},
+        {'data_mart_name': 'hcc_recapture', 'model_name': 'hcc_recapture__recapture_rates'},
+        {'data_mart_name': 'hcc_suspecting', 'model_name': 'hcc_suspecting__summary'},
+        {'data_mart_name': 'pharmacy', 'model_name': 'pharmacy__brand_generic_opportunity'},
+        {'data_mart_name': 'provider_attribution', 'model_name': 'provider_attribution__provider_ranking'},
+        {'data_mart_name': 'quality_measures', 'model_name': 'quality_measures__summary_wide'},
+        {'data_mart_name': 'readmissions', 'model_name': 'readmissions__readmission_summary'},
+        {'data_mart_name': 'semantic_layer', 'model_name': 'semantic_layer__fact_member_months'}
+    ] %}
+
+    {% set marts = [] %}
+    {% for representative in representatives %}
+        {% set node = dq_find_model_node(representative['model_name']) %}
+        {% if node is not none %}
+            {% do marts.append({
+                'data_mart_name': representative['data_mart_name'],
+                'model_name': representative['model_name'],
+                'node': node
+            }) %}
+        {% endif %}
+    {% endfor %}
+
+    {{ return(marts) }}
+{% endmacro %}
+
+{% macro dq_logical_rules() %}
+    {{ return([
+        {
+            'test_name': 'medical_claim__claim_start_after_claim_end',
+            'model_name': 'input_layer__medical_claim',
+            'rule_type': 'date_order',
+            'left_column': 'claim_start_date',
+            'right_column': 'claim_end_date'
+        },
+        {
+            'test_name': 'medical_claim__admit_after_discharge',
+            'model_name': 'input_layer__medical_claim',
+            'rule_type': 'date_order',
+            'left_column': 'admission_date',
+            'right_column': 'discharge_date'
+        },
+        {
+            'test_name': 'medical_claim__paid_amount_gt_allowed_amount',
+            'model_name': 'input_layer__medical_claim',
+            'rule_type': 'amount_lte',
+            'left_column': 'paid_amount',
+            'right_column': 'allowed_amount'
+        },
+        {
+            'test_name': 'pharmacy_claim__paid_amount_gt_allowed_amount',
+            'model_name': 'input_layer__pharmacy_claim',
+            'rule_type': 'amount_lte',
+            'left_column': 'paid_amount',
+            'right_column': 'allowed_amount'
+        },
+        {
+            'test_name': 'eligibility__enrollment_start_after_end',
+            'model_name': 'input_layer__eligibility',
+            'rule_type': 'date_order',
+            'left_column': 'enrollment_start_date',
+            'right_column': 'enrollment_end_date'
+        },
+        {
+            'test_name': 'eligibility__death_before_birth',
+            'model_name': 'input_layer__eligibility',
+            'rule_type': 'date_order',
+            'left_column': 'death_date',
+            'right_column': 'birth_date',
+            'operator': '<'
+        },
+        {
+            'test_name': 'provider_attribution__invalid_year_month',
+            'model_name': 'input_layer__provider_attribution',
+            'rule_type': 'invalid_year_month',
+            'column': 'year_month'
+        },
+        {
+            'test_name': 'encounter__start_after_end',
+            'model_name': 'input_layer__encounter',
+            'rule_type': 'date_order',
+            'left_column': 'encounter_start_date',
+            'right_column': 'encounter_end_date'
+        },
+        {
+            'test_name': 'condition__onset_after_resolved',
+            'model_name': 'input_layer__condition',
+            'rule_type': 'date_order',
+            'left_column': 'onset_date',
+            'right_column': 'resolved_date'
+        },
+        {
+            'test_name': 'lab_result__collection_after_result',
+            'model_name': 'input_layer__lab_result',
+            'rule_type': 'date_order',
+            'left_column': 'collection_datetime',
+            'right_column': 'result_datetime'
+        },
+        {
+            'test_name': 'appointment__start_after_end',
+            'model_name': 'input_layer__appointment',
+            'rule_type': 'date_order',
+            'left_column': 'start_datetime',
+            'right_column': 'end_datetime'
+        }
+    ]) }}
+{% endmacro %}
+
+{% macro dq_logical_rule_required_columns(rule) %}
+    {% set required_columns = [] %}
+    {% if rule['rule_type'] in ['date_order', 'amount_lte'] %}
+        {% do required_columns.append(rule['left_column']) %}
+        {% do required_columns.append(rule['right_column']) %}
+    {% elif rule['rule_type'] == 'invalid_year_month' %}
+        {% do required_columns.append(rule['column']) %}
+    {% endif %}
+    {{ return(required_columns) }}
+{% endmacro %}
+
+{% macro dq_render_logical_rule_sql(rule, relation) %}
+    {% set actual_columns = dq_actual_columns(relation) %}
+    {% set has_data_source = dq_has_column(actual_columns, 'data_source') %}
+    {% set required_columns = dq_logical_rule_required_columns(rule) %}
+
+    {% for column_name in required_columns %}
+        {% if not dq_has_column(actual_columns, column_name) %}
+            {{ return(none) }}
+        {% endif %}
+    {% endfor %}
+
+    {% set source_key_expression %}
+        {% if has_data_source %}
+            coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
+        {% else %}
+            '{{ dq_source_key_sentinel() }}'
+        {% endif %}
+    {% endset %}
+
+    {% set predicate %}
+        {% if rule['rule_type'] == 'date_order' %}
+            {% set operator = rule.get('operator', '>') %}
+            {{ quote_column(rule['left_column']) }} is not null
+            and {{ quote_column(rule['right_column']) }} is not null
+            and {{ quote_column(rule['left_column']) }} {{ operator }} {{ quote_column(rule['right_column']) }}
+        {% elif rule['rule_type'] == 'amount_lte' %}
+            {{ quote_column(rule['left_column']) }} is not null
+            and {{ quote_column(rule['right_column']) }} is not null
+            and {{ quote_column(rule['left_column']) }} > {{ quote_column(rule['right_column']) }}
+        {% endif %}
+    {% endset %}
+
+    {% if rule['rule_type'] == 'invalid_year_month' %}
+        {% set query %}
+            select
+                  sources.data_source
+                , '{{ rule['test_name'] }}' as test_name
+                , cast(coalesce(invalid_counts.test_result, 0) as {{ dbt.type_numeric() }}) as test_result
+            from (
+                {{ dq_source_dimension_sql(relation) }}
+            ) as sources
+            left join (
+                select
+                      {{ source_key_expression }} as data_source_key
+                    , cast(count(*) as {{ dbt.type_numeric() }}) as test_result
+                from {{ relation }}
+                where {{ quote_column(rule['column']) }} is not null
+                  and cast({{ quote_column(rule['column']) }} as {{ dbt.type_string() }}) not in (
+                      select distinct
+                          cast(replace(year_month, '-', '') as {{ dbt.type_string() }})
+                      from {{ ref('reference_data__calendar') }}
+                  )
+                group by 1
+            ) as invalid_counts
+                on sources.data_source_key = invalid_counts.data_source_key
+        {% endset %}
+    {% else %}
+        {% set query %}
+            select
+                  sources.data_source
+                , '{{ rule['test_name'] }}' as test_name
+                , cast(coalesce(violations.test_result, 0) as {{ dbt.type_numeric() }}) as test_result
+            from (
+                {{ dq_source_dimension_sql(relation) }}
+            ) as sources
+            left join (
+                select
+                      {{ source_key_expression }} as data_source_key
+                    , cast(count(*) as {{ dbt.type_numeric() }}) as test_result
+                from {{ relation }}
+                where {{ predicate }}
+                group by 1
+            ) as violations
+                on sources.data_source_key = violations.data_source_key
+        {% endset %}
+    {% endif %}
+
+    {{ return(query) }}
+{% endmacro %}

--- a/models/data_quality/data_quality__analytical_data_marts.sql
+++ b/models/data_quality/data_quality__analytical_data_marts.sql
@@ -1,0 +1,94 @@
+{{ config(
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'analytical_data_marts',
+     tags = ['data_quality', 'dqi'],
+     materialized = 'table'
+   )
+}}
+
+{% set analytical_data_mart_dependency_names = [
+    'ahrq_measures__pqi_summary',
+    'ccsr__procedure_summary',
+    'chronic_conditions__cms_chronic_conditions_wide',
+    'cms_hcc__patient_risk_scores',
+    'ed_classification__summary',
+    'financial_pmpm__pmpm_payer',
+    'hcc_recapture__recapture_rates',
+    'hcc_suspecting__summary',
+    'pharmacy__brand_generic_opportunity',
+    'provider_attribution__provider_ranking',
+    'quality_measures__summary_wide',
+    'readmissions__readmission_summary',
+    'semantic_layer__fact_member_months',
+    'semantic_layer__fact_quality_measures'
+] %}
+
+{% for dependency_name in analytical_data_mart_dependency_names %}
+-- depends_on: {{ ref(dependency_name) }}
+{% endfor %}
+
+{% if execute %}
+    {% set final_marts = dq_representative_data_marts() %}
+    {% set mart_queries = [] %}
+
+    {% for final_mart in final_marts %}
+        {% set model_node = final_mart['node'] %}
+        {% set relation = dq_actual_relation(model_node) %}
+
+        {% if relation is none %}
+            {% set query %}
+                select
+                      cast('all' as {{ dbt.type_string() }}) as data_source
+                    , '{{ final_mart['data_mart_name'] }}' as data_mart_name
+                    , cast(null as {{ dbt.type_numeric() }}) as row_count
+            {% endset %}
+        {% else %}
+            {% set actual_columns = dq_actual_columns(relation) %}
+
+            {% if dq_has_column(actual_columns, 'data_source') %}
+                {% set query %}
+                    select
+                          mart_counts.data_source
+                        , '{{ final_mart['data_mart_name'] }}' as data_mart_name
+                        , cast(mart_counts.row_count as {{ dbt.type_numeric() }}) as row_count
+                    from (
+                        {{ dq_grouped_rowcount_sql(relation, ['data_source']) }}
+                    ) as mart_counts
+
+                    union all
+
+                    select
+                          cast('all' as {{ dbt.type_string() }}) as data_source
+                        , '{{ final_mart['data_mart_name'] }}' as data_mart_name
+                        , cast(0 as {{ dbt.type_numeric() }}) as row_count
+                    where not exists (
+                        select 1
+                        from {{ relation }}
+                    )
+                {% endset %}
+            {% else %}
+                {% set query %}
+                    select
+                          cast('all' as {{ dbt.type_string() }}) as data_source
+                        , '{{ final_mart['data_mart_name'] }}' as data_mart_name
+                        , cast(count(*) as {{ dbt.type_numeric() }}) as row_count
+                    from {{ relation }}
+                {% endset %}
+            {% endif %}
+        {% endif %}
+
+        {% do mart_queries.append(query) %}
+    {% endfor %}
+
+    {{ mart_queries | join('\nunion all\n') }}
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as data_mart_name
+        , cast(null as {{ dbt.type_numeric() }}) as row_count
+    where 1 = 0
+{% endif %}

--- a/models/data_quality/data_quality__analytical_key_metrics.sql
+++ b/models/data_quality/data_quality__analytical_key_metrics.sql
@@ -1,0 +1,935 @@
+{{ config(
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'analytical_key_metrics',
+     tags = ['data_quality', 'dqi'],
+     materialized = 'table'
+   )
+}}
+
+{% set dependency_names = [
+    'core__patient',
+    'core__medical_claim',
+    'core__pharmacy_claim',
+    'core__member_months',
+    'core__encounter',
+    'core__eligibility',
+    'readmissions__readmission_summary',
+    'readmissions__encounter_augmented',
+    'ed_classification__summary',
+    'chronic_conditions__tuva_chronic_conditions_long',
+    'cms_hcc__patient_risk_factors'
+] %}
+
+{% for dependency_name in dependency_names %}
+-- depends_on: {{ ref(dependency_name) }}
+{% endfor %}
+
+{% if execute %}
+    {% set core_patient_node = dq_find_model_node('core__patient') %}
+    {% set core_medical_claim_node = dq_find_model_node('core__medical_claim') %}
+    {% set core_pharmacy_claim_node = dq_find_model_node('core__pharmacy_claim') %}
+    {% set core_member_months_node = dq_find_model_node('core__member_months') %}
+    {% set core_encounter_node = dq_find_model_node('core__encounter') %}
+    {% set core_eligibility_node = dq_find_model_node('core__eligibility') %}
+    {% set readmission_summary_node = dq_find_model_node('readmissions__readmission_summary') %}
+    {% set readmission_augmented_node = dq_find_model_node('readmissions__encounter_augmented') %}
+    {% set ed_classification_node = dq_find_model_node('ed_classification__summary') %}
+    {% set chronic_conditions_node = dq_find_model_node('chronic_conditions__tuva_chronic_conditions_long') %}
+    {% set cms_hcc_node = dq_find_model_node('cms_hcc__patient_risk_factors') %}
+
+    {% set core_patient_rel = dq_actual_relation(core_patient_node) %}
+    {% set core_medical_claim_rel = dq_actual_relation(core_medical_claim_node) %}
+    {% set core_pharmacy_claim_rel = dq_actual_relation(core_pharmacy_claim_node) %}
+    {% set core_member_months_rel = dq_actual_relation(core_member_months_node) %}
+    {% set core_encounter_rel = dq_actual_relation(core_encounter_node) %}
+    {% set core_eligibility_rel = dq_actual_relation(core_eligibility_node) %}
+    {% set readmission_summary_rel = dq_actual_relation(readmission_summary_node) %}
+    {% set readmission_augmented_rel = dq_actual_relation(readmission_augmented_node) %}
+    {% set ed_classification_rel = dq_actual_relation(ed_classification_node) %}
+    {% set chronic_conditions_rel = dq_actual_relation(chronic_conditions_node) %}
+    {% set cms_hcc_rel = dq_actual_relation(cms_hcc_node) %}
+
+    {% set metric_queries = [] %}
+
+    {% if core_patient_rel is not none %}
+        {% set patient_metrics_query %}
+            select
+                  sources.data_source
+                , 'patient demographics' as domain
+                , 'count distinct patients' as metric
+                , cast(coalesce(patient_counts.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_patient_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(distinct person_id) as result
+                from {{ core_patient_rel }}
+                group by 1
+            ) as patient_counts
+                on sources.data_source_key = patient_counts.data_source_key
+
+            union all
+
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , 'patient demographics' as domain
+                , {{ concat_custom([
+                    "'count distinct patients | sex = '",
+                    "coalesce(cast(sex as " ~ dbt.type_string() ~ "), cast('unknown' as " ~ dbt.type_string() ~ "))"
+                  ]) }} as metric
+                , cast(count(distinct person_id) as {{ dbt.type_numeric() }}) as result
+            from {{ core_patient_rel }}
+            group by 1, 3
+
+            union all
+
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , 'patient demographics' as domain
+                , {{ concat_custom([
+                    "'count distinct patients | age_group = '",
+                    "coalesce(cast(age_group as " ~ dbt.type_string() ~ "), cast('unknown' as " ~ dbt.type_string() ~ "))"
+                  ]) }} as metric
+                , cast(count(distinct person_id) as {{ dbt.type_numeric() }}) as result
+            from {{ core_patient_rel }}
+            group by 1, 3
+
+            union all
+
+            select
+                  sources.data_source
+                , 'patient demographics' as domain
+                , 'count dead' as metric
+                , cast(coalesce(dead_counts.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_patient_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , sum(
+                        case
+                            when coalesce(death_flag, 0) = 1 or death_date is not null then 1
+                            else 0
+                        end
+                      ) as result
+                from {{ core_patient_rel }}
+                group by 1
+            ) as dead_counts
+                on sources.data_source_key = dead_counts.data_source_key
+        {% endset %}
+        {% do metric_queries.append(patient_metrics_query) %}
+    {% endif %}
+
+    {% if core_medical_claim_rel is not none %}
+        {% set medical_claim_metrics_query %}
+            select
+                  sources.data_source
+                , 'basic claims' as domain
+                , 'sum paid_amount in core.medical_claim' as metric
+                , cast(coalesce(paid_totals.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_medical_claim_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , coalesce(sum(paid_amount), 0) as result
+                from {{ core_medical_claim_rel }}
+                group by 1
+            ) as paid_totals
+                on sources.data_source_key = paid_totals.data_source_key
+
+            union all
+
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , 'basic claims' as domain
+                , {{ concat_custom([
+                    "'sum paid_amount by claim_type | '",
+                    "coalesce(cast(claim_type as " ~ dbt.type_string() ~ "), cast('unknown' as " ~ dbt.type_string() ~ "))"
+                  ]) }} as metric
+                , cast(coalesce(sum(paid_amount), 0) as {{ dbt.type_numeric() }}) as result
+            from {{ core_medical_claim_rel }}
+            group by 1, 3
+
+            union all
+
+            select
+                  sources.data_source
+                , 'basic claims' as domain
+                , 'sum allowed_amount in core.medical_claim' as metric
+                , cast(coalesce(allowed_totals.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_medical_claim_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , coalesce(sum(allowed_amount), 0) as result
+                from {{ core_medical_claim_rel }}
+                group by 1
+            ) as allowed_totals
+                on sources.data_source_key = allowed_totals.data_source_key
+
+            union all
+
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , 'basic claims' as domain
+                , {{ concat_custom([
+                    "'sum allowed_amount by claim_type | '",
+                    "coalesce(cast(claim_type as " ~ dbt.type_string() ~ "), cast('unknown' as " ~ dbt.type_string() ~ "))"
+                  ]) }} as metric
+                , cast(coalesce(sum(allowed_amount), 0) as {{ dbt.type_numeric() }}) as result
+            from {{ core_medical_claim_rel }}
+            group by 1, 3
+
+            union all
+
+            select
+                  sources.data_source
+                , 'basic claims' as domain
+                , 'count distinct claim_id in core.medical_claim' as metric
+                , cast(coalesce(claim_counts.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_medical_claim_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(distinct claim_id) as result
+                from {{ core_medical_claim_rel }}
+                group by 1
+            ) as claim_counts
+                on sources.data_source_key = claim_counts.data_source_key
+
+            union all
+
+            select
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , 'basic claims' as domain
+                , {{ concat_custom([
+                    "'count distinct claim_id by claim_type | '",
+                    "coalesce(cast(claim_type as " ~ dbt.type_string() ~ "), cast('unknown' as " ~ dbt.type_string() ~ "))"
+                  ]) }} as metric
+                , cast(count(distinct claim_id) as {{ dbt.type_numeric() }}) as result
+            from {{ core_medical_claim_rel }}
+            group by 1, 3
+        {% endset %}
+        {% do metric_queries.append(medical_claim_metrics_query) %}
+    {% endif %}
+
+    {% if core_pharmacy_claim_rel is not none %}
+        {% set pharmacy_claim_metrics_query %}
+            select
+                  sources.data_source
+                , 'basic claims' as domain
+                , 'sum paid_amount in core.pharmacy_claim' as metric
+                , cast(coalesce(paid_totals.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_pharmacy_claim_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , coalesce(sum(paid_amount), 0) as result
+                from {{ core_pharmacy_claim_rel }}
+                group by 1
+            ) as paid_totals
+                on sources.data_source_key = paid_totals.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'basic claims' as domain
+                , 'sum allowed_amount in core.pharmacy_claim' as metric
+                , cast(coalesce(allowed_totals.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_pharmacy_claim_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , coalesce(sum(allowed_amount), 0) as result
+                from {{ core_pharmacy_claim_rel }}
+                group by 1
+            ) as allowed_totals
+                on sources.data_source_key = allowed_totals.data_source_key
+        {% endset %}
+        {% do metric_queries.append(pharmacy_claim_metrics_query) %}
+    {% endif %}
+
+    {% if core_member_months_rel is not none %}
+        {% set member_month_metrics_query %}
+            select
+                  sources.data_source
+                , 'basic enrollment' as domain
+                , 'total member months' as metric
+                , cast(coalesce(total_member_months.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_member_months_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as result
+                from {{ core_member_months_rel }}
+                group by 1
+            ) as total_member_months
+                on sources.data_source_key = total_member_months.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'basic enrollment' as domain
+                , 'avg member months' as metric
+                , cast(coalesce(member_month_averages.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_member_months_rel) }}
+            ) as sources
+            left join (
+                select
+                      member_month_counts.data_source_key
+                    , avg(cast(member_month_counts.member_months as {{ dbt.type_numeric() }})) as result
+                from (
+                    select
+                          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , person_id
+                        , count(*) as member_months
+                    from {{ core_member_months_rel }}
+                    group by 1, 2
+                ) as member_month_counts
+                group by 1
+            ) as member_month_averages
+                on sources.data_source_key = member_month_averages.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'basic enrollment' as domain
+                , 'max member months' as metric
+                , cast(coalesce(member_month_maxima.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_member_months_rel) }}
+            ) as sources
+            left join (
+                select
+                      member_month_counts.data_source_key
+                    , max(member_month_counts.member_months) as result
+                from (
+                    select
+                          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , person_id
+                        , count(*) as member_months
+                    from {{ core_member_months_rel }}
+                    group by 1, 2
+                ) as member_month_counts
+                group by 1
+            ) as member_month_maxima
+                on sources.data_source_key = member_month_maxima.data_source_key
+        {% endset %}
+        {% do metric_queries.append(member_month_metrics_query) %}
+    {% endif %}
+
+    {% set claims_member_queries = [] %}
+    {% set claim_month_queries = [] %}
+
+    {% if core_medical_claim_rel is not none %}
+        {% set medical_claim_members_query %}
+            select distinct
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , person_id
+            from {{ core_medical_claim_rel }}
+        {% endset %}
+        {% do claims_member_queries.append(medical_claim_members_query) %}
+
+        {% set medical_claim_months_query %}
+            select distinct
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , person_id
+                , {{ year_month('claim_start_date') }} as year_month
+            from {{ core_medical_claim_rel }}
+            where claim_start_date is not null
+        {% endset %}
+        {% do claim_month_queries.append(medical_claim_months_query) %}
+    {% endif %}
+
+    {% if core_pharmacy_claim_rel is not none %}
+        {% set pharmacy_claim_members_query %}
+            select distinct
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , person_id
+            from {{ core_pharmacy_claim_rel }}
+        {% endset %}
+        {% do claims_member_queries.append(pharmacy_claim_members_query) %}
+
+        {% set pharmacy_claim_months_query %}
+            select distinct
+                  cast(data_source as {{ dbt.type_string() }}) as data_source
+                , person_id
+                , {{ year_month('dispensing_date') }} as year_month
+            from {{ core_pharmacy_claim_rel }}
+            where dispensing_date is not null
+        {% endset %}
+        {% do claim_month_queries.append(pharmacy_claim_months_query) %}
+    {% endif %}
+
+    {% if claims_member_queries | length > 0 and core_eligibility_rel is not none %}
+        {% set claims_without_enrollment_query %}
+            select
+                  sources.data_source
+                , 'basic enrollment' as domain
+                , 'members w/ claims w/o any enrollment' as metric
+                , cast(coalesce(missing_members.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                select distinct
+                      source_rows.data_source_key
+                    , source_rows.data_source
+                from (
+                    {% if core_medical_claim_rel is not none and core_pharmacy_claim_rel is not none %}
+                        {{ dq_source_dimension_sql(core_medical_claim_rel) }}
+                        union all
+                        {{ dq_source_dimension_sql(core_pharmacy_claim_rel) }}
+                    {% elif core_medical_claim_rel is not none %}
+                        {{ dq_source_dimension_sql(core_medical_claim_rel) }}
+                    {% else %}
+                        {{ dq_source_dimension_sql(core_pharmacy_claim_rel) }}
+                    {% endif %}
+                ) as source_rows
+            ) as sources
+            left join (
+                select
+                      claim_members.data_source_key
+                    , count(distinct claim_members.person_id) as result
+                from (
+                    select
+                          coalesce(data_source, '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , data_source
+                        , person_id
+                    from (
+                        {{ claims_member_queries | join('\nunion\n') }}
+                    ) as claim_members
+                ) as claim_members
+                left join (
+                    select distinct
+                          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , person_id
+                    from {{ core_eligibility_rel }}
+                ) as eligible_members
+                    on claim_members.data_source_key = eligible_members.data_source_key
+                    and claim_members.person_id = eligible_members.person_id
+                where eligible_members.person_id is null
+                group by 1
+            ) as missing_members
+                on sources.data_source_key = missing_members.data_source_key
+        {% endset %}
+        {% do metric_queries.append(claims_without_enrollment_query) %}
+    {% endif %}
+
+    {% if claim_month_queries | length > 0 and core_member_months_rel is not none %}
+        {% set claims_missing_enrollment_month_query %}
+            select
+                  sources.data_source
+                , 'basic enrollment' as domain
+                , 'members w/ claims missing enrollment that month' as metric
+                , cast(coalesce(missing_months.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                select distinct
+                      source_rows.data_source_key
+                    , source_rows.data_source
+                from (
+                    {% if core_medical_claim_rel is not none and core_pharmacy_claim_rel is not none %}
+                        {{ dq_source_dimension_sql(core_medical_claim_rel) }}
+                        union all
+                        {{ dq_source_dimension_sql(core_pharmacy_claim_rel) }}
+                    {% elif core_medical_claim_rel is not none %}
+                        {{ dq_source_dimension_sql(core_medical_claim_rel) }}
+                    {% else %}
+                        {{ dq_source_dimension_sql(core_pharmacy_claim_rel) }}
+                    {% endif %}
+                ) as source_rows
+            ) as sources
+            left join (
+                select
+                      claim_member_months.data_source_key
+                    , count(distinct claim_member_months.person_id) as result
+                from (
+                    select
+                          coalesce(data_source, '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , data_source
+                        , person_id
+                        , year_month
+                    from (
+                        {{ claim_month_queries | join('\nunion\n') }}
+                    ) as claim_member_months
+                ) as claim_member_months
+                left join (
+                    select distinct
+                          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , person_id
+                        , year_month
+                    from {{ core_member_months_rel }}
+                ) as member_months
+                    on claim_member_months.data_source_key = member_months.data_source_key
+                    and claim_member_months.person_id = member_months.person_id
+                    and claim_member_months.year_month = member_months.year_month
+                where member_months.person_id is null
+                group by 1
+            ) as missing_months
+                on sources.data_source_key = missing_months.data_source_key
+        {% endset %}
+        {% do metric_queries.append(claims_missing_enrollment_month_query) %}
+    {% endif %}
+
+    {% if core_encounter_rel is not none and core_member_months_rel is not none %}
+        {% set encounter_rate_metrics_query %}
+            select
+                  sources.data_source
+                , 'acute inpatient' as domain
+                , 'acute inpatient visits per 1,000' as metric
+                , cast(
+                    case
+                        when coalesce(member_month_totals.member_months, 0) = 0 then 0
+                        else (
+                            cast(coalesce(acute_inpatient_counts.encounter_count, 0) as {{ dbt.type_numeric() }})
+                            / cast(member_month_totals.member_months as {{ dbt.type_numeric() }})
+                        ) * 12000
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                {{ dq_source_dimension_sql(core_member_months_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as encounter_count
+                from {{ core_encounter_rel }}
+                where encounter_type = 'acute inpatient'
+                group by 1
+            ) as acute_inpatient_counts
+                on sources.data_source_key = acute_inpatient_counts.data_source_key
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as member_months
+                from {{ core_member_months_rel }}
+                group by 1
+            ) as member_month_totals
+                on sources.data_source_key = member_month_totals.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'skilled nursing' as domain
+                , 'snf visits per 1,000' as metric
+                , cast(
+                    case
+                        when coalesce(member_month_totals.member_months, 0) = 0 then 0
+                        else (
+                            cast(coalesce(snf_counts.encounter_count, 0) as {{ dbt.type_numeric() }})
+                            / cast(member_month_totals.member_months as {{ dbt.type_numeric() }})
+                        ) * 12000
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                {{ dq_source_dimension_sql(core_member_months_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as encounter_count
+                from {{ core_encounter_rel }}
+                where encounter_type = 'inpatient skilled nursing'
+                group by 1
+            ) as snf_counts
+                on sources.data_source_key = snf_counts.data_source_key
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as member_months
+                from {{ core_member_months_rel }}
+                group by 1
+            ) as member_month_totals
+                on sources.data_source_key = member_month_totals.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'emergency department' as domain
+                , 'ed visits per 1,000' as metric
+                , cast(
+                    case
+                        when coalesce(member_month_totals.member_months, 0) = 0 then 0
+                        else (
+                            cast(coalesce(ed_counts.encounter_count, 0) as {{ dbt.type_numeric() }})
+                            / cast(member_month_totals.member_months as {{ dbt.type_numeric() }})
+                        ) * 12000
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                {{ dq_source_dimension_sql(core_member_months_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as encounter_count
+                from {{ core_encounter_rel }}
+                where encounter_type = 'emergency department'
+                group by 1
+            ) as ed_counts
+                on sources.data_source_key = ed_counts.data_source_key
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as member_months
+                from {{ core_member_months_rel }}
+                group by 1
+            ) as member_month_totals
+                on sources.data_source_key = member_month_totals.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'office visits' as domain
+                , 'office visits per 1,000' as metric
+                , cast(
+                    case
+                        when coalesce(member_month_totals.member_months, 0) = 0 then 0
+                        else (
+                            cast(coalesce(office_counts.encounter_count, 0) as {{ dbt.type_numeric() }})
+                            / cast(member_month_totals.member_months as {{ dbt.type_numeric() }})
+                        ) * 12000
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                {{ dq_source_dimension_sql(core_member_months_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as encounter_count
+                from {{ core_encounter_rel }}
+                where encounter_group = 'office based'
+                group by 1
+            ) as office_counts
+                on sources.data_source_key = office_counts.data_source_key
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , count(*) as member_months
+                from {{ core_member_months_rel }}
+                group by 1
+            ) as member_month_totals
+                on sources.data_source_key = member_month_totals.data_source_key
+        {% endset %}
+        {% do metric_queries.append(encounter_rate_metrics_query) %}
+    {% endif %}
+
+    {% if core_encounter_rel is not none %}
+        {% set acute_inpatient_metrics_query %}
+            select
+                  sources.data_source
+                , 'acute inpatient' as domain
+                , 'inpatient alos' as metric
+                , cast(coalesce(alos.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_encounter_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , avg(cast(length_of_stay as {{ dbt.type_numeric() }})) as result
+                from {{ core_encounter_rel }}
+                where encounter_type = 'acute inpatient'
+                group by 1
+            ) as alos
+                on sources.data_source_key = alos.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'acute inpatient' as domain
+                , 'inpatient mortality rate' as metric
+                , cast(coalesce(mortality.result, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(core_encounter_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , case
+                        when count(*) = 0 then 0
+                        else (
+                            cast(sum(
+                                case
+                                    when discharge_disposition_code in ('20', '40', '41', '42') then 1
+                                    else 0
+                                end
+                            ) as {{ dbt.type_numeric() }})
+                            / cast(count(*) as {{ dbt.type_numeric() }})
+                        ) * 100
+                      end as result
+                from {{ core_encounter_rel }}
+                where encounter_type = 'acute inpatient'
+                  and discharge_disposition_code is not null
+                  and encounter_end_date is not null
+                group by 1
+            ) as mortality
+                on sources.data_source_key = mortality.data_source_key
+        {% endset %}
+        {% do metric_queries.append(acute_inpatient_metrics_query) %}
+    {% endif %}
+
+    {% if readmission_summary_rel is not none and readmission_augmented_rel is not none %}
+        {% set readmission_metrics_query %}
+            select
+                  sources.data_source
+                , 'readmissions' as domain
+                , 'index admissions' as metric
+                , cast(coalesce(readmission_counts.index_admissions, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(readmission_augmented_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(augmented.data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , sum(case when summary.index_admission_flag = 1 then 1 else 0 end) as index_admissions
+                    , sum(case when summary.index_admission_flag = 1 and summary.unplanned_readmit_30_flag = 1 then 1 else 0 end) as readmissions
+                from {{ readmission_summary_rel }} as summary
+                inner join {{ readmission_augmented_rel }} as augmented
+                    on summary.encounter_id = augmented.encounter_id
+                group by 1
+            ) as readmission_counts
+                on sources.data_source_key = readmission_counts.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'readmissions' as domain
+                , '30-day readmissions' as metric
+                , cast(coalesce(readmission_counts.readmissions, 0) as {{ dbt.type_numeric() }}) as result
+            from (
+                {{ dq_source_dimension_sql(readmission_augmented_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(augmented.data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , sum(case when summary.index_admission_flag = 1 then 1 else 0 end) as index_admissions
+                    , sum(case when summary.index_admission_flag = 1 and summary.unplanned_readmit_30_flag = 1 then 1 else 0 end) as readmissions
+                from {{ readmission_summary_rel }} as summary
+                inner join {{ readmission_augmented_rel }} as augmented
+                    on summary.encounter_id = augmented.encounter_id
+                group by 1
+            ) as readmission_counts
+                on sources.data_source_key = readmission_counts.data_source_key
+
+            union all
+
+            select
+                  sources.data_source
+                , 'readmissions' as domain
+                , '30-day readmission rate' as metric
+                , cast(
+                    case
+                        when coalesce(readmission_counts.index_admissions, 0) = 0 then 0
+                        else (
+                            cast(readmission_counts.readmissions as {{ dbt.type_numeric() }})
+                            / cast(readmission_counts.index_admissions as {{ dbt.type_numeric() }})
+                        ) * 100
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                {{ dq_source_dimension_sql(readmission_augmented_rel) }}
+            ) as sources
+            left join (
+                select
+                      coalesce(cast(augmented.data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                    , sum(case when summary.index_admission_flag = 1 then 1 else 0 end) as index_admissions
+                    , sum(case when summary.index_admission_flag = 1 and summary.unplanned_readmit_30_flag = 1 then 1 else 0 end) as readmissions
+                from {{ readmission_summary_rel }} as summary
+                inner join {{ readmission_augmented_rel }} as augmented
+                    on summary.encounter_id = augmented.encounter_id
+                group by 1
+            ) as readmission_counts
+                on sources.data_source_key = readmission_counts.data_source_key
+        {% endset %}
+        {% do metric_queries.append(readmission_metrics_query) %}
+    {% endif %}
+
+    {% if ed_classification_rel is not none %}
+        {% set ed_classification_metrics_query %}
+            select
+                  classified.data_source
+                , 'ed classification' as domain
+                , {{ concat_custom([
+                    "'percent of ed encounters | '",
+                    "classified.classification"
+                  ]) }} as metric
+                , cast(
+                    case
+                        when totals.total_encounters = 0 then null
+                        else (
+                            cast(classified.encounters as {{ dbt.type_numeric() }})
+                            / cast(totals.total_encounters as {{ dbt.type_numeric() }})
+                        ) * 100
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                select
+                      cast(data_source as {{ dbt.type_string() }}) as data_source
+                    , coalesce(
+                        cast(ed_classification_description as {{ dbt.type_string() }}),
+                        cast('Not Classified' as {{ dbt.type_string() }})
+                      ) as classification
+                    , count(*) as encounters
+                from {{ ed_classification_rel }}
+                group by 1, 2
+            ) as classified
+            inner join (
+                select
+                      cast(data_source as {{ dbt.type_string() }}) as data_source
+                    , count(*) as total_encounters
+                from {{ ed_classification_rel }}
+                group by 1
+            ) as totals
+                on classified.data_source = totals.data_source
+        {% endset %}
+        {% do metric_queries.append(ed_classification_metrics_query) %}
+    {% endif %}
+
+    {% if chronic_conditions_rel is not none and core_patient_rel is not none %}
+        {% set chronic_condition_metrics_query %}
+            select
+                  ranked_conditions.data_source
+                , 'top chronic condition prevalence' as domain
+                , {{ concat_custom([
+                    "'prevalence | '",
+                    "ranked_conditions.condition"
+                  ]) }} as metric
+                , cast(
+                    case
+                        when patient_totals.total_patients = 0 then null
+                        else (
+                            cast(ranked_conditions.patient_count as {{ dbt.type_numeric() }})
+                            / cast(patient_totals.total_patients as {{ dbt.type_numeric() }})
+                        ) * 100
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                select
+                      condition_counts.data_source
+                    , condition_counts.condition
+                    , condition_counts.patient_count
+                    , row_number() over (
+                        partition by condition_counts.data_source
+                        order by condition_counts.patient_count desc, condition_counts.condition
+                      ) as condition_rank
+                from (
+                    select
+                          cast(patient.data_source as {{ dbt.type_string() }}) as data_source
+                        , cast(chronic_conditions.condition as {{ dbt.type_string() }}) as condition
+                        , count(distinct chronic_conditions.person_id) as patient_count
+                    from {{ chronic_conditions_rel }} as chronic_conditions
+                    inner join {{ core_patient_rel }} as patient
+                        on chronic_conditions.person_id = patient.person_id
+                    group by 1, 2
+                ) as condition_counts
+            ) as ranked_conditions
+            inner join (
+                select
+                      cast(data_source as {{ dbt.type_string() }}) as data_source
+                    , count(distinct person_id) as total_patients
+                from {{ core_patient_rel }}
+                group by 1
+            ) as patient_totals
+                on ranked_conditions.data_source = patient_totals.data_source
+            where ranked_conditions.condition_rank <= 10
+        {% endset %}
+        {% do metric_queries.append(chronic_condition_metrics_query) %}
+    {% endif %}
+
+    {% if cms_hcc_rel is not none and core_patient_rel is not none %}
+        {% set cms_hcc_metrics_query %}
+            select
+                  ranked_hcc.data_source
+                , 'top hcc prevalence' as domain
+                , {{ concat_custom([
+                    "'prevalence | '",
+                    "ranked_hcc.risk_factor_description"
+                  ]) }} as metric
+                , cast(
+                    case
+                        when patient_totals.total_patients = 0 then null
+                        else (
+                            cast(ranked_hcc.patient_count as {{ dbt.type_numeric() }})
+                            / cast(patient_totals.total_patients as {{ dbt.type_numeric() }})
+                        ) * 100
+                    end as {{ dbt.type_numeric() }}
+                  ) as result
+            from (
+                select
+                      hcc_counts.data_source
+                    , hcc_counts.risk_factor_description
+                    , hcc_counts.patient_count
+                    , row_number() over (
+                        partition by hcc_counts.data_source
+                        order by hcc_counts.patient_count desc, hcc_counts.risk_factor_description
+                      ) as hcc_rank
+                from (
+                    select
+                          cast(patient.data_source as {{ dbt.type_string() }}) as data_source
+                        , cast(hcc.risk_factor_description as {{ dbt.type_string() }}) as risk_factor_description
+                        , count(distinct hcc.person_id) as patient_count
+                    from {{ cms_hcc_rel }} as hcc
+                    inner join {{ core_patient_rel }} as patient
+                        on hcc.person_id = patient.person_id
+                    where hcc.factor_type = 'Disease'
+                    group by 1, 2
+                ) as hcc_counts
+            ) as ranked_hcc
+            inner join (
+                select
+                      cast(data_source as {{ dbt.type_string() }}) as data_source
+                    , count(distinct person_id) as total_patients
+                from {{ core_patient_rel }}
+                group by 1
+            ) as patient_totals
+                on ranked_hcc.data_source = patient_totals.data_source
+            where ranked_hcc.hcc_rank <= 10
+        {% endset %}
+        {% do metric_queries.append(cms_hcc_metrics_query) %}
+    {% endif %}
+
+    {% if metric_queries | length > 0 %}
+        {{ metric_queries | join('\nunion all\n') }}
+    {% else %}
+        select
+              cast(null as {{ dbt.type_string() }}) as data_source
+            , cast(null as {{ dbt.type_string() }}) as domain
+            , cast(null as {{ dbt.type_string() }}) as metric
+            , cast(null as {{ dbt.type_numeric() }}) as result
+        where 1 = 0
+    {% endif %}
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as domain
+        , cast(null as {{ dbt.type_string() }}) as metric
+        , cast(null as {{ dbt.type_numeric() }}) as result
+    where 1 = 0
+{% endif %}

--- a/models/data_quality/data_quality__logical.sql
+++ b/models/data_quality/data_quality__logical.sql
@@ -1,0 +1,60 @@
+{{ config(
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'logical',
+     tags = ['data_quality', 'dqi'],
+     materialized = 'table'
+   )
+}}
+
+{% set logical_rules = dq_logical_rules() %}
+{% set dependency_names = [
+    'input_layer__appointment',
+    'input_layer__condition',
+    'input_layer__eligibility',
+    'input_layer__encounter',
+    'input_layer__lab_result',
+    'input_layer__medical_claim',
+    'input_layer__pharmacy_claim',
+    'input_layer__provider_attribution'
+] %}
+
+{% for dependency_name in dependency_names %}
+-- depends_on: {{ ref(dependency_name) }}
+{% endfor %}
+-- depends_on: {{ ref('reference_data__calendar') }}
+
+{% if execute %}
+    {% set logical_queries = [] %}
+
+    {% for rule in logical_rules %}
+        {% set model_node = dq_find_model_node(rule['model_name']) %}
+        {% set relation = dq_actual_relation(model_node) if model_node is not none else none %}
+
+        {% if relation is not none %}
+            {% set query = dq_render_logical_rule_sql(rule, relation) %}
+            {% if query is not none %}
+                {% do logical_queries.append(query) %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {% if logical_queries | length > 0 %}
+        {{ logical_queries | join('\nunion all\n') }}
+    {% else %}
+        select
+              cast(null as {{ dbt.type_string() }}) as data_source
+            , cast(null as {{ dbt.type_string() }}) as test_name
+            , cast(null as {{ dbt.type_numeric() }}) as test_result
+        where 1 = 0
+    {% endif %}
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as test_name
+        , cast(null as {{ dbt.type_numeric() }}) as test_result
+    where 1 = 0
+{% endif %}

--- a/models/data_quality/data_quality__structural.sql
+++ b/models/data_quality/data_quality__structural.sql
@@ -1,0 +1,151 @@
+{{ config(
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural',
+     tags = ['data_quality', 'dqi'],
+     materialized = 'table'
+   )
+}}
+
+{% set structural_dependency_names = [
+    'input_layer__appointment',
+    'input_layer__condition',
+    'input_layer__eligibility',
+    'input_layer__encounter',
+    'input_layer__immunization',
+    'input_layer__lab_result',
+    'input_layer__location',
+    'input_layer__medical_claim',
+    'input_layer__medication',
+    'input_layer__observation',
+    'input_layer__patient',
+    'input_layer__pharmacy_claim',
+    'input_layer__practitioner',
+    'input_layer__procedure',
+    'input_layer__provider_attribution'
+] %}
+
+{% for dependency_name in structural_dependency_names %}
+-- depends_on: {{ ref(dependency_name) }}
+{% endfor %}
+
+{% if execute %}
+    {% set expected_models = dq_expected_input_layer_models() %}
+    {% set structural_queries = [] %}
+
+    {% for model_node in expected_models %}
+        {% set table_name = model_node.name | replace('input_layer__', '') %}
+        {% set relation = dq_actual_relation(model_node) %}
+
+        {% if relation is none %}
+            {% set query %}
+                select
+                      cast(null as {{ dbt.type_string() }}) as data_source
+                    , '{{ table_name }}' as table_name
+                    , 'fail' as table_exists
+                    , 'fail' as columns_exist
+                    , 'fail' as data_types
+                    , 'fail' as primary_keys
+                    , cast(null as {{ dbt.type_numeric() }}) as row_count
+            {% endset %}
+        {% else %}
+            {% set expected_columns = dq_expected_columns(model_node) %}
+            {% set actual_columns = dq_actual_columns(relation) %}
+            {% set actual_column_types = {} %}
+            {% set status = namespace(columns_exist='pass', data_types='pass', pk_columns_exist=true) %}
+
+            {% for column in actual_columns %}
+                {% do actual_column_types.update({column.name | lower: column.dtype}) %}
+            {% endfor %}
+
+            {% for expected_column in expected_columns %}
+                {% set expected_name = expected_column['name'] %}
+                {% set actual_type = actual_column_types.get(expected_name) %}
+
+                {% if actual_type is none %}
+                    {% set status.columns_exist = 'fail' %}
+                    {% set status.data_types = 'fail' %}
+                {% elif expected_column['data_type'] is not none
+                        and not dq_type_families_match(expected_column['data_type'], actual_type) %}
+                    {% set status.data_types = 'fail' %}
+                {% endif %}
+            {% endfor %}
+
+            {% set pk_columns = dq_expected_pk_columns(model_node) %}
+
+            {% for pk_column in pk_columns %}
+                {% if actual_column_types.get(pk_column) is none %}
+                    {% set status.pk_columns_exist = false %}
+                {% endif %}
+            {% endfor %}
+
+            {% if pk_columns | length == 0 or not status.pk_columns_exist %}
+                {% set query %}
+                    select
+                          sources.data_source
+                        , '{{ table_name }}' as table_name
+                        , 'pass' as table_exists
+                        , '{{ status.columns_exist }}' as columns_exist
+                        , '{{ status.data_types }}' as data_types
+                        , 'fail' as primary_keys
+                        , coalesce(source_counts.row_count, 0) as row_count
+                    from (
+                        {{ dq_source_dimension_sql(relation) }}
+                    ) as sources
+                    left join (
+                        {{ dq_source_row_count_sql(relation) }}
+                    ) as source_counts
+                        on sources.data_source_key = source_counts.data_source_key
+                {% endset %}
+            {% else %}
+                {% set query %}
+                    select
+                          sources.data_source
+                        , '{{ table_name }}' as table_name
+                        , 'pass' as table_exists
+                        , '{{ status.columns_exist }}' as columns_exist
+                        , '{{ status.data_types }}' as data_types
+                        , case
+                            when coalesce(pk_nulls.null_pk_count, 0) = 0
+                             and coalesce(pk_duplicates.duplicate_pk_count, 0) = 0
+                            then 'pass'
+                            else 'fail'
+                          end as primary_keys
+                        , coalesce(source_counts.row_count, 0) as row_count
+                    from (
+                        {{ dq_source_dimension_sql(relation) }}
+                    ) as sources
+                    left join (
+                        {{ dq_source_row_count_sql(relation) }}
+                    ) as source_counts
+                        on sources.data_source_key = source_counts.data_source_key
+                    left join (
+                        {{ dq_pk_null_count_sql(relation, pk_columns) }}
+                    ) as pk_nulls
+                        on sources.data_source_key = pk_nulls.data_source_key
+                    left join (
+                        {{ dq_duplicate_pk_count_sql(relation, pk_columns) }}
+                    ) as pk_duplicates
+                        on sources.data_source_key = pk_duplicates.data_source_key
+                {% endset %}
+            {% endif %}
+        {% endif %}
+
+        {% do structural_queries.append(query) %}
+    {% endfor %}
+
+    {{ structural_queries | join('\nunion all\n') }}
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as table_name
+        , cast(null as {{ dbt.type_string() }}) as table_exists
+        , cast(null as {{ dbt.type_string() }}) as columns_exist
+        , cast(null as {{ dbt.type_string() }}) as data_types
+        , cast(null as {{ dbt.type_string() }}) as primary_keys
+        , cast(null as {{ dbt.type_numeric() }}) as row_count
+    where 1 = 0
+{% endif %}

--- a/models/data_quality/data_quality_models.yml
+++ b/models/data_quality/data_quality_models.yml
@@ -31,6 +31,88 @@ models:
               - level_of_detail
               - y_axis
               - x_axis
+  - name: data_quality__structural
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural
+      tags:
+        - data_quality
+        - dqi
+      materialized: table
+    columns:
+      - name: data_source
+        description: The input-layer data source being evaluated. Null means the source could not be determined from the relation.
+      - name: table_name
+        description: The input-layer table being evaluated.
+      - name: table_exists
+        description: Pass or fail result indicating whether the expected input-layer relation exists.
+      - name: columns_exist
+        description: Pass or fail result indicating whether all documented input-layer columns are present.
+      - name: data_types
+        description: Pass or fail result indicating whether all documented input-layer columns match the expected data-type family.
+      - name: primary_keys
+        description: Pass or fail result indicating whether the documented primary-key columns exist, are non-null, and remain unique at the documented grain.
+      - name: row_count
+        description: The number of rows present for the evaluated data_source and input-layer table. Null means the relation does not exist.
+
+  - name: data_quality__logical
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: logical
+      tags:
+        - data_quality
+        - dqi
+      materialized: table
+    columns:
+      - name: data_source
+        description: The input-layer data source being evaluated. Null means the source could not be determined from the relation.
+      - name: test_name
+        description: The logical consistency test being evaluated.
+      - name: test_result
+        description: The count of rows that violate the logical consistency test. Healthy results are expected to be zero.
+
+  - name: data_quality__analytical_key_metrics
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: analytical_key_metrics
+      tags:
+        - data_quality
+        - dqi
+      materialized: table
+    columns:
+      - name: data_source
+        description: The data source for the analytical metric.
+      - name: domain
+        description: The high-level analytical domain for the metric.
+      - name: metric
+        description: The analytical metric name, including any grouping label carried into the output.
+      - name: result
+        description: The metric result value.
+
+  - name: data_quality__analytical_data_marts
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: analytical_data_marts
+      tags:
+        - data_quality
+        - dqi
+      materialized: table
+    columns:
+      - name: data_source
+        description: The data source for the mart row count. The value all is used when a mart does not expose data_source or when an empty mart still needs a summary row.
+      - name: data_mart_name
+        description: The Tuva final mart model name being summarized.
+      - name: row_count
+        description: The row count for the mart. Null indicates the mart relation does not exist.
+
   - name: data_quality__chronic_conditions_prevalence
     config:
       schema: |


### PR DESCRIPTION
## Summary
- add user-facing structural, logical, analytical key metrics, and analytical data marts summary models
- add shared cross-warehouse data quality helper macros and document the new outputs
- add row counts to structural and reduce analytical mart coverage to one representative model per mart family

## Validation
- `./scripts/dbt-local build --select data_quality__structural data_quality__logical data_quality__analytical_key_metrics data_quality__analytical_data_marts --threads 1 --vars {synthetic_data_size: large, use_synthetic_data: true}`
- prior local DuckDB full refresh on large synthetic data completed successfully with `ERROR=0`