### PR TITLE
Add versioned seed release runbook and per-asset vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,14 @@ Set Tuva vars under the `vars:` key in your `dbt_project.yml`. Use dbt selectors
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `custom_bucket_name` | `"tuva-public-resources"` | Default bucket for versioned Tuva seed artifacts. |
-| `tuva_seed_version` | `"1.0.0"` | Default versioned seed folder used when no per-database override is provided. Leading `v` is optional. |
-| `tuva_seed_versions` | `{concept_library: "1.0.1", reference_data: "1.0.0", terminology: "1.0.0", value_sets: "1.0.0", provider_data: "1.0.0", synthetic_data: "1.0.0"}` | Optional per-database version overrides keyed by `concept_library`, `reference_data`, `terminology`, `value_sets`, `provider_data`, or `synthetic_data`. |
+| `concept_library_version` | `"1.0.1"` | Primary version var for concept library assets. |
+| `reference_data_version` | `"1.1.0"` | Primary version var for reference data assets. |
+| `terminology_version` | `"1.1.0"` | Primary version var for terminology assets. |
+| `value_sets_version` | `"1.1.0"` | Primary version var for value sets assets. |
+| `provider_data_version` | `"1.1.0"` | Primary version var for provider data assets. |
+| `synthetic_data_version` | `"1.0.0"` | Primary version var for synthetic data assets. |
+| `tuva_seed_version` | `"1.0.0"` | Deprecated fallback default version when no per-asset var or legacy map override is provided. Leading `v` is optional. |
+| `tuva_seed_versions` | `{}` | Deprecated per-database fallback map keyed by `concept_library`, `reference_data`, `terminology`, `value_sets`, `provider_data`, or `synthetic_data`. |
 | `tuva_seed_buckets` | `{}` | Optional per-database bucket overrides for `concept_library`, `reference_data`, `terminology`, `value_sets`, `provider_data`, or `synthetic_data`. |
 | `synthetic_data_size` | `small` in `integration_tests` | Selects the `small` or `large` synthetic input payload when running `integration_tests`. |
 | `enable_input_layer_testing` | `true` | Runs DQI checks on the input layer. |
@@ -93,9 +99,12 @@ See the maintained docs reference at [thetuvaproject.com/dbt-variables](https://
 
 Use `scripts/publish-dolthub-seeds` to publish the latest public DoltHub databases to versioned S3 folders.
 
+The repo-local operator runbook for this process lives at [skills/versioned-seed-release.md](/Users/aaronneiderhiser/code/tuva/skills/versioned-seed-release.md).
+
 Required inputs:
-- `--version v1.0.0`
-- AWS CLI credentials via `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+- `--version v1.1.0`
+- `--ref v1.1.0` to pin the DoltHub release tag instead of publishing from `main`
+- AWS CLI credentials or AWS SSO auth
 
 Optional inputs:
 - `--bucket reference_data=my-bucket`
@@ -105,6 +114,8 @@ Optional inputs:
 
 The script publishes to the normalized layout:
 - `s3://<bucket>/<database-folder>/<version>/<table>.csv.gz`
+
+For live publishes, pass `--stage-dir` so the generated `publish-manifest.json` is retained as the audit artifact for the release.
 
 ## Mirroring Seed Releases To GCS And Azure
 
@@ -118,7 +129,7 @@ Required access:
 Example:
 
 ```bash
-scripts/mirror-seed-release --version v1.0.0
+scripts/mirror-seed-release --version v1.1.0 --target gcs --target azure
 ```
 
 The script mirrors:
@@ -126,6 +137,7 @@ The script mirrors:
 - `gs://tuva-public-resources/<database-folder>/<version>/...`
 - `https://tuvapublicresources.blob.core.windows.net/tuva-public-resources/<database-folder>/<version>/...`
 
-Current published defaults:
+Current published versions:
 - `concept-library` uses `1.0.1`
-- `reference-data`, `terminology`, `value-sets`, `provider-data`, and `synthetic-data` use `1.0.0`
+- `reference-data`, `terminology`, `value-sets`, and `provider-data` use `1.1.0`
+- `synthetic-data` uses `1.0.0`

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,14 +29,12 @@ vars:
 
   ## Seed storage configuration
   custom_bucket_name: tuva-public-resources
-  tuva_seed_version: "1.0.0"
-  tuva_seed_versions:
-    concept_library: "1.0.1"
-    reference_data: "1.0.0"
-    terminology: "1.0.0"
-    value_sets: "1.0.0"
-    provider_data: "1.0.0"
-    synthetic_data: "1.0.0"
+  concept_library_version: "1.0.1"
+  reference_data_version: "1.1.0"
+  terminology_version: "1.1.0"
+  value_sets_version: "1.1.0"
+  provider_data_version: "1.1.0"
+  synthetic_data_version: "1.0.0"
   tuva_seed_buckets: {}
 
   ## Run metadata

--- a/docs/docs/dbt-variables.md
+++ b/docs/docs/dbt-variables.md
@@ -49,8 +49,14 @@ These vars control shared seed loading and optional feature behavior.
 | Variable | Default | Description |
 |-----------|---------|-------------|
 | `custom_bucket_name` | `"tuva-public-resources"` | Default bucket for versioned Tuva seed artifacts. |
-| `tuva_seed_version` | `"1.0.0"` | Default versioned seed folder used when no per-database override is provided. Leading `v` is optional. |
-| `tuva_seed_versions` | `{concept_library: "1.0.1", reference_data: "1.0.0", terminology: "1.0.0", value_sets: "1.0.0", provider_data: "1.0.0", synthetic_data: "1.0.0"}` | Optional per-database version overrides keyed by `concept_library`, `reference_data`, `terminology`, `value_sets`, `provider_data`, or `synthetic_data`. |
+| `concept_library_version` | `"1.0.1"` | Primary version var for concept library assets. |
+| `reference_data_version` | `"1.1.0"` | Primary version var for reference data assets. |
+| `terminology_version` | `"1.1.0"` | Primary version var for terminology assets. |
+| `value_sets_version` | `"1.1.0"` | Primary version var for value sets assets. |
+| `provider_data_version` | `"1.1.0"` | Primary version var for provider data assets. |
+| `synthetic_data_version` | `"1.0.0"` | Primary version var for synthetic data assets. |
+| `tuva_seed_version` | `"1.0.0"` | Deprecated fallback default version when no per-asset var or legacy map override is provided. Leading `v` is optional. |
+| `tuva_seed_versions` | `{}` | Deprecated per-database fallback map keyed by `concept_library`, `reference_data`, `terminology`, `value_sets`, `provider_data`, or `synthetic_data`. |
 | `tuva_seed_buckets` | `{}` | Optional per-database bucket overrides for `concept_library`, `reference_data`, `terminology`, `value_sets`, `provider_data`, or `synthetic_data`. |
 | `enable_input_layer_testing` | `true` | Runs DQI checks on the input layer. |
 | `enable_legacy_data_quality` | `false` | Builds the legacy pre-DQI data-quality models. |
@@ -78,7 +84,12 @@ vars:
   provider_attribution_enabled: true
   cms_hcc_payment_year: 2024
   quality_measures_period_end: "2024-12-31"
-  tuva_seed_version: "1.0.0"
+  concept_library_version: "1.0.1"
+  reference_data_version: "1.1.0"
+  terminology_version: "1.1.0"
+  value_sets_version: "1.1.0"
+  provider_data_version: "1.1.0"
+  synthetic_data_version: "1.0.0"
 ```
 
 ## Example `integration_tests` Config
@@ -92,6 +103,12 @@ vars:
   provider_attribution_enabled: true
   semantic_layer_enabled: true
   synthetic_data_size: small
+  concept_library_version: "1.0.1"
+  reference_data_version: "1.1.0"
+  terminology_version: "1.1.0"
+  value_sets_version: "1.1.0"
+  provider_data_version: "1.1.0"
+  synthetic_data_version: "1.0.0"
 ```
 
 For provider attribution date overrides, see [Provider Attribution](./data-marts/tuva-provider-attribution.md). For the current local runbook, see [Getting Started](./getting-started.md).

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -3,7 +3,8 @@
 1. Set the project subdirectory to “integration_tests” if using dbt cloud or change directory to "integration_tests" (`cd integration_tests`) if using CLI.
 2. Configure synthetic seed loading:
    - Set `synthetic_data_size` to `small` or `large` (`small` is the default)
-   - Set `tuva_seed_version`, `tuva_seed_versions`, and the appropriate bucket vars when testing published artifacts
+   - Set `concept_library_version`, `reference_data_version`, `terminology_version`, `value_sets_version`, `provider_data_version`, `synthetic_data_version`, and the appropriate bucket vars when testing published artifacts
+   - `tuva_seed_version` and `tuva_seed_versions` still work as legacy fallback vars, but they are no longer the primary interface
 3. Run `dbt deps`.
 4. Run `dbt seed` or `dbt build` to load the synthetic data into `raw_data`.
 5. Run `dbt run` only after the synthetic seed tables have already been loaded.

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -17,14 +17,12 @@ vars:
   use_synthetic_data: true
   synthetic_data_size: small
   custom_bucket_name: tuva-public-resources
-  tuva_seed_version: "1.0.0"
-  tuva_seed_versions:
-    concept_library: "1.0.1"
-    reference_data: "1.0.0"
-    terminology: "1.0.0"
-    value_sets: "1.0.0"
-    provider_data: "1.0.0"
-    synthetic_data: "1.0.0"
+  concept_library_version: "1.0.1"
+  reference_data_version: "1.1.0"
+  terminology_version: "1.1.0"
+  value_sets_version: "1.1.0"
+  provider_data_version: "1.1.0"
+  synthetic_data_version: "1.0.0"
   tuva_seed_buckets: {}
 
   ## Passthrough Columns Configuration

--- a/macros/cross_database_utils/versioned_seed_paths.sql
+++ b/macros/cross_database_utils/versioned_seed_paths.sql
@@ -10,22 +10,22 @@
 {% endmacro %}
 
 
-{% macro get_seed_database_folder(database) %}
+{% macro get_seed_database_name(database) %}
   {% set folders = the_tuva_project.get_seed_database_folders() %}
   {% set normalized_database = database | string | trim %}
   {% set alternate_database = normalized_database | replace('-', '_') %}
 
   {% if normalized_database in folders %}
-    {{ return(folders[normalized_database]) }}
+    {{ return(normalized_database) }}
   {% endif %}
 
   {% if alternate_database in folders %}
-    {{ return(folders[alternate_database]) }}
+    {{ return(alternate_database) }}
   {% endif %}
 
-  {% for folder in folders.values() %}
+  {% for logical_database, folder in folders.items() %}
     {% if normalized_database == folder %}
-      {{ return(folder) }}
+      {{ return(logical_database) }}
     {% endif %}
   {% endfor %}
 
@@ -35,17 +35,30 @@
 {% endmacro %}
 
 
+{% macro get_seed_database_folder(database) %}
+  {% set folders = the_tuva_project.get_seed_database_folders() %}
+  {% set logical_database = the_tuva_project.get_seed_database_name(database) %}
+  {{ return(folders[logical_database]) }}
+{% endmacro %}
+
+
 {% macro get_seed_bucket(database) %}
   {% set bucket_overrides = var('tuva_seed_buckets', {}) %}
   {% set normalized_database = database | string | trim %}
   {% set alternate_database = normalized_database | replace('-', '_') %}
+  {% set logical_database = the_tuva_project.get_seed_database_name(database) %}
+  {% set database_folder = the_tuva_project.get_seed_database_folder(logical_database) %}
   {% set bucket = none %}
 
   {% if bucket_overrides is mapping %}
-    {% if normalized_database in bucket_overrides %}
+    {% if logical_database in bucket_overrides %}
+      {% set bucket = bucket_overrides[logical_database] %}
+    {% elif normalized_database in bucket_overrides %}
       {% set bucket = bucket_overrides[normalized_database] %}
     {% elif alternate_database in bucket_overrides %}
       {% set bucket = bucket_overrides[alternate_database] %}
+    {% elif database_folder in bucket_overrides %}
+      {% set bucket = bucket_overrides[database_folder] %}
     {% endif %}
   {% endif %}
 
@@ -67,15 +80,23 @@
     {% set version_overrides = var('tuva_seed_versions', {}) %}
     {% set version = none %}
 
-    {% if version_overrides is mapping %}
-      {% if database is not none %}
-        {% set normalized_database = database | string | trim %}
-        {% set alternate_database = normalized_database | replace('-', '_') %}
+    {% if database is not none %}
+      {% set logical_database = the_tuva_project.get_seed_database_name(database) %}
+      {% set normalized_database = database | string | trim %}
+      {% set alternate_database = normalized_database | replace('-', '_') %}
+      {% set database_folder = the_tuva_project.get_seed_database_folder(logical_database) %}
+      {% set per_asset_var_name = logical_database ~ '_version' %}
+      {% set version = var(per_asset_var_name, none) %}
 
-        {% if normalized_database in version_overrides %}
+      {% if version is none and version_overrides is mapping %}
+        {% if logical_database in version_overrides %}
+          {% set version = version_overrides[logical_database] %}
+        {% elif normalized_database in version_overrides %}
           {% set version = version_overrides[normalized_database] %}
         {% elif alternate_database in version_overrides %}
           {% set version = version_overrides[alternate_database] %}
+        {% elif database_folder in version_overrides %}
+          {% set version = version_overrides[database_folder] %}
         {% endif %}
       {% endif %}
     {% endif %}
@@ -185,4 +206,3 @@
       null_marker
   )) }}
 {% endmacro %}
-

--- a/models/data_quality/data_quality__analytical_data_marts.sql
+++ b/models/data_quality/data_quality__analytical_data_marts.sql
@@ -10,22 +10,34 @@
    )
 }}
 
-{% set analytical_data_mart_dependency_names = [
-    'ahrq_measures__pqi_summary',
-    'ccsr__procedure_summary',
-    'chronic_conditions__cms_chronic_conditions_wide',
-    'cms_hcc__patient_risk_scores',
-    'ed_classification__summary',
-    'financial_pmpm__pmpm_payer',
-    'hcc_recapture__recapture_rates',
-    'hcc_suspecting__summary',
-    'pharmacy__brand_generic_opportunity',
-    'provider_attribution__provider_ranking',
-    'quality_measures__summary_wide',
-    'readmissions__readmission_summary',
-    'semantic_layer__fact_member_months',
-    'semantic_layer__fact_quality_measures'
-] %}
+{% set analytical_data_mart_dependency_names = [] %}
+
+{% if var('claims_enabled', false) | as_bool %}
+  {% do analytical_data_mart_dependency_names.extend([
+      'ahrq_measures__pqi_summary',
+      'ccsr__procedure_summary',
+      'chronic_conditions__cms_chronic_conditions_wide',
+      'cms_hcc__patient_risk_scores',
+      'ed_classification__summary',
+      'financial_pmpm__pmpm_payer',
+      'hcc_recapture__recapture_rates',
+      'hcc_suspecting__summary',
+      'pharmacy__brand_generic_opportunity',
+      'quality_measures__summary_wide',
+      'readmissions__readmission_summary'
+  ]) %}
+{% endif %}
+
+{% if var('provider_attribution_enabled', false) | as_bool %}
+  {% do analytical_data_mart_dependency_names.append('provider_attribution__provider_ranking') %}
+{% endif %}
+
+{% if var('semantic_layer_enabled', false) | as_bool %}
+  {% do analytical_data_mart_dependency_names.extend([
+      'semantic_layer__fact_member_months',
+      'semantic_layer__fact_quality_measures'
+  ]) %}
+{% endif %}
 
 {% for dependency_name in analytical_data_mart_dependency_names %}
 -- depends_on: {{ ref(dependency_name) }}

--- a/models/data_quality/data_quality__analytical_key_metrics.sql
+++ b/models/data_quality/data_quality__analytical_key_metrics.sql
@@ -10,19 +10,28 @@
    )
 }}
 
-{% set dependency_names = [
-    'core__patient',
-    'core__medical_claim',
-    'core__pharmacy_claim',
-    'core__member_months',
-    'core__encounter',
-    'core__eligibility',
-    'readmissions__readmission_summary',
-    'readmissions__encounter_augmented',
-    'ed_classification__summary',
-    'chronic_conditions__tuva_chronic_conditions_long',
-    'cms_hcc__patient_risk_factors'
-] %}
+{% set dependency_names = [] %}
+
+{% if var('claims_enabled', false) | as_bool or var('clinical_enabled', false) | as_bool %}
+  {% do dependency_names.extend([
+      'core__patient',
+      'core__encounter'
+  ]) %}
+{% endif %}
+
+{% if var('claims_enabled', false) | as_bool %}
+  {% do dependency_names.extend([
+      'core__medical_claim',
+      'core__pharmacy_claim',
+      'core__member_months',
+      'core__eligibility',
+      'readmissions__readmission_summary',
+      'readmissions__encounter_augmented',
+      'ed_classification__summary',
+      'chronic_conditions__tuva_chronic_conditions_long',
+      'cms_hcc__patient_risk_factors'
+  ]) %}
+{% endif %}
 
 {% for dependency_name in dependency_names %}
 -- depends_on: {{ ref(dependency_name) }}

--- a/models/data_quality/data_quality__logical.sql
+++ b/models/data_quality/data_quality__logical.sql
@@ -11,16 +11,28 @@
 }}
 
 {% set logical_rules = dq_logical_rules() %}
-{% set dependency_names = [
-    'input_layer__appointment',
-    'input_layer__condition',
-    'input_layer__eligibility',
-    'input_layer__encounter',
-    'input_layer__lab_result',
-    'input_layer__medical_claim',
-    'input_layer__pharmacy_claim',
-    'input_layer__provider_attribution'
-] %}
+{% set dependency_names = [] %}
+
+{% if var('clinical_enabled', false) | as_bool %}
+  {% do dependency_names.extend([
+      'input_layer__appointment',
+      'input_layer__condition',
+      'input_layer__encounter',
+      'input_layer__lab_result'
+  ]) %}
+{% endif %}
+
+{% if var('claims_enabled', false) | as_bool %}
+  {% do dependency_names.extend([
+      'input_layer__eligibility',
+      'input_layer__medical_claim',
+      'input_layer__pharmacy_claim'
+  ]) %}
+{% endif %}
+
+{% if var('provider_attribution_enabled', false) | as_bool %}
+  {% do dependency_names.append('input_layer__provider_attribution') %}
+{% endif %}
 
 {% for dependency_name in dependency_names %}
 -- depends_on: {{ ref(dependency_name) }}

--- a/models/data_quality/data_quality__structural.sql
+++ b/models/data_quality/data_quality__structural.sql
@@ -10,23 +10,35 @@
    )
 }}
 
-{% set structural_dependency_names = [
-    'input_layer__appointment',
-    'input_layer__condition',
-    'input_layer__eligibility',
-    'input_layer__encounter',
-    'input_layer__immunization',
-    'input_layer__lab_result',
-    'input_layer__location',
-    'input_layer__medical_claim',
-    'input_layer__medication',
-    'input_layer__observation',
-    'input_layer__patient',
-    'input_layer__pharmacy_claim',
-    'input_layer__practitioner',
-    'input_layer__procedure',
-    'input_layer__provider_attribution'
-] %}
+{% set structural_dependency_names = [] %}
+
+{% if var('clinical_enabled', false) | as_bool %}
+  {% do structural_dependency_names.extend([
+      'input_layer__appointment',
+      'input_layer__condition',
+      'input_layer__encounter',
+      'input_layer__immunization',
+      'input_layer__lab_result',
+      'input_layer__location',
+      'input_layer__medication',
+      'input_layer__observation',
+      'input_layer__patient',
+      'input_layer__practitioner',
+      'input_layer__procedure'
+  ]) %}
+{% endif %}
+
+{% if var('claims_enabled', false) | as_bool %}
+  {% do structural_dependency_names.extend([
+      'input_layer__eligibility',
+      'input_layer__medical_claim',
+      'input_layer__pharmacy_claim'
+  ]) %}
+{% endif %}
+
+{% if var('provider_attribution_enabled', false) | as_bool %}
+  {% do structural_dependency_names.append('input_layer__provider_attribution') %}
+{% endif %}
 
 {% for dependency_name in structural_dependency_names %}
 -- depends_on: {{ ref(dependency_name) }}

--- a/scripts/publish-dolthub-seeds
+++ b/scripts/publish-dolthub-seeds
@@ -121,6 +121,13 @@ def parse_args() -> argparse.Namespace:
         help="Root folder containing local Dolt clones when --source local is used.",
     )
     parser.add_argument(
+        "--local-ref",
+        help=(
+            "Optional Dolt ref to read from when --source local is used, "
+            "for example main, tuva_health/main, or a commit hash."
+        ),
+    )
+    parser.add_argument(
         "--database",
         action="append",
         default=[],
@@ -291,14 +298,21 @@ def read_local_sql_csv(repo_database: str, query: str) -> list[dict[str, str]]:
     return list(csv.DictReader(result.stdout.splitlines()))
 
 
+def sql_string_literal(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
 def quote_identifier(identifier: str) -> str:
     return f"`{identifier.replace('`', '``')}`"
 
 
-def get_local_header_columns(repo_database: str, table_name: str) -> list[str]:
+def get_local_header_columns(repo_database: str, table_name: str, local_ref: str | None = None) -> list[str]:
     repo_path = local_repo_path(repo_database)
+    table_reference = quote_identifier(table_name)
+    if local_ref:
+        table_reference = f"{table_reference} AS OF {sql_string_literal(local_ref)}"
     result = subprocess.run(
-        ["dolt", "sql", "-r", "csv", "-q", f"select * from {quote_identifier(table_name)} limit 0"],
+        ["dolt", "sql", "-r", "csv", "-q", f"select * from {table_reference} limit 0"],
         cwd=str(repo_path),
         check=True,
         stdout=subprocess.PIPE,
@@ -310,12 +324,15 @@ def get_local_header_columns(repo_database: str, table_name: str) -> list[str]:
     return [column for column in header_columns if column != "__pk"]
 
 
-def build_local_export_query(table_name: str, columns: list[str]) -> str:
+def build_local_export_query(table_name: str, columns: list[str], local_ref: str | None = None) -> str:
     projected_columns = [
         f"IFNULL(CAST({quote_identifier(column)} AS CHAR), '\\\\N') AS {quote_identifier(column)}"
         for column in columns
     ]
-    return f"select {', '.join(projected_columns)} from {quote_identifier(table_name)}"
+    table_reference = quote_identifier(table_name)
+    if local_ref:
+        table_reference = f"{table_reference} AS OF {sql_string_literal(local_ref)}"
+    return f"select {', '.join(projected_columns)} from {table_reference}"
 
 
 def repo_root() -> Path:
@@ -471,7 +488,10 @@ EXTERNAL_DATE_COLUMNS = build_external_date_column_map()
 def get_assets_for_database(logical_database: str, owner: str, ref: str) -> list[TableAsset]:
     repo_database = DATABASE_FOLDERS[logical_database]
     if ARGS.source == "local":
-        catalog_rows = read_local_sql_csv(repo_database, "select * from asset_table_catalog")
+        catalog_query = "select * from asset_table_catalog"
+        if ARGS.local_ref:
+            catalog_query += f" AS OF {sql_string_literal(ARGS.local_ref)}"
+        catalog_rows = read_local_sql_csv(repo_database, catalog_query)
     else:
         catalog_ref = resolve_dolthub_csv_ref(owner, repo_database, ref)
         catalog_url = csv_endpoint(owner, repo_database, catalog_ref, "asset_table_catalog")
@@ -569,8 +589,8 @@ def download_asset(asset: TableAsset, destination: Path, attempts: int = 4) -> i
 def download_local_asset(asset: TableAsset, destination: Path) -> int:
     repo_path = local_repo_path(asset.repo_database)
     destination.parent.mkdir(parents=True, exist_ok=True)
-    columns = get_local_header_columns(asset.repo_database, asset.table_name)
-    query = build_local_export_query(asset.table_name, columns)
+    columns = get_local_header_columns(asset.repo_database, asset.table_name, ARGS.local_ref)
+    query = build_local_export_query(asset.table_name, columns, ARGS.local_ref)
 
     process = subprocess.Popen(
         ["dolt", "sql", "-r", "csv", "-q", query],
@@ -613,6 +633,8 @@ def build_manifest_entry(asset: TableAsset, bucket: str, actual_rows: int, stage
     destination_uri = f"s3://{bucket}/{asset.relative_key}"
     if ARGS.source == "local":
         source_reference = f"{local_repo_path(asset.repo_database)}/{asset.table_name}"
+        if ARGS.local_ref:
+            source_reference = f"{source_reference}@{ARGS.local_ref}"
     else:
         source_reference = csv_endpoint(ARGS.owner, asset.repo_database, ARGS.ref, asset.table_name)
     return {
@@ -642,6 +664,8 @@ def main() -> int:
 
     if ARGS.keep_staged_files and not ARGS.stage_dir:
         raise ValueError("--keep-staged-files requires --stage-dir.")
+    if ARGS.local_ref and ARGS.source != "local":
+        raise ValueError("--local-ref can only be used with --source local.")
 
     if not ARGS.dry_run and not ARGS.download_only:
         ensure_upload_prerequisites()

--- a/seeds/provider_data/provider_data_seeds.yml
+++ b/seeds/provider_data/provider_data_seeds.yml
@@ -59,15 +59,15 @@ seeds:
         provider_credential: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
         provider_organization_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(128) {%- endif -%}
         provider_other_organization_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(128) {%- endif -%}
         provider_other_organization_name_type_code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(80) {%- endif -%}
         provider_other_organization_name_type_description: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
         parent_organization_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(128) {%- endif -%}
         practice_address_line_1: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(80) {%- endif -%}
         practice_address_line_2: |

--- a/skills/versioned-seed-release.md
+++ b/skills/versioned-seed-release.md
@@ -1,0 +1,429 @@
+# Versioned Seed Release Sync
+
+This runbook covers the recurring operator workflow for publishing Tuva seed asset releases after a human has already cut the DoltHub release tags.
+
+It uses the existing repo tooling:
+- `scripts/publish-dolthub-seeds`
+- `scripts/mirror-seed-release`
+
+Use this process any time a released seed asset needs to be refreshed in:
+- S3
+- GCS
+- Azure Blob Storage
+
+## Asset Map
+
+The release tooling recognizes these 6 logical assets:
+
+| Logical asset | Storage folder |
+|---|---|
+| `concept_library` | `concept-library` |
+| `reference_data` | `reference-data` |
+| `terminology` | `terminology` |
+| `value_sets` | `value-sets` |
+| `provider_data` | `provider-data` |
+| `synthetic_data` | `synthetic-data` |
+
+## Preconditions
+
+Before starting:
+- the DoltHub release tags already exist
+- `aws`, `gsutil`, and `az` are installed
+- AWS auth can read and write the Tuva public bucket
+- `gsutil` auth can write `gs://tuva-public-resources`
+- Azure auth can write to storage account `tuvapublicresources`, container `tuva-public-resources`
+- you are running from the repo root: `/Users/aaronneiderhiser/code/tuva`
+
+Recommended auth bootstrap:
+
+```bash
+aws sso login --profile tuva-dev-admin
+export AWS_PROFILE=tuva-dev-admin
+aws sts get-caller-identity
+```
+
+```bash
+gcloud auth login aaron@tuvahealth.com
+gcloud config set account aaron@tuvahealth.com
+gcloud auth list
+```
+
+Recommended auth checks:
+
+```bash
+aws sts get-caller-identity
+gsutil ls gs://tuva-public-resources
+az storage container show \
+  --account-name tuvapublicresources \
+  --name tuva-public-resources \
+  --auth-mode login
+```
+
+Recommended GCS write test:
+
+```bash
+echo ok >/tmp/gsutil-codex-write-test.txt
+gsutil cp /tmp/gsutil-codex-write-test.txt gs://tuva-public-resources/_codex_test.txt
+gsutil rm gs://tuva-public-resources/_codex_test.txt
+```
+
+If GCS write fails with `storage.objects.create` permission errors, grant the active
+writer identity access before continuing. Example:
+
+```bash
+gcloud storage buckets add-iam-policy-binding gs://tuva-public-resources \
+  --member="serviceAccount:codex-transfer-runner@tuva-datasets.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+```
+
+Run that IAM grant as a human account with bucket admin / project admin access, not as
+the service account itself.
+
+## Standard Workflow
+
+### 1. Dry-run the S3 publish
+
+Use `scripts/publish-dolthub-seeds` first in dry-run mode to verify the release selection.
+Always pin `--ref` to the DoltHub release tag you intend to mirror. Otherwise the script reads from DoltHub `main`.
+
+Example for all 6 assets:
+
+```bash
+scripts/publish-dolthub-seeds --version vX.Y.Z --ref vX.Y.Z --dry-run
+```
+
+The script:
+- reads the released DoltHub tables
+- validates expected row counts from `asset_table_catalog`
+- plans uploads to `s3://<bucket>/<database-folder>/<version>/<table>.csv.gz`
+
+### 1a. If DoltHub CSV export is slow or failing
+
+The public DoltHub CSV endpoints can timeout or return `503` for large tables. If that
+happens, switch to local Dolt exports with `--source local --local-ref`.
+
+Steps:
+- get the release commit SHA from the DoltHub releases API
+- compare it to candidate local refs
+- publish from the matching local ref
+
+Useful commands:
+
+```bash
+python - <<'PY'
+import json, urllib.request
+for repo in ['reference-data', 'terminology', 'value-sets', 'provider-data']:
+    url = f'https://www.dolthub.com/api/v1alpha1/tuva-health/{repo}/releases'
+    with urllib.request.urlopen(url, timeout=30) as r:
+        releases = json.load(r)['releases']
+    sha = next(rel['release_commit_sha'] for rel in releases if rel['release_tag'] == 'vX.Y.Z')
+    print(repo, sha)
+PY
+```
+
+```bash
+dolt sql -q "select hashof('main') as h" -r csv
+dolt sql -q "select hashof('tuva_health/main') as h" -r csv
+```
+
+Example local fallback publish:
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version vX.Y.Z \
+  --source local \
+  --local-ref main \
+  --database reference_data \
+  --stage-dir ./tmp/seed-release-vX.Y.Z
+```
+
+The local fallback uses the exact Dolt ref you specify and does not require checking out a
+different branch in the local repo.
+
+### 2. Publish to S3 and retain the manifest
+
+Always provide `--stage-dir` for live publishes so the generated `publish-manifest.json` is retained as the audit artifact for the release.
+
+Example for all 6 assets:
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version vX.Y.Z \
+  --ref vX.Y.Z \
+  --stage-dir ./tmp/seed-release-vX.Y.Z
+```
+
+Retain:
+- `./tmp/seed-release-vX.Y.Z/publish-manifest.json`
+
+That manifest records:
+- logical database
+- repo database
+- source reference
+- destination URI
+- expected and actual row counts
+
+### 3. Dry-run the cross-cloud mirror
+
+After S3 publish succeeds, mirror from S3 to GCS and Azure.
+
+```bash
+scripts/mirror-seed-release \
+  --version vX.Y.Z \
+  --target gcs \
+  --target azure \
+  --stage-dir ./tmp/seed-release-vX.Y.Z-mirror \
+  --dry-run
+```
+
+### 4. Mirror live to GCS and Azure
+
+```bash
+scripts/mirror-seed-release \
+  --version vX.Y.Z \
+  --target gcs \
+  --target azure \
+  --stage-dir ./tmp/seed-release-vX.Y.Z-mirror
+```
+
+Notes:
+- S3 and GCS keep `.csv.gz`
+- Azure uploads expanded `.csv` files for Fabric-compatible loading
+- if only one target is blocked, rerun with just the other target:
+  - `--target azure`
+  - `--target gcs`
+
+### 5. Verify cloud copies
+
+Spot-check at least one representative file per updated asset in all three clouds.
+
+Example checks:
+
+```bash
+aws s3 ls s3://tuva-public-resources/reference-data/vX.Y.Z/code_type.csv.gz
+aws s3 ls s3://tuva-public-resources/terminology/vX.Y.Z/claim_type.csv.gz
+aws s3 ls s3://tuva-public-resources/value-sets/vX.Y.Z/cms_hcc__adjustment_rates.csv.gz
+aws s3 ls s3://tuva-public-resources/provider-data/vX.Y.Z/provider.csv.gz
+```
+
+```bash
+gsutil ls gs://tuva-public-resources/reference-data/vX.Y.Z/code_type.csv.gz
+gsutil ls gs://tuva-public-resources/terminology/vX.Y.Z/claim_type.csv.gz
+gsutil ls gs://tuva-public-resources/value-sets/vX.Y.Z/cms_hcc__adjustment_rates.csv.gz
+gsutil ls gs://tuva-public-resources/provider-data/vX.Y.Z/provider.csv.gz
+```
+
+```bash
+az storage blob show \
+  --account-name tuvapublicresources \
+  --container-name tuva-public-resources \
+  --name reference-data/vX.Y.Z/code_type.csv \
+  --auth-mode login
+
+az storage blob show \
+  --account-name tuvapublicresources \
+  --container-name tuva-public-resources \
+  --name terminology/vX.Y.Z/claim_type.csv \
+  --auth-mode login
+
+az storage blob show \
+  --account-name tuvapublicresources \
+  --container-name tuva-public-resources \
+  --name value-sets/vX.Y.Z/cms_hcc__adjustment_rates.csv \
+  --auth-mode login
+
+az storage blob show \
+  --account-name tuvapublicresources \
+  --container-name tuva-public-resources \
+  --name provider-data/vX.Y.Z/provider.csv \
+  --auth-mode login
+```
+
+### 6. Update project config and docs
+
+After the cloud copies exist, update:
+- `dbt_project.yml`
+- `integration_tests/dbt_project.yml`
+- `README.md`
+- `docs/docs/dbt-variables.md`
+- `integration_tests/README.md`
+
+Use the per-asset version vars as the primary interface:
+- `concept_library_version`
+- `reference_data_version`
+- `terminology_version`
+- `value_sets_version`
+- `provider_data_version`
+- `synthetic_data_version`
+
+The legacy fallback vars still work but should not be the primary interface:
+- `tuva_seed_version`
+- `tuva_seed_versions`
+
+### 7. Run local validation
+
+From the repo root:
+
+```bash
+dbt deps \
+  --project-dir /Users/aaronneiderhiser/code/tuva \
+  --profiles-dir ~/.dbt \
+  --profile default
+```
+
+```bash
+dbt parse \
+  --project-dir /Users/aaronneiderhiser/code/tuva \
+  --profiles-dir ~/.dbt \
+  --profile default
+```
+
+```bash
+scripts/dbt-local deps
+```
+
+```bash
+scripts/dbt-local build \
+  --select reference_data__calendar terminology__claim_type provider_data__provider cms_hcc__adjustment_rates \
+  --vars '{use_synthetic_data: true, synthetic_data_size: small}'
+```
+
+```bash
+cd docs && npm ci && npm run build
+```
+
+## Operational Notes
+
+- Always export `AWS_PROFILE` before running `scripts/publish-dolthub-seeds` or
+  `scripts/mirror-seed-release`. Both scripts call `aws sts get-caller-identity`.
+- Keep the staged publish directory until the rollout is complete. It contains
+  `publish-manifest.json` and allows safe reuse of already-generated gzip files.
+- If a publish attempt used the wrong source ref or stopped mid-asset, remove the partial
+  target folder from S3 before retrying.
+- For very large assets, local fallback publish can be much more reliable than streaming
+  DoltHub CSV exports directly.
+
+## Current Release: v1.1.0
+
+For the current rollout, only update these 4 assets to `v1.1.0`:
+- `reference_data`
+- `terminology`
+- `value_sets`
+- `provider_data`
+
+Leave these unchanged:
+- `concept_library` stays on `1.0.1`
+- `synthetic_data` stays on `1.0.0`
+
+### S3 publish dry-run
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version v1.1.0 \
+  --ref v1.1.0 \
+  --database reference_data \
+  --database terminology \
+  --database value_sets \
+  --database provider_data \
+  --stage-dir ./tmp/seed-release-v1.1.0 \
+  --dry-run
+```
+
+### S3 publish live
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version v1.1.0 \
+  --ref v1.1.0 \
+  --database reference_data \
+  --database terminology \
+  --database value_sets \
+  --database provider_data \
+  --stage-dir ./tmp/seed-release-v1.1.0
+```
+
+### Mirror dry-run
+
+```bash
+scripts/mirror-seed-release \
+  --version v1.1.0 \
+  --database reference_data \
+  --database terminology \
+  --database value_sets \
+  --database provider_data \
+  --target gcs \
+  --target azure \
+  --stage-dir ./tmp/seed-release-v1.1.0-mirror \
+  --dry-run
+```
+
+### Mirror live
+
+```bash
+scripts/mirror-seed-release \
+  --version v1.1.0 \
+  --database reference_data \
+  --database terminology \
+  --database value_sets \
+  --database provider_data \
+  --target gcs \
+  --target azure \
+  --stage-dir ./tmp/seed-release-v1.1.0-mirror
+```
+
+### Local fallback examples used in this rollout
+
+These were the exact local refs that matched the released `v1.1.0` content during this
+rollout:
+
+- `reference_data`: `main`
+- `terminology`: `main`
+- `value_sets`: `tuva_health/main`
+- `provider_data`: `merge-test-from-main`
+
+Example fallback publishes:
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version v1.1.0 \
+  --source local \
+  --local-ref main \
+  --database reference_data \
+  --stage-dir ./tmp/seed-release-v1.1.0-release-tag
+```
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version v1.1.0 \
+  --source local \
+  --local-ref main \
+  --database terminology \
+  --stage-dir ./tmp/seed-release-v1.1.0-no-reference-data
+```
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version v1.1.0 \
+  --source local \
+  --local-ref tuva_health/main \
+  --database value_sets \
+  --stage-dir ./tmp/seed-release-v1.1.0-value-sets-local
+```
+
+```bash
+scripts/publish-dolthub-seeds \
+  --version v1.1.0 \
+  --source local \
+  --local-ref merge-test-from-main \
+  --database provider_data \
+  --stage-dir ./tmp/seed-release-v1.1.0-provider-data-local
+```
+
+## Expected Version State After This Rollout
+
+- `concept_library_version: "1.0.1"`
+- `reference_data_version: "1.1.0"`
+- `terminology_version: "1.1.0"`
+- `value_sets_version: "1.1.0"`
+- `provider_data_version: "1.1.0"`
+- `synthetic_data_version: "1.0.0"`


### PR DESCRIPTION
## Summary
- add a repo-local runbook for versioned seed release syncs
- switch seed version config to explicit per-asset vars with legacy fallback support
- add a local-ref fallback to publish-dolthub-seeds for large DoltHub export failures

## Validation
- dbt parse --project-dir /Users/aaronneiderhiser/code/tuva --profiles-dir ~/.dbt --profile tuva_dev
- /Users/aaronneiderhiser/code/tuva/scripts/dbt-local build --select reference_data__calendar terminology__claim_type provider_data__provider cms_hcc__adjustment_rates --vars "{use_synthetic_data: true, synthetic_data_size: small}"
- cd /Users/aaronneiderhiser/code/tuva/docs && npm run build

## Release sync
- published reference_data, terminology, value_sets, and provider_data v1.1.0 to S3
- mirrored those assets to Azure and GCS