### PR TITLE
fix: add missing DC and UM rows to ansi_fips_state seed file

### DIFF
--- a/seeds/reference_data/reference_data__ansi_fips_state.csv
+++ b/seeds/reference_data/reference_data__ansi_fips_state.csv
@@ -1,1 +1,3 @@
 ansi_fips_state_code,ansi_fips_state_abbreviation,ansi_fips_state_name
+11,DC,District of Columbia
+74,UM,U.S. Minor Outlying Islands


### PR DESCRIPTION
## Summary
Fixes #1099

The `reference_data__ansi_fips_state.csv` seed file was missing two entries 
from the Census FIPS reference data:

| ansi_fips_state_code | ansi_fips_state_abbreviation | ansi_fips_state_name |
|---|---|---|
| 11 | DC | District of Columbia |
| 74 | UM | U.S. Minor Outlying Islands |

## Source
https://www2.census.gov/geo/docs/reference/codes2020/national_state2020.txt

## Notes
- PR #1084 addressed some FIPS updates but UM (code 74) remained missing
- DC (code 11) also confirmed missing from current seed file