### PR TITLE
Add CI command sequencing and structural DQ updates

### DIFF
--- a/.github/workflows/dbt_ci_modes.yml
+++ b/.github/workflows/dbt_ci_modes.yml
@@ -27,7 +27,7 @@ on:
         required: true
         type: string
       dbt_command:
-        description: Full dbt command to execute, for example `dbt seed --select tag:tuva_demo`
+        description: Full dbt command or ordered command sequence, for example `dbt seed --select tag:tuva_demo dbt run --select tag:tuva_demo`
         required: false
         type: string
         default: ""
@@ -75,7 +75,7 @@ jobs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       adapter_matrix: ${{ steps.resolve.outputs.adapter_matrix }}
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
-      dbt_command_json: ${{ steps.validate.outputs.dbt_command_json }}
+      dbt_commands_json: ${{ steps.validate.outputs.dbt_commands_json }}
       dbt_command_display: ${{ steps.validate.outputs.dbt_command }}
       subcommand: ${{ steps.validate.outputs.subcommand }}
       requires_seed_baseline: ${{ steps.validate.outputs.requires_seed_baseline }}
@@ -104,7 +104,7 @@ jobs:
             const inputs = context.payload.inputs || {};
             const requestedCommand = `${{ steps.validate.outputs.dbt_command }}`;
             const requestedTargets = JSON.parse(String.raw`${{ steps.validate.outputs.targets_json }}`);
-            const subcommand = `${{ steps.validate.outputs.subcommand }}`;
+            const requestedTargetsCsv = `${{ steps.validate.outputs.targets_csv }}`;
             const refreshesSeeds = `${{ steps.validate.outputs.refreshes_seeds }}` === "true";
             const requiresSeedBaseline = `${{ steps.validate.outputs.requires_seed_baseline }}` === "true";
 
@@ -171,14 +171,44 @@ jobs:
                   runGuardPrefixes.some((prefix) => path.startsWith(prefix))
               );
 
-            async function hasReusableSeedRefresh(targetName) {
-              const titleNeedles = [
-                `PR #${prNumber} / ${targetName}: dbt seed`,
-                `PR #${prNumber} / ${targetName}: dbt build --full-refresh`,
-                `PR #${prNumber} / all: dbt seed`,
-                `PR #${prNumber} / all: dbt build --full-refresh`,
-              ];
+            function parseDisplayTitle(run) {
+              const prefix = `Tuva CI / PR #${prNumber} / `;
+              const displayTitle = String(run.display_title || "");
+              if (!displayTitle.startsWith(prefix)) {
+                return null;
+              }
 
+              const label = displayTitle.slice(prefix.length);
+              const separator = label.indexOf(": ");
+              if (separator === -1) {
+                return null;
+              }
+
+              return {
+                targetLabel: label.slice(0, separator).trim().toLowerCase(),
+                commandLabel: label.slice(separator + 2).trim().toLowerCase(),
+              };
+            }
+
+            function labelIncludesTarget(targetLabel, targetName) {
+              if (targetLabel === "all") {
+                return true;
+              }
+              return targetLabel
+                .split(",")
+                .map((part) => part.trim())
+                .filter(Boolean)
+                .includes(targetName);
+            }
+
+            function labelRefreshesSeeds(commandLabel) {
+              return commandLabel
+                .split(" -> ")
+                .map((part) => part.trim())
+                .some((part) => part.startsWith("dbt seed") || part.startsWith("dbt build"));
+            }
+
+            async function hasReusableSeedRefresh(targetName) {
               const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
                 repo,
@@ -192,8 +222,16 @@ jobs:
                   continue;
                 }
 
-                const displayTitle = String(run.display_title || "");
-                if (!titleNeedles.some((needle) => displayTitle.includes(needle))) {
+                const parsedTitle = parseDisplayTitle(run);
+                if (!parsedTitle) {
+                  continue;
+                }
+
+                if (!labelIncludesTarget(parsedTitle.targetLabel, targetName)) {
+                  continue;
+                }
+
+                if (!labelRefreshesSeeds(parsedTitle.commandLabel)) {
                   continue;
                 }
 
@@ -223,7 +261,7 @@ jobs:
               return false;
             }
 
-            if (isDispatch && requiresBuild && requiresSeedBaseline && !refreshesSeeds) {
+            if (isDispatch && requiresBuild && requiresSeedBaseline) {
               const reusableTargets = [];
               for (const targetName of requestedTargets) {
                 if (await hasReusableSeedRefresh(targetName)) {
@@ -236,9 +274,10 @@ jobs:
                   .filter((path) => touchesSeedState([path]))
                   .slice(0, 8)
                   .join(", ");
+                const ciTargetPrefix = requestedTargetsCsv === "all" ? "all" : requestedTargets.join(" ");
 
                 core.setFailed(
-                  `This PR changes seed/config files (${sample}). Run a seed-refreshing command such as /ci dbt seed --select ... or /ci snowflake dbt build --full-refresh --select ... before running ${requestedCommand}.`
+                  `This PR changes seed/config files (${sample}). The requested sequence \`${requestedCommand}\` reaches dbt run/test before refreshing seeds. Run a seed-refreshing command such as \`/ci ${ciTargetPrefix} dbt seed\` or \`/ci ${ciTargetPrefix} dbt build --full-refresh\` before running this sequence.`
                 );
                 return;
               }
@@ -250,14 +289,7 @@ jobs:
 
   run_dbt:
     name: >-
-      ${{
-        needs.resolve_request.outputs.subcommand == 'build' && 'Build' ||
-        needs.resolve_request.outputs.subcommand == 'seed' && 'Seed' ||
-        needs.resolve_request.outputs.subcommand == 'test' && 'Test' ||
-        needs.resolve_request.outputs.subcommand == 'compile' && 'Compile' ||
-        needs.resolve_request.outputs.subcommand == 'debug' && 'Debug' ||
-        'Run'
-      }} / DW: ${{
+      Commands / DW: ${{
         matrix.adapter == 'snowflake' && 'Snowflake' ||
         matrix.adapter == 'bigquery' && 'BigQuery' ||
         matrix.adapter == 'databricks' && 'Databricks' ||
@@ -382,10 +414,9 @@ jobs:
 
       - name: Execute dbt
         env:
-          DBT_COMMAND_JSON: ${{ needs.resolve_request.outputs.dbt_command_json }}
+          DBT_COMMANDS_JSON: ${{ needs.resolve_request.outputs.dbt_commands_json }}
           DBT_ADAPTER: ${{ matrix.adapter }}
           CI_REQUIRES_SEED_BASELINE: ${{ needs.resolve_request.outputs.requires_seed_baseline }}
-          CI_REFRESHES_SEEDS: ${{ needs.resolve_request.outputs.refreshes_seeds }}
         run: |
           python - <<'PY'
           import json
@@ -393,25 +424,38 @@ jobs:
           import shlex
           import subprocess
 
-          command = json.loads(os.environ["DBT_COMMAND_JSON"])
-          command.extend(
-              [
-                  "--project-dir",
-                  "./integration_tests",
-                  "--profiles-dir",
-                  f"./integration_tests/profiles/{os.environ['DBT_ADAPTER']}",
-              ]
-          )
+          commands = json.loads(os.environ["DBT_COMMANDS_JSON"])
           child_env = os.environ.copy()
-          child_env["DBT_CI_USE_BASELINE_SEEDS"] = (
-              "true"
-              if child_env.get("CI_REQUIRES_SEED_BASELINE") == "true"
-              or child_env.get("CI_REFRESHES_SEEDS") == "true"
-              else "false"
-          )
-          if child_env["DBT_CI_USE_BASELINE_SEEDS"] == "true" and "--no-partial-parse" not in command:
-              command.append("--no-partial-parse")
-          print(f"DBT_CI_USE_BASELINE_SEEDS={child_env['DBT_CI_USE_BASELINE_SEEDS']}")
-          print(f"Running: {shlex.join(command)}")
-          subprocess.run(command, check=True, env=child_env)
+          seed_refreshing_subcommands = {"seed", "build"}
+          baseline_required = child_env.get("CI_REQUIRES_SEED_BASELINE") == "true"
+          seed_refreshed_in_sequence = False
+
+          for index, raw_command in enumerate(commands, start=1):
+              command = list(raw_command)
+              subcommand = command[1].lower()
+              use_baseline_seeds = (
+                  subcommand in seed_refreshing_subcommands
+                  or seed_refreshed_in_sequence
+                  or (baseline_required and subcommand in {"run", "test"})
+              )
+
+              command.extend(
+                  [
+                      "--project-dir",
+                      "./integration_tests",
+                      "--profiles-dir",
+                      f"./integration_tests/profiles/{os.environ['DBT_ADAPTER']}",
+                  ]
+              )
+
+              child_env["DBT_CI_USE_BASELINE_SEEDS"] = "true" if use_baseline_seeds else "false"
+              if child_env["DBT_CI_USE_BASELINE_SEEDS"] == "true" and "--no-partial-parse" not in command:
+                  command.append("--no-partial-parse")
+
+              print(f"Step {index}: DBT_CI_USE_BASELINE_SEEDS={child_env['DBT_CI_USE_BASELINE_SEEDS']}")
+              print(f"Running: {shlex.join(command)}")
+              subprocess.run(command, check=True, env=child_env)
+
+              if subcommand in seed_refreshing_subcommands:
+                  seed_refreshed_in_sequence = True
           PY

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -10,6 +10,8 @@ vars:
   clinical_enabled: true
   provider_attribution_enabled: true
   semantic_layer_enabled: true
+  enable_data_quality: true
+  enable_legacy_data_quality: false
   # Use selectors to run specific marts.
   # fhir_preprocessing_enabled: true # defaults to false
 

--- a/integration_tests/macros/ci/assert_ci_seed_baseline_ready.sql
+++ b/integration_tests/macros/ci/assert_ci_seed_baseline_ready.sql
@@ -34,7 +34,7 @@
         {% do exceptions.raise_compiler_error(
             "CI baseline seed schemas are not ready for run-only mode. Missing required objects: "
             ~ (missing | join(', '))
-            ~ ". Run `/ci large` on this PR to refresh `raw_data`, `provider_data`, `terminology`, `reference_data`, and `concept_library`."
+            ~ ". Run a seed-refreshing CI command such as `/ci snowflake dbt seed` or `/ci snowflake dbt build --full-refresh` to refresh `raw_data`, `provider_data`, `terminology`, `reference_data`, and `concept_library`."
         ) %}
     {% endif %}
 

--- a/macros/data_quality/dq_summary_helpers.sql
+++ b/macros/data_quality/dq_summary_helpers.sql
@@ -15,6 +15,14 @@
     {{ return(models) }}
 {% endmacro %}
 
+{% macro dq_claims_structural_model_names() %}
+    {{ return([
+        'input_layer__eligibility',
+        'input_layer__medical_claim',
+        'input_layer__pharmacy_claim'
+    ]) }}
+{% endmacro %}
+
 {% macro dq_expected_final_marts() %}
     {% if not execute %}
         {{ return([]) }}
@@ -165,6 +173,22 @@
         select
               '{{ dq_source_key_sentinel() }}' as data_source_key
             , cast(null as {{ dbt.type_string() }}) as data_source
+    {% endif %}
+{% endmacro %}
+
+{% macro dq_missing_source_dimension_sql() %}
+    select
+          '{{ dq_source_key_sentinel() }}' as data_source_key
+        , cast(null as {{ dbt.type_string() }}) as data_source
+{% endmacro %}
+
+{% macro dq_source_key_expression_sql(relation, relation_alias='source_rows') %}
+    {% set actual_columns = dq_actual_columns(relation) %}
+
+    {% if dq_has_column(actual_columns, 'data_source') %}
+        {{ return("coalesce(cast(" ~ relation_alias ~ ".data_source as " ~ dbt.type_string() ~ "), '" ~ dq_source_key_sentinel() ~ "')") }}
+    {% else %}
+        {{ return("'" ~ dq_source_key_sentinel() ~ "'") }}
     {% endif %}
 {% endmacro %}
 

--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -39,34 +39,41 @@ unit_tests:
         _extension_columns_override: ['x_temp_person_id', 'x_temp_first_name']
     given:
       - input: ref('normalized_input__eligibility')
-        rows:
-          - person_id: '10'
-            member_id: '10'
-            payer: 'medicare'
-            plan: 'medicare'
-            data_source: 'test'
-            enrollment_start_date: '2020-01-01'
-            enrollment_end_date: '2020-01-31'
-            tuva_last_run: '2024-01-01 00:00:00'
-            x_temp_person_id: '10'
-            x_temp_first_name: 'John'
+        format: sql
+        rows: |
+          select
+            '10' as person_id,
+            '10' as member_id,
+            'medicare' as payer,
+            'medicare' as plan,
+            'test' as data_source,
+            cast('2020-01-01' as date) as enrollment_start_date,
+            cast('2020-01-31' as date) as enrollment_end_date,
+            cast('2024-01-01 00:00:00' as timestamp) as tuva_last_run,
+            '10' as x_temp_person_id,
+            'John' as x_temp_first_name
       # Provide first + last day of January so the aggregate yields the correct
       # month_start_date / month_end_date for the enrollment overlap check.
       - input: ref('reference_data__calendar')
-        rows:
-          - full_date: '2020-01-01'
-            year: 2020
-            month: 1
-          - full_date: '2020-01-31'
-            year: 2020
-            month: 1
+        format: sql
+        rows: |
+          select cast('2020-01-01' as date) as full_date, 2020 as year, 1 as month
+          union all
+          select cast('2020-01-31' as date) as full_date, 2020 as year, 1 as month
       # Listed to satisfy the compile-time ref() dependency inside
       # select_extension_columns(). The fixture data is not used because
       # _extension_columns_override is set.
       - input: ref('input_layer__eligibility')
-        rows:
-          - x_temp_person_id: '10'
-            x_temp_first_name: 'John'
+        format: sql
+        rows: |
+          select
+            '10' as person_id,
+            '10' as member_id,
+            'medicare' as payer,
+            'medicare' as plan,
+            'test' as data_source,
+            cast('2020-01-01' as date) as enrollment_start_date,
+            cast('2020-01-31' as date) as enrollment_end_date
     expect:
       rows:
         # member_month_key = md5('10-10-202001-medicare-medicare-test')
@@ -95,32 +102,41 @@ unit_tests:
         _extension_columns_override: ['x_temp_person_id', 'x_temp_first_name']
     given:
       - input: ref('core__stg_claims_member_months')
-        rows:
-          - member_month_key: 'b8cc2c5022647c213f23a44b819d61a0'
-            person_id: '10'
-            member_id: '10'
-            year_month: '202001'
-            payer: 'medicare'
-            plan: 'medicare'
-            payer_attributed_provider: null
-            payer_attributed_provider_practice: null
-            payer_attributed_provider_organization: null
-            payer_attributed_provider_lob: null
-            custom_attributed_provider: null
-            custom_attributed_provider_practice: null
-            custom_attributed_provider_organization: null
-            custom_attributed_provider_lob: null
-            x_temp_person_id: '10'
-            x_temp_first_name: 'John'
-            data_source: 'test'
-            tuva_last_run: '2024-01-01 00:00:00'
+        format: sql
+        rows: |
+          select
+            'b8cc2c5022647c213f23a44b819d61a0' as member_month_key,
+            '10' as person_id,
+            '10' as member_id,
+            '202001' as year_month,
+            'medicare' as payer,
+            'medicare' as plan,
+            null as payer_attributed_provider,
+            null as payer_attributed_provider_practice,
+            null as payer_attributed_provider_organization,
+            null as payer_attributed_provider_lob,
+            null as custom_attributed_provider,
+            null as custom_attributed_provider_practice,
+            null as custom_attributed_provider_organization,
+            null as custom_attributed_provider_lob,
+            '10' as x_temp_person_id,
+            'John' as x_temp_first_name,
+            'test' as data_source,
+            cast('2024-01-01 00:00:00' as timestamp) as tuva_last_run
       # Listed to satisfy the compile-time ref() dependency inside
       # select_extension_columns(). The fixture data is not used because
       # _extension_columns_override is set.
       - input: ref('input_layer__eligibility')
-        rows:
-          - x_temp_person_id: '10'
-            x_temp_first_name: 'John'
+        format: sql
+        rows: |
+          select
+            '10' as person_id,
+            '10' as member_id,
+            'medicare' as payer,
+            'medicare' as plan,
+            'test' as data_source,
+            cast('2020-01-01' as date) as enrollment_start_date,
+            cast('2020-01-31' as date) as enrollment_end_date
     expect:
       rows:
         - member_month_key: 'b8cc2c5022647c213f23a44b819d61a0'

--- a/models/data_quality/data_quality_models.yml
+++ b/models/data_quality/data_quality_models.yml
@@ -51,13 +51,61 @@ models:
       - name: table_exists
         description: Pass or fail result indicating whether the expected input-layer relation exists.
       - name: columns_exist
-        description: Pass or fail result indicating whether all documented input-layer columns are present.
+        description: Pass or fail result indicating whether all documented input-layer columns are present. For the three claims input tables, this is derived from the structural column detail table.
       - name: data_types
-        description: Pass or fail result indicating whether all documented input-layer columns match the expected data-type family.
+        description: Pass or fail result indicating whether all documented input-layer columns match the expected data-type family. For the three claims input tables, this is derived from the structural column detail table.
       - name: primary_keys
-        description: Pass or fail result indicating whether the documented primary-key columns exist, are non-null, and remain unique at the documented grain.
+        description: Pass or fail result indicating whether the documented primary-key columns exist, are non-null, and remain unique at the documented grain. For the three claims input tables, this is derived from the structural column detail and structural primary-key test tables.
       - name: row_count
         description: The integer number of rows present for the evaluated data_source and input-layer table. Null means the relation does not exist.
+
+  - name: data_quality__structural_column_details
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_column_details
+      tags:
+        - data_quality
+        - dq
+        - dq1
+        - dq_structural
+      materialized: table
+    columns:
+      - name: data_source
+        description: The input-layer data source being evaluated. Null means the source could not be determined from the relation.
+      - name: table
+        description: The claims input-layer table being evaluated.
+      - name: column
+        description: The documented input-layer column being evaluated.
+      - name: column_exists
+        description: Yes or no indicator for whether the documented column exists on the input-layer relation.
+      - name: data_type_correct
+        description: Yes or no indicator for whether the documented column matches the expected data-type family.
+
+  - name: data_quality__structural_primary_key_tests
+    config:
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_data_quality
+        {% else %}data_quality{%- endif -%}
+      alias: structural_primary_key_tests
+      tags:
+        - data_quality
+        - dq
+        - dq1
+        - dq_structural
+      materialized: table
+    columns:
+      - name: data_source
+        description: The input-layer data source being evaluated. Null means the source could not be determined from the relation.
+      - name: table
+        description: The claims input-layer table being evaluated.
+      - name: column
+        description: The primary-key column under test, or the comma-separated set of documented primary-key columns for the duplicate value test.
+      - name: test
+        description: The primary-key test being evaluated. Current values are not null and duplicate value.
+      - name: test_result
+        description: Integer test result where healthy values are expected to be zero. Not-null tests count null values, and duplicate value tests return total rows minus distinct primary-key combinations.
 
   - name: data_quality__logical
     description: Aggregated logical data quality results derived by summing persisted native-grain flag columns from the logical flag tables.

--- a/models/data_quality/structural/data_quality__structural.sql
+++ b/models/data_quality/structural/data_quality__structural.sql
@@ -45,15 +45,98 @@
 -- depends_on: {{ ref(dependency_name) }}
 {% endfor %}
 
+-- depends_on: {{ ref('data_quality__structural_column_details') }}
+-- depends_on: {{ ref('data_quality__structural_primary_key_tests') }}
+
 {% if execute %}
     {% set expected_models = dq_expected_input_layer_models() %}
+    {% set detailed_claim_model_names = dq_claims_structural_model_names() %}
     {% set structural_queries = [] %}
 
     {% for model_node in expected_models %}
         {% set table_name = model_node.name | replace('input_layer__', '') %}
         {% set relation = dq_actual_relation(model_node) %}
 
-        {% if relation is none %}
+        {% if model_node.name in detailed_claim_model_names %}
+            {% set pk_columns = dq_expected_pk_columns(model_node) %}
+
+            {% if relation is none %}
+                {% set source_dimension_sql = dq_missing_source_dimension_sql() %}
+                {% set source_count_sql %}
+                    select
+                          '{{ dq_source_key_sentinel() }}' as data_source_key
+                        , cast(null as {{ dbt.type_int() }}) as row_count
+                {% endset %}
+            {% else %}
+                {% set source_dimension_sql = dq_source_dimension_sql(relation) %}
+                {% set source_count_sql = dq_source_row_count_sql(relation) %}
+            {% endif %}
+
+            {% set query %}
+                select
+                      sources.data_source
+                    , '{{ table_name }}' as table_name
+                    , '{% if relation is not none %}pass{% else %}fail{% endif %}' as table_exists
+                    , case
+                        when coalesce(column_status.missing_column_count, 0) = 0
+                        then 'pass'
+                        else 'fail'
+                      end as columns_exist
+                    , case
+                        when coalesce(column_status.bad_data_type_count, 0) = 0
+                        then 'pass'
+                        else 'fail'
+                      end as data_types
+                    , case
+                        when {% if relation is not none %}1 = 1{% else %}1 = 0{% endif %}
+                         and coalesce(pk_column_status.missing_pk_column_count, 0) = 0
+                         and coalesce(pk_test_status.failing_test_count, 0) = 0
+                        then 'pass'
+                        else 'fail'
+                      end as primary_keys
+                    , cast(source_counts.row_count as {{ dbt.type_int() }}) as row_count
+                from (
+                    {{ source_dimension_sql }}
+                ) as sources
+                left join (
+                    {{ source_count_sql }}
+                ) as source_counts
+                    on sources.data_source_key = source_counts.data_source_key
+                left join (
+                    select
+                          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , cast(sum(case when column_exists = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as missing_column_count
+                        , cast(sum(case when data_type_correct = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as bad_data_type_count
+                    from {{ ref('data_quality__structural_column_details') }}
+                    where {{ adapter.quote('table') }} = '{{ table_name }}'
+                    group by 1
+                ) as column_status
+                    on sources.data_source_key = column_status.data_source_key
+                left join (
+                    select
+                          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , cast(sum(case when column_exists = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as missing_pk_column_count
+                    from {{ ref('data_quality__structural_column_details') }}
+                    where {{ adapter.quote('table') }} = '{{ table_name }}'
+                      and {{ adapter.quote('column') }} in (
+                          {% for pk_column in pk_columns %}
+                          '{{ pk_column }}'{% if not loop.last %}, {% endif %}
+                          {% endfor %}
+                      )
+                    group by 1
+                ) as pk_column_status
+                    on sources.data_source_key = pk_column_status.data_source_key
+                left join (
+                    select
+                          coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}') as data_source_key
+                        , cast(sum(case when test_result is null or test_result <> 0 then 1 else 0 end) as {{ dbt.type_int() }}) as failing_test_count
+                    from {{ ref('data_quality__structural_primary_key_tests') }}
+                    where {{ adapter.quote('table') }} = '{{ table_name }}'
+                    group by 1
+                ) as pk_test_status
+                    on sources.data_source_key = pk_test_status.data_source_key
+            {% endset %}
+        {% elif relation is none %}
             {% set query %}
                 select
                       cast(null as {{ dbt.type_string() }}) as data_source
@@ -150,7 +233,11 @@
         {% do structural_queries.append(query) %}
     {% endfor %}
 
-    {{ structural_queries | join('\nunion all\n') }}
+    select *
+    from (
+        {{ structural_queries | join('\nunion all\n') }}
+    ) as structural_results
+    order by 1, 2
 {% else %}
     select
           cast(null as {{ dbt.type_string() }}) as data_source

--- a/models/data_quality/structural/data_quality__structural_column_details.sql
+++ b/models/data_quality/structural/data_quality__structural_column_details.sql
@@ -1,0 +1,85 @@
+{{ config(
+     enabled = var('enable_data_quality', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_column_details',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+{% set claim_model_names = dq_claims_structural_model_names() %}
+
+{% for model_name in claim_model_names %}
+-- depends_on: {{ ref(model_name) }}
+{% endfor %}
+
+{% if execute %}
+    {% set detail_queries = [] %}
+
+    {% for model_name in claim_model_names %}
+        {% set model_node = dq_find_model_node(model_name) %}
+
+        {% if model_node is not none %}
+            {% set table_name = model_name | replace('input_layer__', '') %}
+            {% set relation = dq_actual_relation(model_node) %}
+            {% set expected_columns = dq_expected_columns(model_node) %}
+            {% set actual_column_types = {} %}
+
+            {% if relation is not none %}
+                {% for column in dq_actual_columns(relation) %}
+                    {% do actual_column_types.update({column.name | lower: column.dtype}) %}
+                {% endfor %}
+                {% set source_dimension_sql = dq_source_dimension_sql(relation) %}
+            {% else %}
+                {% set source_dimension_sql = dq_missing_source_dimension_sql() %}
+            {% endif %}
+
+            {% for expected_column in expected_columns %}
+                {% set expected_name = expected_column['name'] %}
+                {% set expected_type = expected_column['data_type'] %}
+                {% set actual_type = actual_column_types.get(expected_name) %}
+                {% set column_exists = 'yes' if actual_type is not none else 'no' %}
+
+                {% if actual_type is none %}
+                    {% set data_type_correct = 'no' %}
+                {% elif expected_type is none or dq_type_families_match(expected_type, actual_type) %}
+                    {% set data_type_correct = 'yes' %}
+                {% else %}
+                    {% set data_type_correct = 'no' %}
+                {% endif %}
+
+                {% set query %}
+                    select
+                          sources.data_source
+                        , '{{ table_name }}' as {{ adapter.quote('table') }}
+                        , '{{ expected_name }}' as {{ adapter.quote('column') }}
+                        , '{{ column_exists }}' as column_exists
+                        , '{{ data_type_correct }}' as data_type_correct
+                    from (
+                        {{ source_dimension_sql }}
+                    ) as sources
+                {% endset %}
+
+                {% do detail_queries.append(query) %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+
+    select *
+    from (
+        {{ detail_queries | join('\nunion all\n') }}
+    ) as structural_column_details
+    order by 1, 2, 3
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('table') }}
+        , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('column') }}
+        , cast(null as {{ dbt.type_string() }}) as column_exists
+        , cast(null as {{ dbt.type_string() }}) as data_type_correct
+    where 1 = 0
+{% endif %}

--- a/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
+++ b/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
@@ -1,0 +1,206 @@
+{{ config(
+     enabled = var('enable_data_quality', false) | as_bool,
+     schema = (
+       var('tuva_schema_prefix', None) ~ '_data_quality'
+       if var('tuva_schema_prefix', None) is not none
+       else 'data_quality'
+     ),
+     alias = 'structural_primary_key_tests',
+     tags = ['data_quality', 'dq', 'dq1', 'dq_structural'],
+     materialized = 'table'
+   )
+}}
+
+{% set claim_model_names = dq_claims_structural_model_names() %}
+
+{% for model_name in claim_model_names %}
+-- depends_on: {{ ref(model_name) }}
+{% endfor %}
+
+{% if execute %}
+    {% set pk_queries = [] %}
+
+    {% for model_name in claim_model_names %}
+        {% set model_node = dq_find_model_node(model_name) %}
+
+        {% if model_node is not none %}
+            {% set table_name = model_name | replace('input_layer__', '') %}
+            {% set relation = dq_actual_relation(model_node) %}
+            {% set pk_columns = dq_expected_pk_columns(model_node) %}
+            {% set pk_column_list = pk_columns | join(', ') %}
+            {% set actual_column_types = {} %}
+            {% set missing_pk_columns = [] %}
+
+            {% if relation is not none %}
+                {% for column in dq_actual_columns(relation) %}
+                    {% do actual_column_types.update({column.name | lower: column.dtype}) %}
+                {% endfor %}
+                {% set source_dimension_sql = dq_source_dimension_sql(relation) %}
+                {% set source_count_sql = dq_source_row_count_sql(relation) %}
+                {% set source_key_expression = dq_source_key_expression_sql(relation, 'source_rows') %}
+
+                {% for pk_column in pk_columns %}
+                    {% if actual_column_types.get(pk_column) is none %}
+                        {% do missing_pk_columns.append(pk_column) %}
+                    {% endif %}
+                {% endfor %}
+            {% else %}
+                {% set source_dimension_sql = dq_missing_source_dimension_sql() %}
+                {% set source_count_sql %}
+                    select
+                          '{{ dq_source_key_sentinel() }}' as data_source_key
+                        , cast(null as {{ dbt.type_int() }}) as row_count
+                {% endset %}
+            {% endif %}
+
+            {% for pk_column in pk_columns %}
+                {% if relation is none %}
+                    {% set query %}
+                        select
+                              sources.data_source
+                            , '{{ table_name }}' as {{ adapter.quote('table') }}
+                            , '{{ pk_column }}' as {{ adapter.quote('column') }}
+                            , 'not null' as test
+                            , cast(null as {{ dbt.type_int() }}) as test_result
+                        from (
+                            {{ source_dimension_sql }}
+                        ) as sources
+                    {% endset %}
+                {% elif actual_column_types.get(pk_column) is none %}
+                    {% set query %}
+                        select
+                              sources.data_source
+                            , '{{ table_name }}' as {{ adapter.quote('table') }}
+                            , '{{ pk_column }}' as {{ adapter.quote('column') }}
+                            , 'not null' as test
+                            , cast(coalesce(source_counts.row_count, 0) as {{ dbt.type_int() }}) as test_result
+                        from (
+                            {{ source_dimension_sql }}
+                        ) as sources
+                        left join (
+                            {{ source_count_sql }}
+                        ) as source_counts
+                            on sources.data_source_key = source_counts.data_source_key
+                    {% endset %}
+                {% else %}
+                    {% set query %}
+                        select
+                              sources.data_source
+                            , '{{ table_name }}' as {{ adapter.quote('table') }}
+                            , '{{ pk_column }}' as {{ adapter.quote('column') }}
+                            , 'not null' as test
+                            , cast(coalesce(null_counts.test_result, 0) as {{ dbt.type_int() }}) as test_result
+                        from (
+                            {{ source_dimension_sql }}
+                        ) as sources
+                        left join (
+                            select
+                                  {{ source_key_expression }} as data_source_key
+                                , cast(count(*) as {{ dbt.type_int() }}) as test_result
+                            from {{ relation }} as source_rows
+                            where source_rows.{{ quote_column(pk_column) }} is null
+                            group by 1
+                        ) as null_counts
+                            on sources.data_source_key = null_counts.data_source_key
+                    {% endset %}
+                {% endif %}
+
+                {% do pk_queries.append(query) %}
+            {% endfor %}
+
+            {% if relation is none %}
+                {% set duplicate_query %}
+                    select
+                          sources.data_source
+                        , '{{ table_name }}' as {{ adapter.quote('table') }}
+                        , '{{ pk_column_list }}' as {{ adapter.quote('column') }}
+                        , 'duplicate value' as test
+                        , cast(null as {{ dbt.type_int() }}) as test_result
+                    from (
+                        {{ source_dimension_sql }}
+                    ) as sources
+                {% endset %}
+            {% elif missing_pk_columns | length > 0 %}
+                {% set duplicate_query %}
+                    select
+                          sources.data_source
+                        , '{{ table_name }}' as {{ adapter.quote('table') }}
+                        , '{{ pk_column_list }}' as {{ adapter.quote('column') }}
+                        , 'duplicate value' as test
+                        , cast(coalesce(source_counts.row_count, 0) as {{ dbt.type_int() }}) as test_result
+                    from (
+                        {{ source_dimension_sql }}
+                    ) as sources
+                    left join (
+                        {{ source_count_sql }}
+                    ) as source_counts
+                        on sources.data_source_key = source_counts.data_source_key
+                {% endset %}
+            {% else %}
+                {% set duplicate_pk_columns = [] %}
+
+                {% for pk_column in pk_columns %}
+                    {% if pk_column != 'data_source' %}
+                        {% do duplicate_pk_columns.append(pk_column) %}
+                    {% endif %}
+                {% endfor %}
+
+                {% if duplicate_pk_columns | length == 0 %}
+                    {% set duplicate_pk_columns = pk_columns %}
+                {% endif %}
+
+                {% set duplicate_query %}
+                    select
+                          sources.data_source
+                        , '{{ table_name }}' as {{ adapter.quote('table') }}
+                        , '{{ pk_column_list }}' as {{ adapter.quote('column') }}
+                        , 'duplicate value' as test
+                        , cast(coalesce(source_counts.row_count, 0) - coalesce(distinct_counts.distinct_row_count, 0) as {{ dbt.type_int() }}) as test_result
+                    from (
+                        {{ source_dimension_sql }}
+                    ) as sources
+                    left join (
+                        {{ source_count_sql }}
+                    ) as source_counts
+                        on sources.data_source_key = source_counts.data_source_key
+                    left join (
+                        select
+                              distinct_rows.data_source_key
+                            , cast(count(*) as {{ dbt.type_int() }}) as distinct_row_count
+                        from (
+                            select
+                                  {{ source_key_expression }} as data_source_key
+                                {% for pk_column in duplicate_pk_columns %}
+                                , source_rows.{{ quote_column(pk_column) }}
+                                {% endfor %}
+                            from {{ relation }} as source_rows
+                            group by
+                                  1
+                                {% for pk_column in duplicate_pk_columns %}
+                                , {{ loop.index + 1 }}
+                                {% endfor %}
+                        ) as distinct_rows
+                        group by 1
+                    ) as distinct_counts
+                        on sources.data_source_key = distinct_counts.data_source_key
+                {% endset %}
+            {% endif %}
+
+            {% do pk_queries.append(duplicate_query) %}
+        {% endif %}
+    {% endfor %}
+
+    select *
+    from (
+        {{ pk_queries | join('\nunion all\n') }}
+    ) as structural_primary_key_tests
+    order by 1, 2, 3, 4
+{% else %}
+    select
+          cast(null as {{ dbt.type_string() }}) as data_source
+        , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('table') }}
+        , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('column') }}
+        , cast(null as {{ dbt.type_string() }}) as test
+        , cast(null as {{ dbt.type_int() }}) as test_result
+    where 1 = 0
+{% endif %}

--- a/scripts/parse_ci_command.py
+++ b/scripts/parse_ci_command.py
@@ -25,7 +25,7 @@ class ValidationError(ValueError):
 
 @dataclass(frozen=True)
 class ParsedRequest:
-    command_tokens: list[str]
+    command_sequences: list[list[str]]
     targets: list[str]
     source: str
 
@@ -52,6 +52,25 @@ class ValidatedCommand:
     @property
     def command_display(self) -> str:
         return shlex.join(self.command_tokens)
+
+
+@dataclass(frozen=True)
+class ValidatedCommandSequence:
+    commands: list[ValidatedCommand]
+    requires_seed_baseline: bool
+    refreshes_seeds: bool
+
+    @property
+    def command_display(self) -> str:
+        return " -> ".join(command.command_display for command in self.commands)
+
+    @property
+    def dispatch_command(self) -> str:
+        return " ".join(command.command_display for command in self.commands)
+
+    @property
+    def first_subcommand(self) -> str:
+        return self.commands[0].subcommand
 
 
 def _write_outputs(values: dict[str, str]) -> None:
@@ -101,6 +120,58 @@ def _normalize_targets_csv(raw: str) -> list[str]:
     if not trimmed or trimmed == "all":
         return WAREHOUSES.copy()
     return _normalize_targets([part.strip() for part in trimmed.split(",") if part.strip()])
+
+
+def _split_command_sequences(command_tokens: list[str]) -> list[list[str]]:
+    if not command_tokens:
+        raise ValidationError("Missing dbt command. Example: `dbt run --select tag:tuva_demo`.")
+    if command_tokens[0].lower() != "dbt":
+        raise ValidationError("CI commands must start with `dbt`.")
+
+    sequences: list[list[str]] = []
+    current: list[str] = []
+    for token in command_tokens:
+        if token.lower() == "dbt":
+            if current:
+                sequences.append(current)
+            current = ["dbt"]
+            continue
+        current.append(token)
+
+    if current:
+        sequences.append(current)
+
+    return sequences
+
+
+def _parse_legacy_alias(tokens: list[str]) -> ParsedRequest | None:
+    if not tokens:
+        return None
+
+    alias = tokens[0].strip().lower()
+    remainder = tokens[1:]
+    if alias in {"run", "build"}:
+        operation = alias
+        targets = WAREHOUSES.copy()
+    elif alias.startswith("run-") or alias.startswith("build-"):
+        operation, _, target = alias.partition("-")
+        if not target:
+            raise ValidationError(
+                "Missing warehouse in legacy CI alias. Example: `/ci run-snowflake`."
+            )
+        targets = _normalize_targets([target])
+    else:
+        return None
+
+    base_command = ["dbt", operation]
+    if operation == "build":
+        base_command.append("--full-refresh")
+
+    return ParsedRequest(
+        command_sequences=[base_command + remainder],
+        targets=targets,
+        source="alias",
+    )
 
 
 def validate_dbt_command(command_tokens: list[str]) -> ValidatedCommand:
@@ -168,6 +239,26 @@ def validate_dbt_command(command_tokens: list[str]) -> ValidatedCommand:
     )
 
 
+def validate_dbt_sequence(command_sequences: list[list[str]]) -> ValidatedCommandSequence:
+    validated_commands = [validate_dbt_command(command_tokens) for command_tokens in command_sequences]
+
+    requires_seed_baseline = False
+    refreshes_seeds = False
+    seen_seed_refresh = False
+    for command in validated_commands:
+        if command.requires_seed_baseline and not seen_seed_refresh:
+            requires_seed_baseline = True
+        if command.refreshes_seeds:
+            refreshes_seeds = True
+            seen_seed_refresh = True
+
+    return ValidatedCommandSequence(
+        commands=validated_commands,
+        requires_seed_baseline=requires_seed_baseline,
+        refreshes_seeds=refreshes_seeds,
+    )
+
+
 def parse_comment_body(body: str) -> ParsedRequest:
     stripped = body.strip()
     if not stripped.startswith("/ci"):
@@ -179,22 +270,25 @@ def parse_comment_body(body: str) -> ParsedRequest:
 
     remainder = tokens[1:]
     if not remainder:
-        return ParsedRequest(command_tokens=["dbt", "run"], targets=WAREHOUSES.copy(), source="default")
+        return ParsedRequest(command_sequences=[["dbt", "run"]], targets=WAREHOUSES.copy(), source="default")
 
-    if "dbt" in remainder:
-        dbt_index = remainder.index("dbt")
+    alias_request = _parse_legacy_alias(remainder)
+    if alias_request is not None:
+        return alias_request
+
+    if any(token.lower() == "dbt" for token in remainder):
+        dbt_index = next(index for index, token in enumerate(remainder) if token.lower() == "dbt")
         target_tokens = remainder[:dbt_index]
-        command_tokens = remainder[dbt_index:]
-        source = "explicit"
-    else:
-        target_tokens = remainder
-        command_tokens = ["dbt", "run"]
-        source = "default"
+        return ParsedRequest(
+            command_sequences=_split_command_sequences(remainder[dbt_index:]),
+            targets=_normalize_targets(target_tokens),
+            source="explicit",
+        )
 
     return ParsedRequest(
-        command_tokens=command_tokens,
-        targets=_normalize_targets(target_tokens),
-        source=source,
+        command_sequences=[["dbt", "run"]],
+        targets=_normalize_targets(remainder),
+        source="default",
     )
 
 
@@ -205,9 +299,8 @@ def resolve_dispatch_inputs(
     target: str,
 ) -> ParsedRequest:
     if dbt_command.strip():
-        command_tokens = _split_shell_words(dbt_command)
         return ParsedRequest(
-            command_tokens=command_tokens,
+            command_sequences=_split_command_sequences(_split_shell_words(dbt_command)),
             targets=_normalize_targets_csv(targets_csv),
             source="explicit",
         )
@@ -220,33 +313,40 @@ def resolve_dispatch_inputs(
         raise ValidationError(f"Invalid workflow_dispatch input target `{target}`.")
 
     return ParsedRequest(
-        command_tokens=["dbt", "build", "--full-refresh"] if lowered_operation == "build" else ["dbt", "run"],
+        command_sequences=[
+            ["dbt", "build", "--full-refresh"] if lowered_operation == "build" else ["dbt", "run"]
+        ],
         targets=WAREHOUSES.copy() if lowered_target == "all" else [lowered_target],
         source="legacy",
     )
 
 
-def _authorize_request(author_association: str, parsed: ParsedRequest, command: ValidatedCommand) -> None:
+def _authorize_request(
+    author_association: str,
+    parsed: ParsedRequest,
+    command_sequence: ValidatedCommandSequence,
+) -> None:
     association = author_association.strip().upper()
     if association not in COLLABORATOR_ASSOCIATIONS:
         raise ValidationError("You are not authorized to run CI commands on this repository.")
-    if parsed.all_targets and command.subcommand in {"build", "seed"} and association not in MAINTAINER_ASSOCIATIONS:
-        raise ValidationError(
-            "Only repository maintainers can run all-warehouse build or seed commands."
-        )
+    if parsed.all_targets and command_sequence.refreshes_seeds and association not in MAINTAINER_ASSOCIATIONS:
+        raise ValidationError("Only repository maintainers can run all-warehouse build or seed commands.")
 
 
-def _emit_parsed_request(parsed: ParsedRequest, validated: ValidatedCommand) -> None:
+def _emit_parsed_request(parsed: ParsedRequest, validated: ValidatedCommandSequence) -> None:
+    normalized_sequences = [command.command_tokens for command in validated.commands]
     _write_outputs(
         {
             "allowed": "true",
-            "dbt_command": validated.command_display,
-            "dbt_command_json": json.dumps(validated.command_tokens),
+            "dbt_command": validated.dispatch_command,
+            "dbt_command_json": json.dumps(validated.commands[0].command_tokens),
+            "dbt_commands_json": json.dumps(normalized_sequences),
             "command_label": f"{parsed.targets_display}: {validated.command_display}",
             "requires_seed_baseline": str(validated.requires_seed_baseline).lower(),
             "refreshes_seeds": str(validated.refreshes_seeds).lower(),
             "source": parsed.source,
-            "subcommand": validated.subcommand,
+            "subcommand": validated.first_subcommand,
+            "first_subcommand": validated.first_subcommand,
             "targets_csv": parsed.targets_csv,
             "targets_json": json.dumps(parsed.targets),
         }
@@ -264,7 +364,7 @@ def run_parse_comment() -> int:
 
     try:
         parsed = parse_comment_body(body)
-        validated = validate_dbt_command(parsed.command_tokens)
+        validated = validate_dbt_sequence(parsed.command_sequences)
         _authorize_request(author_association, parsed, validated)
     except ValidationError as exc:
         _write_outputs(
@@ -272,7 +372,7 @@ def run_parse_comment() -> int:
                 "allowed": "false",
                 "message": (
                     f"{exc} Examples: `/ci`, `/ci snowflake dbt run`, "
-                    "`/ci dbt seed --select tag:tuva_demo`."
+                    "`/ci snowflake fabric dbt seed dbt run`, `/ci run-snowflake`."
                 ),
             }
         )
@@ -290,9 +390,11 @@ def run_resolve_dispatch() -> int:
             operation=_trimmed_env("CI_OPERATION"),
             target=_trimmed_env("CI_TARGET"),
         )
-        validated = validate_dbt_command(parsed.command_tokens)
+        validated = validate_dbt_sequence(parsed.command_sequences)
     except ValidationError as exc:
-        return _emit_failure(str(exc))
+        return _emit_failure(
+            f"{exc} Examples: `dbt run`, `dbt seed dbt run`, `dbt seed --select tag:tuva_demo dbt run`."
+        )
 
     _emit_parsed_request(parsed, validated)
     return 0

--- a/scripts/test_parse_ci_command.py
+++ b/scripts/test_parse_ci_command.py
@@ -15,43 +15,90 @@ SPEC.loader.exec_module(MODULE)
 class ParseCiCommandTests(unittest.TestCase):
     def test_default_comment_runs_all_warehouses(self):
         parsed = MODULE.parse_comment_body("/ci")
-        validated = MODULE.validate_dbt_command(parsed.command_tokens)
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
 
         self.assertEqual(parsed.targets, MODULE.WAREHOUSES)
-        self.assertEqual(validated.command_tokens, ["dbt", "run"])
+        self.assertEqual([command.command_tokens for command in validated.commands], [["dbt", "run"]])
+        self.assertTrue(validated.requires_seed_baseline)
+        self.assertFalse(validated.refreshes_seeds)
 
     def test_explicit_warehouse_list_and_selector(self):
         parsed = MODULE.parse_comment_body("/ci snowflake databricks dbt seed --select tag:tuva_demo")
-        validated = MODULE.validate_dbt_command(parsed.command_tokens)
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
 
         self.assertEqual(parsed.targets, ["snowflake", "databricks"])
         self.assertEqual(
-            validated.command_tokens,
-            ["dbt", "seed", "--select", "tag:tuva_demo"],
+            [command.command_tokens for command in validated.commands],
+            [["dbt", "seed", "--select", "tag:tuva_demo"]],
         )
+        self.assertFalse(validated.requires_seed_baseline)
         self.assertTrue(validated.refreshes_seeds)
 
-    def test_legacy_alias_is_rejected(self):
-        with self.assertRaises(MODULE.ValidationError):
-            MODULE.parse_comment_body("/ci build-snowflake")
+    def test_sequence_parse_preserves_order(self):
+        parsed = MODULE.parse_comment_body("/ci snowflake fabric dbt seed dbt run")
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
 
-    def test_dispatch_resolution_uses_explicit_command(self):
+        self.assertEqual(parsed.targets, ["snowflake", "fabric"])
+        self.assertEqual(
+            [command.command_tokens for command in validated.commands],
+            [["dbt", "seed"], ["dbt", "run"]],
+        )
+        self.assertFalse(validated.requires_seed_baseline)
+        self.assertTrue(validated.refreshes_seeds)
+
+    def test_sequence_parse_preserves_step_flags(self):
+        parsed = MODULE.parse_comment_body(
+            "/ci snowflake fabric dbt seed --select tag:tuva_demo dbt run --select tag:tuva_demo"
+        )
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        self.assertEqual(
+            [command.command_tokens for command in validated.commands],
+            [
+                ["dbt", "seed", "--select", "tag:tuva_demo"],
+                ["dbt", "run", "--select", "tag:tuva_demo"],
+            ],
+        )
+        self.assertFalse(validated.requires_seed_baseline)
+        self.assertTrue(validated.refreshes_seeds)
+
+    def test_trailing_dbt_is_rejected(self):
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.validate_dbt_sequence(MODULE.parse_comment_body("/ci snowflake dbt seed dbt").command_sequences)
+
+    def test_dispatch_resolution_uses_explicit_sequence(self):
         parsed = MODULE.resolve_dispatch_inputs(
-            dbt_command="dbt build --select tag:tuva_demo",
+            dbt_command="dbt seed --select tag:tuva_demo dbt run --select tag:tuva_demo",
             targets_csv="bigquery,fabric",
             operation="run",
             target="snowflake",
         )
-        validated = MODULE.validate_dbt_command(parsed.command_tokens)
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
 
         self.assertEqual(parsed.targets, ["bigquery", "fabric"])
-        self.assertEqual(validated.subcommand, "build")
+        self.assertEqual(
+            [command.command_tokens for command in validated.commands],
+            [
+                ["dbt", "seed", "--select", "tag:tuva_demo"],
+                ["dbt", "run", "--select", "tag:tuva_demo"],
+            ],
+        )
         self.assertFalse(validated.requires_seed_baseline)
         self.assertTrue(validated.refreshes_seeds)
-        self.assertEqual(
-            validated.command_tokens,
-            ["dbt", "build", "--select", "tag:tuva_demo"],
+
+    def test_dispatch_resolution_uses_legacy_inputs(self):
+        parsed = MODULE.resolve_dispatch_inputs(
+            dbt_command="",
+            targets_csv="",
+            operation="build",
+            target="snowflake",
         )
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        self.assertEqual(parsed.targets, ["snowflake"])
+        self.assertEqual([command.command_tokens for command in validated.commands], [["dbt", "build", "--full-refresh"]])
+        self.assertFalse(validated.requires_seed_baseline)
+        self.assertTrue(validated.refreshes_seeds)
 
     def test_multiple_selector_values_are_allowed(self):
         validated = MODULE.validate_dbt_command(
@@ -77,20 +124,82 @@ class ParseCiCommandTests(unittest.TestCase):
 
     def test_unsupported_argument_is_rejected(self):
         with self.assertRaises(MODULE.ValidationError):
-            MODULE.validate_dbt_command(["dbt", "run", "--profiles-dir", "./foo"])
+            MODULE.validate_dbt_sequence([["dbt", "run", "--profiles-dir", "./foo"]])
+
+    def test_run_only_sequence_requires_seed_baseline(self):
+        validated = MODULE.validate_dbt_sequence([["dbt", "run"]])
+
+        self.assertTrue(validated.requires_seed_baseline)
+        self.assertFalse(validated.refreshes_seeds)
+
+    def test_seed_then_run_sequence_does_not_require_seed_baseline(self):
+        validated = MODULE.validate_dbt_sequence([["dbt", "seed"], ["dbt", "run"]])
+
+        self.assertFalse(validated.requires_seed_baseline)
+        self.assertTrue(validated.refreshes_seeds)
+
+    def test_run_then_seed_sequence_still_requires_seed_baseline(self):
+        validated = MODULE.validate_dbt_sequence([["dbt", "run"], ["dbt", "seed"]])
+
+        self.assertTrue(validated.requires_seed_baseline)
+        self.assertTrue(validated.refreshes_seeds)
 
     def test_all_warehouse_seed_requires_maintainer(self):
         parsed = MODULE.parse_comment_body("/ci dbt seed --select tag:tuva_demo")
-        validated = MODULE.validate_dbt_command(parsed.command_tokens)
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE._authorize_request("COLLABORATOR", parsed, validated)
+
+    def test_all_warehouse_seed_run_sequence_requires_maintainer(self):
+        parsed = MODULE.parse_comment_body("/ci dbt seed dbt run")
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
 
         with self.assertRaises(MODULE.ValidationError):
             MODULE._authorize_request("COLLABORATOR", parsed, validated)
 
     def test_single_warehouse_seed_is_allowed_for_collaborator(self):
         parsed = MODULE.parse_comment_body("/ci snowflake dbt seed --select tag:tuva_demo")
-        validated = MODULE.validate_dbt_command(parsed.command_tokens)
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
 
         MODULE._authorize_request("COLLABORATOR", parsed, validated)
+
+    def test_shorthand_run_alias_is_supported(self):
+        parsed = MODULE.parse_comment_body("/ci run")
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        self.assertEqual(parsed.targets, MODULE.WAREHOUSES)
+        self.assertEqual([command.command_tokens for command in validated.commands], [["dbt", "run"]])
+
+    def test_shorthand_build_alias_is_supported(self):
+        parsed = MODULE.parse_comment_body("/ci build")
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        self.assertEqual(parsed.targets, MODULE.WAREHOUSES)
+        self.assertEqual([command.command_tokens for command in validated.commands], [["dbt", "build", "--full-refresh"]])
+
+    def test_shorthand_run_single_warehouse_alias_is_supported(self):
+        parsed = MODULE.parse_comment_body("/ci run-snowflake")
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        self.assertEqual(parsed.targets, ["snowflake"])
+        self.assertEqual([command.command_tokens for command in validated.commands], [["dbt", "run"]])
+
+    def test_shorthand_build_single_warehouse_alias_is_supported(self):
+        parsed = MODULE.parse_comment_body("/ci build-fabric")
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        self.assertEqual(parsed.targets, ["fabric"])
+        self.assertEqual([command.command_tokens for command in validated.commands], [["dbt", "build", "--full-refresh"]])
+
+    def test_shorthand_alias_accepts_flags(self):
+        parsed = MODULE.parse_comment_body("/ci run-snowflake --select tag:tuva_demo")
+        validated = MODULE.validate_dbt_sequence(parsed.command_sequences)
+
+        self.assertEqual(
+            [command.command_tokens for command in validated.commands],
+            [["dbt", "run", "--select", "tag:tuva_demo"]],
+        )
 
     def test_build_full_refresh_still_refreshes_seeds(self):
         validated = MODULE.validate_dbt_command(["dbt", "build", "--full-refresh"])


### PR DESCRIPTION
## Summary
- add ordered multi-step `/ci` dbt command support, including shorthand compatibility aliases
- update structural data quality to use backing detail and primary key test tables in the `data_quality` schema
- make integration test config and extension-column unit tests consistent with the new DQ and CI behavior

## Validation
- `python scripts/test_parse_ci_command.py`
- `ruby -e "require 'yaml'; YAML.load_file(\.github/workflows/dbt_ci_modes.yml\); puts \YAML OK\"`
- `git diff --check`
- `PATH=/Users/aaronneiderhiser/code/tuva/.venv-ci/bin:$PATH DBT_PROFILES_DIR=/Users/aaronneiderhiser/code/tuva/.codex-temp TUVA_DBT_PROFILE=tuva_dev scripts/dbt-local test --select "unit_test:test_member_months_extension_columns_flow_through_calendar_join unit_test:test_core_member_months_extension_columns_appear_in_final_output"`

## Notes
- local dbt validation against `~/.dbt` / `tuva_dev.duckdb` is currently blocked by a DuckDB metadata error in the existing local database file, so the unit tests were rerun against a clean temporary DuckDB profile instead.