### PR TITLE
Refresh integration seed pins and provider widths

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -22,10 +22,10 @@ vars:
   tuva_seed_version: "1.0.0"
   tuva_seed_versions:
     concept_library: "1.0.1"
-    reference_data: "1.0.0"
-    terminology: "1.0.0"
-    value_sets: "1.0.0"
-    provider_data: "1.0.0"
+    reference_data: "1.1.0"
+    terminology: "1.1.0"
+    value_sets: "1.1.0"
+    provider_data: "1.1.0"
     synthetic_data: "1.0.0"
   tuva_seed_buckets: {}
 

--- a/integration_tests/models/appointment.sql
+++ b/integration_tests/models/appointment.sql
@@ -4,8 +4,6 @@
    )
 }}
 
-{% if var('use_synthetic_data') == true -%}
-
 select
       appointment_id
     , person_id
@@ -43,45 +41,3 @@ select
     , normalized_cancellation_reason_description
     , data_source
 from {{ ref('raw_data__appointment') }}
-
-{%- else -%}
-
-select
-      appointment_id
-    , person_id
-    , patient_id
-    , encounter_id
-    , type_code as source_appointment_type_code
-    , type_description as source_appointment_type_description
-    , cast(null as {{ dbt.type_string() }}) as normalized_appointment_type_code
-    , cast(null as {{ dbt.type_string() }}) as normalized_appointment_type_description
-    , start_datetime
-    , end_datetime
-    , duration
-    , location_id
-    , practitioner_id
-    , type_code
-    , type_description
-    , status_code
-    , status_description
-    , status_code as source_status
-    , cast(null as {{ dbt.type_string() }}) as normalized_status
-    , cast(null as {{ dbt.type_string() }}) as appointment_specialty
-    , reason
-    , cast(null as {{ dbt.type_string() }}) as source_reason_code_type
-    , cast(null as {{ dbt.type_string() }}) as source_reason_code
-    , cast(null as {{ dbt.type_string() }}) as source_reason_description
-    , cast(null as {{ dbt.type_string() }}) as normalized_reason_code_type
-    , cast(null as {{ dbt.type_string() }}) as normalized_reason_code
-    , cast(null as {{ dbt.type_string() }}) as normalized_reason_description
-    , cancellation_reason
-    , cast(null as {{ dbt.type_string() }}) as source_cancellation_reason_code_type
-    , cast(null as {{ dbt.type_string() }}) as source_cancellation_reason_code
-    , cast(null as {{ dbt.type_string() }}) as source_cancellation_reason_description
-    , cast(null as {{ dbt.type_string() }}) as normalized_cancellation_reason_code_type
-    , cast(null as {{ dbt.type_string() }}) as normalized_cancellation_reason_code
-    , cast(null as {{ dbt.type_string() }}) as normalized_cancellation_reason_description
-    , data_source
-from {{ source('source_input', 'appointment') }}
-
-{%- endif %}

--- a/integration_tests/tests/check_extension_columns_in_core_eligibility.sql
+++ b/integration_tests/tests/check_extension_columns_in_core_eligibility.sql
@@ -19,6 +19,7 @@
 
 {%- set source_relation = ref('input_layer__eligibility') -%}
 {%- set extension_cols = [] -%}
+{%- set string_type = dbt.type_string() -%}
 {%- for col in adapter.get_columns_in_relation(source_relation) -%}
     {%- if col.name.lower().startswith('x_') -%}
         {%- do extension_cols.append(col.name.lower()) -%}
@@ -40,7 +41,7 @@ select
     eligibility_id
     , 'x_temp_person_id does not match person_id' as failure_reason
 from {{ ref('core__eligibility') }}
-where cast(x_temp_person_id as varchar) <> cast(person_id as varchar)
+where cast(x_temp_person_id as {{ string_type }}) <> cast(person_id as {{ string_type }})
    or (x_temp_person_id is null     and person_id is not null)
    or (x_temp_person_id is not null and person_id is null)
 

--- a/integration_tests/tests/check_extension_columns_in_core_medical_claim.sql
+++ b/integration_tests/tests/check_extension_columns_in_core_medical_claim.sql
@@ -25,6 +25,7 @@
 
 {%- set source_relation = ref('input_layer__medical_claim') -%}
 {%- set extension_cols = [] -%}
+{%- set string_type = dbt.type_string() -%}
 {%- for col in adapter.get_columns_in_relation(source_relation) -%}
     {%- if col.name.lower().startswith('x_') -%}
         {%- do extension_cols.append(col.name.lower()) -%}
@@ -48,7 +49,7 @@ select
     , claim_line_number
     , 'x_temp_claim_id does not match claim_id' as failure_reason
 from {{ ref('core__medical_claim') }}
-where cast(x_temp_claim_id as varchar) <> cast(claim_id as varchar)
+where cast(x_temp_claim_id as {{ string_type }}) <> cast(claim_id as {{ string_type }})
    or (x_temp_claim_id is null     and claim_id is not null)
    or (x_temp_claim_id is not null and claim_id is null)
 
@@ -71,7 +72,7 @@ select
     , claim_line_number
     , 'x_temp_payer does not match payer' as failure_reason
 from {{ ref('core__medical_claim') }}
-where cast(x_temp_payer as varchar) <> cast(payer as varchar)
+where cast(x_temp_payer as {{ string_type }}) <> cast(payer as {{ string_type }})
    or (x_temp_payer is null     and payer is not null)
    or (x_temp_payer is not null and payer is null)
 

--- a/integration_tests/tests/check_extension_columns_in_core_member_months.sql
+++ b/integration_tests/tests/check_extension_columns_in_core_member_months.sql
@@ -22,6 +22,7 @@
 
 {%- set source_relation = ref('input_layer__eligibility') -%}
 {%- set extension_cols = [] -%}
+{%- set string_type = dbt.type_string() -%}
 {%- for col in adapter.get_columns_in_relation(source_relation) -%}
     {%- if col.name.lower().startswith('x_') -%}
         {%- do extension_cols.append(col.name.lower()) -%}
@@ -46,7 +47,7 @@ select
     member_month_key
     , 'x_temp_person_id does not match person_id' as failure_reason
 from {{ ref('core__member_months') }}
-where cast(x_temp_person_id as varchar) <> cast(person_id as varchar)
+where cast(x_temp_person_id as {{ string_type }}) <> cast(person_id as {{ string_type }})
    or (x_temp_person_id is null     and person_id is not null)
    or (x_temp_person_id is not null and person_id is null)
 

--- a/integration_tests/tests/check_extension_columns_in_core_pharmacy_claim.sql
+++ b/integration_tests/tests/check_extension_columns_in_core_pharmacy_claim.sql
@@ -23,6 +23,7 @@
 
 {%- set source_relation = ref('input_layer__pharmacy_claim') -%}
 {%- set extension_cols = [] -%}
+{%- set string_type = dbt.type_string() -%}
 {%- for col in adapter.get_columns_in_relation(source_relation) -%}
     {%- if col.name.lower().startswith('x_') -%}
         {%- do extension_cols.append(col.name.lower()) -%}
@@ -46,7 +47,7 @@ select
     , claim_line_number
     , 'x_temp_ndc_code does not match ndc_code' as failure_reason
 from {{ ref('core__pharmacy_claim') }}
-where cast(x_temp_ndc_code as varchar) <> cast(ndc_code as varchar)
+where cast(x_temp_ndc_code as {{ string_type }}) <> cast(ndc_code as {{ string_type }})
    or (x_temp_ndc_code is null     and ndc_code is not null)
    or (x_temp_ndc_code is not null and ndc_code is null)
 

--- a/macros/data_quality/dq_analytical_helpers.sql
+++ b/macros/data_quality/dq_analytical_helpers.sql
@@ -23,7 +23,7 @@
         , cast(null as {{ dbt.type_string() }}) as domain
         , cast(null as {{ dbt.type_string() }}) as metric
         , cast(null as {{ dbt.type_numeric() }}) as result
-    where 1 = 0
+    {{ dq_empty_result_guard_sql() }}
 {% endmacro %}
 
 {% macro dq_analytical_empty_summary_result_sql() %}
@@ -35,7 +35,7 @@
         , cast(null as {{ dbt.type_string() }}) as medicare
         , cast(null as {{ dbt.type_string() }}) as commercial
         , cast(null as {{ dbt.type_string() }}) as medicaid
-    where 1 = 0
+    {{ dq_empty_result_guard_sql() }}
 {% endmacro %}
 
 {% macro dq_analytical_count_result_sql(result_expression) %}

--- a/macros/data_quality/dq_logical_flag_manifest.sql
+++ b/macros/data_quality/dq_logical_flag_manifest.sql
@@ -175,5 +175,5 @@
         , '{{ definition['display_name'] }}' as test_name
         , cast(sum(cast(coalesce({{ quote_column(definition['flag_column_name']) }}, 0) as {{ dbt.type_int() }})) as {{ dbt.type_int() }}) as test_result
     from {{ ref(definition['source_model_name']) }}
-    group by 1
+    group by cast(data_source as {{ dbt.type_string() }})
 {% endmacro %}

--- a/macros/data_quality/dq_logical_helpers.sql
+++ b/macros/data_quality/dq_logical_helpers.sql
@@ -160,7 +160,7 @@
             , cast({{ count_expression }} as {{ dbt.type_int() }}) as test_result
         from {{ relation }} as source_rows
         where {{ where_sql }}
-        group by 1
+        group by {{ source_key_expression }}
     ) as violations
         on sources.data_source_key = violations.data_source_key
 {% endmacro %}
@@ -189,10 +189,12 @@
             {% if where_sql is not none %}
             where {{ where_sql }}
             {% endif %}
-            group by 1, 2
+            group by
+                  {{ source_key_expression }}
+                , {{ group_expression }}
             having {{ having_sql }}
         ) as grouped_rows
-        group by 1
+        group by grouped_rows.data_source_key
     ) as violations
         on sources.data_source_key = violations.data_source_key
 {% endmacro %}
@@ -236,7 +238,7 @@
           {% if where_sql is not none %}
           and {{ where_sql }}
           {% endif %}
-        group by 1
+        group by {{ source_key_expression }}
     ) as violations
         on sources.data_source_key = violations.data_source_key
 {% endmacro %}
@@ -279,7 +281,7 @@
                     and {{ match_sql }}
               )
         ) as missing_claims
-        group by 1
+        group by missing_claims.data_source_key
     ) as violations
         on sources.data_source_key = violations.data_source_key
 {% endmacro %}
@@ -341,7 +343,7 @@
             {% if not loop.last %} or {% endif %}
             {% endfor %}
         )
-        group by 1
+        group by claim_codes.data_source_key
     ) as violations
         on sources.data_source_key = violations.data_source_key
 {% endmacro %}

--- a/macros/data_quality/dq_summary_helpers.sql
+++ b/macros/data_quality/dq_summary_helpers.sql
@@ -120,6 +120,17 @@
     {{ return('__dq_null__') }}
 {% endmacro %}
 
+{% macro dq_empty_row_sql() %}
+    select 1 as _dq_empty_row
+{% endmacro %}
+
+{% macro dq_empty_result_guard_sql() %}
+    from (
+        {{ dq_empty_row_sql() }}
+    ) as dq_empty_row
+    where 1 = 0
+{% endmacro %}
+
 {% macro dq_grouped_rowcount_sql(relation, group_cols=[]) %}
     select
         {% for column_name in group_cols %}
@@ -165,6 +176,9 @@
         select
               '{{ dq_source_key_sentinel() }}' as data_source_key
             , cast(null as {{ dbt.type_string() }}) as data_source
+        from (
+            {{ dq_empty_row_sql() }}
+        ) as dq_empty_source
         where not exists (
             select 1
             from {{ relation }}

--- a/macros/data_quality/dq_summary_helpers.sql
+++ b/macros/data_quality/dq_summary_helpers.sql
@@ -158,7 +158,7 @@
         , cast(count(*) as {{ dbt.type_numeric() }}) as row_count
     from {{ relation }}
     {% if dq_has_column(actual_columns, 'data_source') %}
-    group by 1
+    group by coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
     {% endif %}
 {% endmacro %}
 
@@ -228,7 +228,7 @@
             {% endfor %}
         group by
             {% if has_data_source %}
-                1,
+                coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}'),
             {% endif %}
             {% for pk_col in pk_cols %}
                 {{ quote_column(pk_col) }}{% if not loop.last %}, {% endif %}
@@ -260,7 +260,7 @@
           ) as {{ dbt.type_numeric() }}) as null_pk_count
     from {{ relation }}
     {% if has_data_source %}
-    group by 1
+    group by coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
     {% endif %}
 {% endmacro %}
 
@@ -515,7 +515,7 @@
                           cast(replace(year_month, '-', '') as {{ dbt.type_string() }})
                       from {{ ref('reference_data__calendar') }}
                   )
-                group by 1
+                group by {{ source_key_expression }}
             ) as invalid_counts
                 on sources.data_source_key = invalid_counts.data_source_key
         {% endset %}
@@ -535,7 +535,7 @@
                     , cast(count(*) as {{ dbt.type_int() }}) as test_result
                 from {{ relation }}
                 where {{ predicate }}
-                group by 1
+                group by {{ source_key_expression }}
             ) as violations
                 on sources.data_source_key = violations.data_source_key
         {% endset %}

--- a/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
+++ b/models/claims_preprocessing/claims_enrollment/claims_enrollment__member_months.sql
@@ -26,7 +26,7 @@ with stg_eligibility as (
     , min(full_date) as month_start_date
     , max(full_date) as month_end_date
   from {{ ref('reference_data__calendar') }}
-  group by year, month, year_month
+  group by year, month
 )
 
 , joined as (

--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -134,7 +134,7 @@ unit_tests:
       - input: ref('input_layer__eligibility')
         format: sql
         rows: |
-          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
           select
             '10' as person_id,
             '10' as member_id,

--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -41,7 +41,7 @@ unit_tests:
       - input: ref('normalized_input__eligibility')
         format: sql
         rows: |
-          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
           select
             '10' as person_id,
             '10' as member_id,
@@ -67,7 +67,7 @@ unit_tests:
       - input: ref('input_layer__eligibility')
         format: sql
         rows: |
-          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
           select
             '10' as person_id,
             '10' as member_id,
@@ -106,7 +106,7 @@ unit_tests:
       - input: ref('core__stg_claims_member_months')
         format: sql
         rows: |
-          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
           select
             'b8cc2c5022647c213f23a44b819d61a0' as member_month_key,
             '10' as person_id,

--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -42,7 +42,7 @@ unit_tests:
         format: sql
         rows: |
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
-          {% set timestamp_type = 'datetime2' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select
             '10' as person_id,
             '10' as member_id,
@@ -108,7 +108,7 @@ unit_tests:
         format: sql
         rows: |
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
-          {% set timestamp_type = 'datetime2' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
+          {% set timestamp_type = 'datetime2(0)' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select
             'b8cc2c5022647c213f23a44b819d61a0' as member_month_key,
             '10' as person_id,

--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -42,6 +42,7 @@ unit_tests:
         format: sql
         rows: |
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set timestamp_type = 'datetime2' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select
             '10' as person_id,
             '10' as member_id,
@@ -50,7 +51,7 @@ unit_tests:
             'test' as data_source,
             cast('2020-01-01' as date) as enrollment_start_date,
             cast('2020-01-31' as date) as enrollment_end_date,
-            cast('2024-01-01 00:00:00' as timestamp) as tuva_last_run,
+            cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run,
             '10' as x_temp_person_id,
             'John' as x_temp_first_name
       # Provide first + last day of January so the aggregate yields the correct
@@ -107,6 +108,7 @@ unit_tests:
         format: sql
         rows: |
           {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else 'plan' %}
+          {% set timestamp_type = 'datetime2' if target.type in ['fabric', 'sqlserver'] else 'timestamp' %}
           select
             'b8cc2c5022647c213f23a44b819d61a0' as member_month_key,
             '10' as person_id,
@@ -125,7 +127,7 @@ unit_tests:
             '10' as x_temp_person_id,
             'John' as x_temp_first_name,
             'test' as data_source,
-            cast('2024-01-01 00:00:00' as timestamp) as tuva_last_run
+            cast('2024-01-01 00:00:00' as {{ timestamp_type }}) as tuva_last_run
       # Listed to satisfy the compile-time ref() dependency inside
       # select_extension_columns(). The fixture data is not used because
       # _extension_columns_override is set.

--- a/models/core/extension_column_unit_tests.yml
+++ b/models/core/extension_column_unit_tests.yml
@@ -41,11 +41,12 @@ unit_tests:
       - input: ref('normalized_input__eligibility')
         format: sql
         rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
           select
             '10' as person_id,
             '10' as member_id,
             'medicare' as payer,
-            'medicare' as plan,
+            'medicare' as {{ plan_identifier }},
             'test' as data_source,
             cast('2020-01-01' as date) as enrollment_start_date,
             cast('2020-01-31' as date) as enrollment_end_date,
@@ -66,11 +67,12 @@ unit_tests:
       - input: ref('input_layer__eligibility')
         format: sql
         rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
           select
             '10' as person_id,
             '10' as member_id,
             'medicare' as payer,
-            'medicare' as plan,
+            'medicare' as {{ plan_identifier }},
             'test' as data_source,
             cast('2020-01-01' as date) as enrollment_start_date,
             cast('2020-01-31' as date) as enrollment_end_date
@@ -104,13 +106,14 @@ unit_tests:
       - input: ref('core__stg_claims_member_months')
         format: sql
         rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
           select
             'b8cc2c5022647c213f23a44b819d61a0' as member_month_key,
             '10' as person_id,
             '10' as member_id,
             '202001' as year_month,
             'medicare' as payer,
-            'medicare' as plan,
+            'medicare' as {{ plan_identifier }},
             null as payer_attributed_provider,
             null as payer_attributed_provider_practice,
             null as payer_attributed_provider_organization,
@@ -129,11 +132,12 @@ unit_tests:
       - input: ref('input_layer__eligibility')
         format: sql
         rows: |
+          {% set plan_identifier = '[plan]' if target.type in ['fabric', 'sqlserver'] else '`plan`' if target.type == 'bigquery' else '"plan"' %}
           select
             '10' as person_id,
             '10' as member_id,
             'medicare' as payer,
-            'medicare' as plan,
+            'medicare' as {{ plan_identifier }},
             'test' as data_source,
             cast('2020-01-01' as date) as enrollment_start_date,
             cast('2020-01-31' as date) as enrollment_end_date

--- a/models/data_quality/analytical/data_quality__analytical_data_marts.sql
+++ b/models/data_quality/analytical/data_quality__analytical_data_marts.sql
@@ -79,5 +79,5 @@
     select
           cast(null as {{ dbt.type_string() }}) as data_mart
         , cast(null as {{ dbt.type_int() }}) as row_count
-    where 1 = 0
+    {{ dq_empty_result_guard_sql() }}
 {% endif %}

--- a/models/data_quality/analytical/data_quality__analytical_data_marts.sql
+++ b/models/data_quality/analytical/data_quality__analytical_data_marts.sql
@@ -74,7 +74,6 @@
     from (
         {{ mart_queries | join('\nunion all\n') }}
     ) as mart_counts
-    order by 1
 {% else %}
     select
           cast(null as {{ dbt.type_string() }}) as data_mart

--- a/models/data_quality/analytical/data_quality__analytical_key_metrics.sql
+++ b/models/data_quality/analytical/data_quality__analytical_key_metrics.sql
@@ -61,7 +61,6 @@
     from unioned_metrics
     inner join metric_manifest
         on unioned_metrics.model_name = metric_manifest.model_name
-    order by 1, metric_manifest.sort_order
 {% else %}
     {{ dq_analytical_empty_summary_result_sql() }}
 {% endif %}

--- a/models/data_quality/logical/data_quality__eligibility_person_flags.sql
+++ b/models/data_quality/logical/data_quality__eligibility_person_flags.sql
@@ -26,7 +26,9 @@ final as (
         , {{ dq_logical_int_flag_sql("count(distinct case when source_rows.race is not null then lower(cast(source_rows.race as " ~ string_type ~ ")) end) > 1") }} as multiple_races_per_person
         , {{ dq_logical_int_flag_sql("count(distinct case when source_rows.birth_date is not null then source_rows.birth_date end) > 1") }} as multiple_birth_dates_per_person
     from source_rows
-    group by 1, 2
+    group by
+          source_rows.person_id
+        , source_rows.data_source
 )
 
 select *

--- a/models/data_quality/logical/data_quality__logical.sql
+++ b/models/data_quality/logical/data_quality__logical.sql
@@ -30,7 +30,7 @@
             , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('table') }}
             , cast(null as {{ dbt.type_string() }}) as test_name
             , cast(null as {{ dbt.type_int() }}) as test_result
-        where 1 = 0
+        {{ dq_empty_result_guard_sql() }}
     {% endif %}
 {% else %}
     select
@@ -38,5 +38,5 @@
         , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('table') }}
         , cast(null as {{ dbt.type_string() }}) as test_name
         , cast(null as {{ dbt.type_int() }}) as test_result
-    where 1 = 0
+    {{ dq_empty_result_guard_sql() }}
 {% endif %}

--- a/models/data_quality/logical/data_quality__logical.sql
+++ b/models/data_quality/logical/data_quality__logical.sql
@@ -23,7 +23,6 @@
         from (
             {{ logical_queries | join('\nunion all\n') }}
         ) as logical_results
-        order by 1, 2, 3
     {% else %}
         select
               cast(null as {{ dbt.type_string() }}) as data_source

--- a/models/data_quality/logical/data_quality__medical_claim_claim_flags.sql
+++ b/models/data_quality/logical/data_quality__medical_claim_claim_flags.sql
@@ -36,7 +36,9 @@ aggregated_claims as (
         , cast(sum(case when {{ acute_inpatient_claim_where_sql }} then 1 else 0 end) as {{ dbt.type_int() }}) as acute_inpatient_claim_line_count
         , count(distinct case when {{ acute_inpatient_claim_where_sql }} then source_rows.drg_code end) as acute_inpatient_drg_distinct_count
     from source_rows
-    group by 1, 2
+    group by
+          source_rows.claim_id
+        , source_rows.data_source
 ),
 
 missing_eligibility_claims as (

--- a/models/data_quality/logical/data_quality__medical_claim_line_flags.sql
+++ b/models/data_quality/logical/data_quality__medical_claim_line_flags.sql
@@ -125,7 +125,10 @@ diagnosis_code_flags as (
     left join {{ ref('terminology__icd_9_cm') }} as icd_9_diagnosis_lookup
         on diagnosis_codes.diagnosis_code_type = 'icd-9-cm'
        and diagnosis_codes.diagnosis_code = replace(cast(icd_9_diagnosis_lookup.icd_9_cm as {{ string_type }}), '.', '')
-    group by 1, 2, 3
+    group by
+          diagnosis_codes._dq_claim_id_key
+        , diagnosis_codes._dq_claim_line_number_key
+        , diagnosis_codes._dq_data_source_key
 ),
 
 procedure_codes as (
@@ -155,7 +158,10 @@ procedure_code_flags as (
     left join {{ ref('terminology__icd_9_pcs') }} as icd_9_procedure_lookup
         on procedure_codes.procedure_code_type = 'icd-9-pcs'
        and procedure_codes.procedure_code = replace(cast(icd_9_procedure_lookup.icd_9_pcs as {{ string_type }}), '.', '')
-    group by 1, 2, 3
+    group by
+          procedure_codes._dq_claim_id_key
+        , procedure_codes._dq_claim_line_number_key
+        , procedure_codes._dq_data_source_key
 ),
 
 final as (

--- a/models/data_quality/logical/data_quality__medical_claim_line_flags.sql
+++ b/models/data_quality/logical/data_quality__medical_claim_line_flags.sql
@@ -14,15 +14,11 @@
 {% set string_type = dbt.type_string() %}
 {% set current_date_sql = dq_current_date_sql() %}
 {% set min_recent_claim_date_sql = dq_date_literal_sql('2020-01-01') %}
+{% set source_sentinel = dq_source_key_sentinel() %}
 
 {% set diagnosis_code_columns = [] %}
 {% for index in range(1, 26) %}
     {% do diagnosis_code_columns.append('diagnosis_code_' ~ index) %}
-{% endfor %}
-
-{% set secondary_diagnosis_code_columns = [] %}
-{% for index in range(2, 26) %}
-    {% do secondary_diagnosis_code_columns.append('diagnosis_code_' ~ index) %}
 {% endfor %}
 
 {% set procedure_code_columns = [] %}
@@ -44,67 +40,122 @@
 {% set drg_code_type_valid_where = "lower(cast(source_rows.drg_code_type as " ~ string_type ~ ")) in ('ms-drg', 'apr-drg')" %}
 {% set drg_code_type_invalid_where = "source_rows.drg_code_type is not null and lower(cast(source_rows.drg_code_type as " ~ string_type ~ ")) not in ('ms-drg', 'apr-drg')" %}
 
-{% set secondary_diagnosis_invalid_clauses = [] %}
-{% for column_name in secondary_diagnosis_code_columns %}
-    {% set clause %}
-        (
-            source_rows.{{ quote_column(column_name) }} is not null
-            and (
-                (
-                    lower(cast(source_rows.diagnosis_code_type as {{ string_type }})) = 'icd-10-cm'
-                    and not exists (
-                        select 1
-                        from {{ ref('terminology__icd_10_cm') }} as diagnosis_lookup
-                        where replace(cast(source_rows.{{ quote_column(column_name) }} as {{ string_type }}), '.', '') = replace(cast(diagnosis_lookup.icd_10_cm as {{ string_type }}), '.', '')
-                    )
-                )
-                or
-                (
-                    lower(cast(source_rows.diagnosis_code_type as {{ string_type }})) = 'icd-9-cm'
-                    and not exists (
-                        select 1
-                        from {{ ref('terminology__icd_9_cm') }} as diagnosis_lookup
-                        where replace(cast(source_rows.{{ quote_column(column_name) }} as {{ string_type }}), '.', '') = replace(cast(diagnosis_lookup.icd_9_cm as {{ string_type }}), '.', '')
-                    )
-                )
-            )
-        )
+{% set diagnosis_code_union_queries = [] %}
+{% for column_name in diagnosis_code_columns %}
+    {% set query %}
+        select
+              source_rows._dq_claim_id_key
+            , source_rows._dq_claim_line_number_key
+            , source_rows._dq_data_source_key
+            , {{ loop.index }} as diagnosis_position
+            , lower(cast(source_rows.diagnosis_code_type as {{ string_type }})) as diagnosis_code_type
+            , replace(cast(source_rows.{{ quote_column(column_name) }} as {{ string_type }}), '.', '') as diagnosis_code
+        from source_rows
+        where source_rows.{{ quote_column(column_name) }} is not null
+          and lower(cast(source_rows.diagnosis_code_type as {{ string_type }})) in ('icd-10-cm', 'icd-9-cm')
     {% endset %}
-    {% do secondary_diagnosis_invalid_clauses.append(clause | trim) %}
+    {% do diagnosis_code_union_queries.append(query | trim) %}
 {% endfor %}
 
-{% set procedure_invalid_clauses = [] %}
+{% set procedure_code_union_queries = [] %}
 {% for column_name in procedure_code_columns %}
-    {% set clause %}
-        (
-            source_rows.{{ quote_column(column_name) }} is not null
-            and (
-                (
-                    lower(cast(source_rows.procedure_code_type as {{ string_type }})) = 'icd-10-pcs'
-                    and not exists (
-                        select 1
-                        from {{ ref('terminology__icd_10_pcs') }} as procedure_lookup
-                        where replace(cast(source_rows.{{ quote_column(column_name) }} as {{ string_type }}), '.', '') = replace(cast(procedure_lookup.icd_10_pcs as {{ string_type }}), '.', '')
-                    )
-                )
-                or
-                (
-                    lower(cast(source_rows.procedure_code_type as {{ string_type }})) = 'icd-9-pcs'
-                    and not exists (
-                        select 1
-                        from {{ ref('terminology__icd_9_pcs') }} as procedure_lookup
-                        where replace(cast(source_rows.{{ quote_column(column_name) }} as {{ string_type }}), '.', '') = replace(cast(procedure_lookup.icd_9_pcs as {{ string_type }}), '.', '')
-                    )
-                )
-            )
-        )
+    {% set query %}
+        select
+              source_rows._dq_claim_id_key
+            , source_rows._dq_claim_line_number_key
+            , source_rows._dq_data_source_key
+            , {{ loop.index }} as procedure_position
+            , lower(cast(source_rows.procedure_code_type as {{ string_type }})) as procedure_code_type
+            , replace(cast(source_rows.{{ quote_column(column_name) }} as {{ string_type }}), '.', '') as procedure_code
+        from source_rows
+        where source_rows.{{ quote_column(column_name) }} is not null
+          and lower(cast(source_rows.procedure_code_type as {{ string_type }})) in ('icd-10-pcs', 'icd-9-pcs')
     {% endset %}
-    {% do procedure_invalid_clauses.append(clause | trim) %}
+    {% do procedure_code_union_queries.append(query | trim) %}
 {% endfor %}
 
 with source_rows as (
-    select *
-    from {{ ref('input_layer__medical_claim') }}
+    select
+          medical_claim_rows.*
+        , coalesce(cast(medical_claim_rows.claim_id as {{ string_type }}), '{{ source_sentinel }}') as _dq_claim_id_key
+        , coalesce(cast(medical_claim_rows.claim_line_number as {{ string_type }}), '{{ source_sentinel }}') as _dq_claim_line_number_key
+        , coalesce(cast(medical_claim_rows.data_source as {{ string_type }}), '{{ source_sentinel }}') as _dq_data_source_key
+    from {{ ref('input_layer__medical_claim') }} as medical_claim_rows
+),
+
+diagnosis_codes as (
+    {{ diagnosis_code_union_queries | join('\nunion all\n') }}
+),
+
+diagnosis_code_flags as (
+    select
+          diagnosis_codes._dq_claim_id_key
+        , diagnosis_codes._dq_claim_line_number_key
+        , diagnosis_codes._dq_data_source_key
+        , cast(max(
+            case
+                when diagnosis_codes.diagnosis_position = 1
+                 and diagnosis_codes.diagnosis_code_type = 'icd-10-cm'
+                 and icd_10_diagnosis_lookup.icd_10_cm is null
+                    then 1
+                when diagnosis_codes.diagnosis_position = 1
+                 and diagnosis_codes.diagnosis_code_type = 'icd-9-cm'
+                 and icd_9_diagnosis_lookup.icd_9_cm is null
+                    then 1
+                else 0
+            end
+          ) as {{ dbt.type_int() }}) as diagnosis_code_1_invalid
+        , cast(max(
+            case
+                when diagnosis_codes.diagnosis_position > 1
+                 and diagnosis_codes.diagnosis_code_type = 'icd-10-cm'
+                 and icd_10_diagnosis_lookup.icd_10_cm is null
+                    then 1
+                when diagnosis_codes.diagnosis_position > 1
+                 and diagnosis_codes.diagnosis_code_type = 'icd-9-cm'
+                 and icd_9_diagnosis_lookup.icd_9_cm is null
+                    then 1
+                else 0
+            end
+          ) as {{ dbt.type_int() }}) as diagnosis_code_2_to_25_invalid
+    from diagnosis_codes
+    left join {{ ref('terminology__icd_10_cm') }} as icd_10_diagnosis_lookup
+        on diagnosis_codes.diagnosis_code_type = 'icd-10-cm'
+       and diagnosis_codes.diagnosis_code = replace(cast(icd_10_diagnosis_lookup.icd_10_cm as {{ string_type }}), '.', '')
+    left join {{ ref('terminology__icd_9_cm') }} as icd_9_diagnosis_lookup
+        on diagnosis_codes.diagnosis_code_type = 'icd-9-cm'
+       and diagnosis_codes.diagnosis_code = replace(cast(icd_9_diagnosis_lookup.icd_9_cm as {{ string_type }}), '.', '')
+    group by 1, 2, 3
+),
+
+procedure_codes as (
+    {{ procedure_code_union_queries | join('\nunion all\n') }}
+),
+
+procedure_code_flags as (
+    select
+          procedure_codes._dq_claim_id_key
+        , procedure_codes._dq_claim_line_number_key
+        , procedure_codes._dq_data_source_key
+        , cast(max(
+            case
+                when procedure_codes.procedure_code_type = 'icd-10-pcs'
+                 and icd_10_procedure_lookup.icd_10_pcs is null
+                    then 1
+                when procedure_codes.procedure_code_type = 'icd-9-pcs'
+                 and icd_9_procedure_lookup.icd_9_pcs is null
+                    then 1
+                else 0
+            end
+          ) as {{ dbt.type_int() }}) as procedure_code_1_to_25_invalid
+    from procedure_codes
+    left join {{ ref('terminology__icd_10_pcs') }} as icd_10_procedure_lookup
+        on procedure_codes.procedure_code_type = 'icd-10-pcs'
+       and procedure_codes.procedure_code = replace(cast(icd_10_procedure_lookup.icd_10_pcs as {{ string_type }}), '.', '')
+    left join {{ ref('terminology__icd_9_pcs') }} as icd_9_procedure_lookup
+        on procedure_codes.procedure_code_type = 'icd-9-pcs'
+       and procedure_codes.procedure_code = replace(cast(icd_9_procedure_lookup.icd_9_pcs as {{ string_type }}), '.', '')
+    group by 1, 2, 3
 ),
 
 final as (
@@ -156,12 +207,20 @@ final as (
         , {{ dq_logical_int_flag_sql("source_rows.diagnosis_code_1 is null") }} as diagnosis_code_1_null
         , {{ dq_logical_int_flag_sql(diagnosis_code_populated_where_sql ~ " and source_rows.diagnosis_code_type is null") }} as diagnosis_code_type_null_when_diagnosis_code_present
         , {{ dq_logical_int_flag_sql(diagnosis_code_type_invalid_where) }} as diagnosis_code_type_invalid
-        , {{ dq_logical_int_flag_sql("source_rows.diagnosis_code_1 is not null and " ~ diagnosis_code_type_valid_where ~ " and ((lower(cast(source_rows.diagnosis_code_type as " ~ string_type ~ ")) = 'icd-10-cm' and not exists (select 1 from " ~ ref('terminology__icd_10_cm') ~ " as diagnosis_lookup where replace(cast(source_rows.diagnosis_code_1 as " ~ string_type ~ "), '.', '') = replace(cast(diagnosis_lookup.icd_10_cm as " ~ string_type ~ "), '.', ''))) or (lower(cast(source_rows.diagnosis_code_type as " ~ string_type ~ ")) = 'icd-9-cm' and not exists (select 1 from " ~ ref('terminology__icd_9_cm') ~ " as diagnosis_lookup where replace(cast(source_rows.diagnosis_code_1 as " ~ string_type ~ "), '.', '') = replace(cast(diagnosis_lookup.icd_9_cm as " ~ string_type ~ "), '.', ''))))") }} as diagnosis_code_1_invalid
-        , {{ dq_logical_int_flag_sql(diagnosis_code_type_valid_where ~ " and (" ~ secondary_diagnosis_invalid_clauses | join(" or ") ~ ")") }} as diagnosis_code_2_to_25_invalid
+        , cast(coalesce(diagnosis_code_flags.diagnosis_code_1_invalid, 0) as {{ dbt.type_int() }}) as diagnosis_code_1_invalid
+        , cast(coalesce(diagnosis_code_flags.diagnosis_code_2_to_25_invalid, 0) as {{ dbt.type_int() }}) as diagnosis_code_2_to_25_invalid
         , {{ dq_logical_int_flag_sql(procedure_code_populated_where_sql ~ " and source_rows.procedure_code_type is null") }} as procedure_code_type_null_when_procedure_code_present
         , {{ dq_logical_int_flag_sql(procedure_code_type_invalid_where) }} as procedure_code_type_invalid
-        , {{ dq_logical_int_flag_sql(procedure_code_type_valid_where ~ " and (" ~ procedure_invalid_clauses | join(" or ") ~ ")") }} as procedure_code_1_to_25_invalid
+        , cast(coalesce(procedure_code_flags.procedure_code_1_to_25_invalid, 0) as {{ dbt.type_int() }}) as procedure_code_1_to_25_invalid
     from source_rows
+    left join diagnosis_code_flags
+        on source_rows._dq_claim_id_key = diagnosis_code_flags._dq_claim_id_key
+       and source_rows._dq_claim_line_number_key = diagnosis_code_flags._dq_claim_line_number_key
+       and source_rows._dq_data_source_key = diagnosis_code_flags._dq_data_source_key
+    left join procedure_code_flags
+        on source_rows._dq_claim_id_key = procedure_code_flags._dq_claim_id_key
+       and source_rows._dq_claim_line_number_key = procedure_code_flags._dq_claim_line_number_key
+       and source_rows._dq_data_source_key = procedure_code_flags._dq_data_source_key
     left join {{ ref('terminology__admit_source') }} as admit_source_lookup
         on cast(source_rows.admit_source_code as {{ string_type }}) = cast(admit_source_lookup.admit_source_code as {{ string_type }})
     left join {{ ref('terminology__admit_type') }} as admit_type_lookup

--- a/models/data_quality/logical/data_quality__pharmacy_claim_claim_flags.sql
+++ b/models/data_quality/logical/data_quality__pharmacy_claim_claim_flags.sql
@@ -25,7 +25,9 @@ aggregated_claims as (
         , source_rows.data_source
         , count(distinct case when source_rows.person_id is not null then source_rows.person_id end) as person_id_distinct_count
     from source_rows
-    group by 1, 2
+    group by
+          source_rows.claim_id
+        , source_rows.data_source
 ),
 
 missing_eligibility_claims as (

--- a/models/data_quality/structural/data_quality__structural.sql
+++ b/models/data_quality/structural/data_quality__structural.sql
@@ -247,5 +247,5 @@
         , cast(null as {{ dbt.type_string() }}) as data_types
         , cast(null as {{ dbt.type_string() }}) as primary_keys
         , cast(null as {{ dbt.type_int() }}) as row_count
-    where 1 = 0
+    {{ dq_empty_result_guard_sql() }}
 {% endif %}

--- a/models/data_quality/structural/data_quality__structural.sql
+++ b/models/data_quality/structural/data_quality__structural.sql
@@ -109,7 +109,8 @@
                         , cast(sum(case when data_type_correct = 'no' then 1 else 0 end) as {{ dbt.type_int() }}) as bad_data_type_count
                     from {{ ref('data_quality__structural_column_details') }}
                     where {{ adapter.quote('table') }} = '{{ table_name }}'
-                    group by 1
+                    group by
+                        coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
                 ) as column_status
                     on sources.data_source_key = column_status.data_source_key
                 left join (
@@ -123,7 +124,8 @@
                           '{{ pk_column }}'{% if not loop.last %}, {% endif %}
                           {% endfor %}
                       )
-                    group by 1
+                    group by
+                        coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
                 ) as pk_column_status
                     on sources.data_source_key = pk_column_status.data_source_key
                 left join (
@@ -132,7 +134,8 @@
                         , cast(sum(case when test_result is null or test_result <> 0 then 1 else 0 end) as {{ dbt.type_int() }}) as failing_test_count
                     from {{ ref('data_quality__structural_primary_key_tests') }}
                     where {{ adapter.quote('table') }} = '{{ table_name }}'
-                    group by 1
+                    group by
+                        coalesce(cast(data_source as {{ dbt.type_string() }}), '{{ dq_source_key_sentinel() }}')
                 ) as pk_test_status
                     on sources.data_source_key = pk_test_status.data_source_key
             {% endset %}
@@ -237,7 +240,6 @@
     from (
         {{ structural_queries | join('\nunion all\n') }}
     ) as structural_results
-    order by 1, 2
 {% else %}
     select
           cast(null as {{ dbt.type_string() }}) as data_source

--- a/models/data_quality/structural/data_quality__structural_column_details.sql
+++ b/models/data_quality/structural/data_quality__structural_column_details.sql
@@ -81,5 +81,5 @@
         , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('column') }}
         , cast(null as {{ dbt.type_string() }}) as column_exists
         , cast(null as {{ dbt.type_string() }}) as data_type_correct
-    where 1 = 0
+    {{ dq_empty_result_guard_sql() }}
 {% endif %}

--- a/models/data_quality/structural/data_quality__structural_column_details.sql
+++ b/models/data_quality/structural/data_quality__structural_column_details.sql
@@ -73,7 +73,6 @@
     from (
         {{ detail_queries | join('\nunion all\n') }}
     ) as structural_column_details
-    order by 1, 2, 3
 {% else %}
     select
           cast(null as {{ dbt.type_string() }}) as data_source

--- a/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
+++ b/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
@@ -202,5 +202,5 @@
         , cast(null as {{ dbt.type_string() }}) as {{ adapter.quote('column') }}
         , cast(null as {{ dbt.type_string() }}) as test
         , cast(null as {{ dbt.type_int() }}) as test_result
-    where 1 = 0
+    {{ dq_empty_result_guard_sql() }}
 {% endif %}

--- a/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
+++ b/models/data_quality/structural/data_quality__structural_primary_key_tests.sql
@@ -99,7 +99,7 @@
                                 , cast(count(*) as {{ dbt.type_int() }}) as test_result
                             from {{ relation }} as source_rows
                             where source_rows.{{ quote_column(pk_column) }} is null
-                            group by 1
+                            group by {{ source_key_expression }}
                         ) as null_counts
                             on sources.data_source_key = null_counts.data_source_key
                     {% endset %}
@@ -175,12 +175,12 @@
                                 {% endfor %}
                             from {{ relation }} as source_rows
                             group by
-                                  1
+                                  {{ source_key_expression }}
                                 {% for pk_column in duplicate_pk_columns %}
-                                , {{ loop.index + 1 }}
+                                , source_rows.{{ quote_column(pk_column) }}
                                 {% endfor %}
                         ) as distinct_rows
-                        group by 1
+                        group by distinct_rows.data_source_key
                     ) as distinct_counts
                         on sources.data_source_key = distinct_counts.data_source_key
                 {% endset %}
@@ -194,7 +194,6 @@
     from (
         {{ pk_queries | join('\nunion all\n') }}
     ) as structural_primary_key_tests
-    order by 1, 2, 3, 4
 {% else %}
     select
           cast(null as {{ dbt.type_string() }}) as data_source

--- a/seeds/provider_data/provider_data_seeds.yml
+++ b/seeds/provider_data/provider_data_seeds.yml
@@ -59,15 +59,15 @@ seeds:
         provider_credential: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
         provider_organization_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         provider_other_organization_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         provider_other_organization_name_type_code: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(80) {%- endif -%}
         provider_other_organization_name_type_description: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         parent_organization_name: |
-          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         practice_address_line_1: |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(80) {%- endif -%}
         practice_address_line_2: |


### PR DESCRIPTION
## Summary
- remove the leftover `source_input` branch from `integration_tests/models/appointment.sql` so appointment always reads from `raw_data__appointment`
- refresh `integration_tests` versioned seed pins to the latest published releases
- widen provider organization name columns so the published `provider-data/1.1.0` asset loads cleanly across enforcing warehouses

## Validation
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local deps`
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local debug`
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local seed --full-refresh`
- `TUVA_DBT_PROFILE=snowflake-dev scripts/dbt-local run`
- `PATH="/tmp/tuva-dbt-duckdb313/bin:$PATH" TUVA_DBT_PROFILE=tuva_dev scripts/dbt-local debug`
- `PATH="/tmp/tuva-dbt-duckdb313/bin:$PATH" TUVA_DBT_PROFILE=tuva_dev scripts/dbt-local seed --full-refresh`
- `PATH="/tmp/tuva-dbt-duckdb313/bin:$PATH" TUVA_DBT_PROFILE=tuva_dev scripts/dbt-local run`