### PR TITLE
Bump version to 0.18.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'the_tuva_project'
-version: '0.17.1'
+version: '0.18.0'
 config-version: 2
 require-dbt-version: ">=1.10.0"
 


### PR DESCRIPTION
## Summary
- bump the package version in `dbt_project.yml` to `0.18.0`
- prepare the next release PR from current `main`
- note that both current `main` and the `v0.17.2` tag still show `version: '0.17.1'` in `dbt_project.yml`; this change corrects the release version going forward

## Validation
- `PATH="/tmp/tuva-dbt-duckdb313/bin:$PATH" TUVA_DBT_PROFILE=tuva_dev scripts/dbt-local parse --no-partial-parse`

## Release Automation
- merging this PR to `main` should trigger `.github/workflows/create-release.yml`, which creates a draft GitHub release when `dbt_project.yml` changes and the version differs from the previous commit