### PR TITLE
Consolidate Tuva agent workflow context

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,18 +3,24 @@ changelog:
     labels:
       - ignore-for-release
   categories:
-    - title: 🚨 Breaking Changes 🚨
+    - title: Breaking Changes
       labels:
-        - Semver-Major
         - breaking-change
-    - title: 🎉 Exciting New Features 🎉
+    - title: New Features
       labels:
-        - Semver-Minor
         - enhancement
-    - title: 🪲 Bug Fixes 🪲
+    - title: Bug Fixes
       labels:
-        - Semver-Minor
         - bug
+    - title: Terminology and Value Sets
+      labels:
+        - terminology
+    - title: Connectors
+      labels:
+        - connector
+    - title: Documentation
+      labels:
+        - docs
     - title: Other Changes
       labels:
         - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,99 +1,191 @@
-# Tuva Local Development Workflow
+# Tuva Agent Operating Manual
 
-Follow this workflow for all work in this repository unless the user explicitly overrides it.
+This file is the canonical agent context for the Tuva repository. Agents must read
+and follow it for all Tuva work, including work performed from separate git
+worktrees. Keep workflow details here rather than duplicating them in local Codex
+skills or nested agent files.
 
 ## Project Context
 
-- The Tuva Project is an open-source healthcare data model and analytics framework built with dbt and SQL.
-- It transforms raw healthcare data (claims, clinical, eligibility, pharmacy) into a standardized model used for:
-  - Risk adjustment (CMS-HCC)
-  - Quality measures (HEDIS)
-  - Cost and utilization analytics
-  - Clinical and population health analytics
+- The Tuva Project is an open-source healthcare data model and analytics
+  framework built with dbt and SQL.
+- It transforms raw healthcare data, including claims, clinical, eligibility, and
+  pharmacy data, into a standardized model used for:
+  - Risk adjustment, including CMS-HCC.
+  - Quality measures, including HEDIS-oriented marts.
+  - Cost and utilization analytics.
+  - Clinical and population health analytics.
+- The docs site under `docs/` is a Docusaurus project hosted by Netlify at
+  `www.thetuvaproject.com`. It documents the package and includes data
+  dictionaries generated from model YAML metadata.
 
 ## Architecture Context
 
 - Input Layer (`models/input_layer`):
   - Defines the contract user data must conform to before package processing.
-  - Users map their raw data to this contract in their own dbt project, and Tuva refs those models.
+  - Users map raw data to this contract in their own dbt project; Tuva refs those
+    input models.
 - Claims Preprocessing (`models/claims_preprocessing`):
   - Normalizes claims and runs service category and encounter grouping logic.
 - Core Data Model (`models/core`):
   - Cleaned claims and clinical outputs expected to remain relatively stable.
-  - Treat breaking changes carefully and communicate them clearly.
-- Data Marts (`models/*` outside core/input/preprocessing):
-  - Advanced marts for measures, groupers, and risk models.
-- Terminology and Value Sets (`seeds/` definitions):
-  - Seed definitions in repo are primarily schema/header definitions.
-  - Underlying terminology/value set content is loaded from S3 via hooks.
+  - Treat breaking changes carefully and make them explicit in issues, PRs, and
+    release labels.
+- Data Marts (`models/data_marts` and other marts outside input/core/preprocessing):
+  - Advanced marts for measures, groupers, risk models, analytics, and derived
+    outputs.
+  - When changing mart behavior or schema, update SQL, YAML descriptions/tests,
+    and any docs/data dictionary source affected by the change.
+- Terminology, value sets, and data assets (`seeds/`):
+  - Top-level package seed CSVs are primarily definitions or headers.
+  - Larger underlying terminology/value-set content is loaded from public object
+    storage through seed hooks and version vars.
+  - Data asset changes must preserve cross-warehouse loading behavior.
 
-## Local Environment Rules (Mandatory)
+## Mandatory Local Rules
 
-- Treat `integration_tests/profiles/*` as CI-only configuration. Do not use these files for local development runs.
-- Treat `.github/workflows/*` as CI-only pipeline definitions, not local runbooks.
-- Changes to `.github/workflows/*` are valid when the task is a CI workflow feature/fix.
-- Keep `.github/workflows/create-release.yml` intact unless release workflow changes are explicitly requested.
-- For docs changes under `docs/*`, run local docs build validation before push/PR.
-- Use local DuckDB for development unless the user explicitly asks for MotherDuck or another warehouse.
-- Run dbt from `integration_tests` using local profiles from `~/.dbt` (or `DBT_PROFILES_DIR` if set).
-- Set `TUVA_DBT_PROFILE` (or `DBT_PROFILE`) for local profile selection when needed.
-- Keep `integration_tests/dbt_project.yml` on `profile: default` before push.
-- For data model and seed feature/bug work, validate using the shipped synthetic seed definitions in `integration_tests/seeds/*` on local DuckDB.
+- Use local DuckDB for development unless the user explicitly asks for another
+  warehouse.
+- Run dbt from `integration_tests` using local profiles from `~/.dbt` or
+  `DBT_PROFILES_DIR`.
+- Prefer `scripts/dbt-local` for local dbt commands.
+- Set `TUVA_DBT_PROFILE` or `DBT_PROFILE` only when local profile selection is
+  needed.
+- Keep `integration_tests/dbt_project.yml` on `profile: default` before pushing.
+- Treat `integration_tests/profiles/*` as CI-only configuration, not local
+  runbooks.
+- Treat `.github/workflows/*` as CI pipeline definitions, not local runbooks.
+- Keep `.github/workflows/create-release.yml` intact unless the task explicitly
+  targets release automation.
+- Never merge to `main`; the user reviews and merges PRs.
 
-## Standard Local Docs Commands
+## Seed And Data Safety
 
-For docs changes (`docs/**`), run:
+- Do not modify `integration_tests/seeds/*` without explicit user approval.
+- For local validation, use the integration test defaults:
+  - `use_synthetic_data: true`
+  - `synthetic_data_size: small`
+- For data model, data mart, seed, terminology, or value-set work, validate
+  against the shipped synthetic data on local DuckDB.
+- If a change appears to require new synthetic columns or synthetic data rows,
+  stop and ask for explicit generation requirements before editing
+  `integration_tests/seeds/*`.
+- Seed feature or bug work in top-level `seeds/*` is allowed when requested, but
+  must be validated through `integration_tests` and local DuckDB before PR.
 
-- `cd docs && npm ci`
-- `cd docs && npm run build`
+## Issue-First Worktree Workflow
 
-## Standard Local dbt Commands
+Use this workflow for normal Tuva issue work, especially when the user points to a
+GitHub issue or asks the agent to create one.
 
-Use the repo wrapper:
+1. Issue creation:
+   - If the user asks the agent to create an issue, create it in
+     `tuva-health/tuva`.
+   - Include title, problem statement, acceptance criteria, constraints,
+     validation expectations, and one release-note label.
+   - If acceptance criteria or the release-note label are ambiguous, ask the
+     user. If a conservative default is clear, choose it and record the
+     assumption in the issue.
+2. Planning:
+   - Read the issue body and comments.
+   - Inspect the relevant repo context.
+   - Produce a concise implementation plan before creating a worktree or making
+     code changes.
+3. Branch and worktree:
+   - After the plan is accepted, run `scripts/start-issue-worktree <issue-number>
+     [slug]`.
+   - The helper creates or reuses a GitHub-linked branch named
+     `codex/issue-<n>-<slug>` from `origin/main`.
+   - The helper creates or reuses a local worktree under
+     `/Users/aaronneiderhiser/code/tuva-worktrees/issue-<n>-<slug>`.
+   - All implementation happens in that worktree. Do not reuse the main checkout
+     for issue implementation.
+4. Implementation:
+   - Keep changes focused on the issue acceptance criteria.
+   - Preserve cross-warehouse SQL portability.
+   - Update docs and YAML metadata when model behavior, schema, or user-facing
+     fields change.
+5. PR:
+   - Rebase or update from `origin/main` before pushing when needed.
+   - Push the linked branch and open a PR to `main`.
+   - The PR body must include summary, validation, release-note label, and
+     `Closes #<issue-number>`.
+   - Mirror the issue release-note label onto the PR.
+6. CI:
+   - PR open still triggers the default Snowflake `dbt run`.
+   - After PR creation, post `/ci snowflake dbt seed dbt run`.
+   - Monitor checks, fix failures in the same worktree, push, and continue until
+     the relevant checks pass.
+   - Leave merge to the user.
+
+`scripts/start-dev-branch <topic>` remains available for older non-issue flows,
+but issue-linked worktrees are preferred.
+
+## Release Labels And Notes
+
+Use exactly one release-note disposition on each issue and PR:
+
+- `breaking-change`
+- `enhancement`
+- `bug`
+- `docs`
+- `terminology`
+- `connector`
+- `ignore-for-release`
+
+Optional version labels such as `v0.18.0` may be used for triage, but they do not
+drive release note categories.
+
+Release behavior:
+
+- `.github/workflows/create-release.yml` creates a draft release when the package
+  version changes in `dbt_project.yml` on `main`.
+- GitHub generated release notes are built from merged PRs between tags.
+- `.github/release.yml` groups those notes by PR labels.
+- Because release notes are PR-label based, mirror the issue release-note label
+  onto the PR.
+- Use `Closes #<issue-number>` in PR bodies so merge closes the issue and keeps
+  issue-to-release traceability.
+
+## Local Validation
+
+Standard dbt commands:
 
 - `scripts/dbt-local deps`
 - `scripts/dbt-local debug`
 - `scripts/dbt-local build --select <selector>`
-- `scripts/dbt-local build --full-refresh` before push for model/seed feature or bug work
+- `scripts/dbt-local build --full-refresh`
 
-Equivalent explicit form:
+Validation expectations by change type:
 
-- `dbt --project-dir integration_tests --profiles-dir ~/.dbt <command>`
+- Docs changes under `docs/**`:
+  - `cd docs && npm ci`
+  - `cd docs && npm run build`
+- Models, marts, macros, seeds, terminology, or value sets:
+  - `scripts/dbt-local deps`
+  - Run the narrowest useful `scripts/dbt-local build --select <selector>`.
+  - Run `scripts/dbt-local build --full-refresh` before PR.
+- CI workflow changes:
+  - Validate workflow YAML and available local workflow linting tools.
+  - Confirm PR-open default remains `run-snowflake`.
+  - Confirm `/ci run|build[-warehouse]` mappings still behave as documented.
 
-Outside contributor bridge helper:
-
-- `scripts/outside-pr-bridge <pr-number>`
+`dbt seed`, `dbt run`, and `dbt build` may require internet access because some
+seed and value-set content is loaded from public object storage.
 
 ## CI Command Workflows
 
-- Default on PR open: run `run-snowflake` (Snowflake-only `dbt run`).
+- Default on PR open: Snowflake-only `dbt run`.
 - Comment commands on PRs:
   - `/ci run` runs `dbt run` across all supported warehouses.
   - `/ci run-<warehouse>` runs `dbt run` on one warehouse.
   - `/ci build` runs `dbt build --full-refresh` across all supported warehouses.
   - `/ci build-<warehouse>` runs `dbt build --full-refresh` on one warehouse.
-- Supported warehouses: `snowflake`, `bigquery`, `databricks`, `fabric`, `redshift`, `duckdb`.
-- If a PR changes seed/config files that require a full refresh, use a build command (`/ci build*`) instead of a run command (`/ci run*`).
-
-## Git and PR Workflow
-
-- Never commit directly to `main`.
-- Start every new feature/bug task from a clean, up-to-date `main`:
-  - Preferred: `scripts/start-dev-branch <topic>`
-  - Equivalent manual flow: clean working tree -> `git fetch origin main` -> `git checkout main` -> `git pull --ff-only origin main` -> create a concise, descriptive feature branch
-- Use succinct, straightforward branch names and PR titles that clearly describe the change.
-- Make focused commits with clear messages.
-- Push branch and open PR to `main`.
-- Monitor CI checks by default after opening a PR until all required checks pass.
-- If any check fails, troubleshoot, fix, push, and continue monitoring until green.
-- Never merge to `main`; the user merges.
-
-## Seed/Data Safety
-
-- Do not modify `integration_tests/seeds/*` without explicit user approval.
-- If a change appears to require seed changes, stop and ask first.
-- If new synthetic columns/data are required, ask for explicit generation requirements first (for example expected date ranges).
-- Seed feature/bug work in top-level `seeds/*` is allowed, but must be validated via `integration_tests` + local DuckDB before push.
+  - `/ci snowflake dbt seed dbt run` runs Snowflake seed followed by Snowflake run.
+- Supported warehouses: `snowflake`, `bigquery`, `databricks`, `fabric`,
+  `redshift`, `duckdb`.
+- If a PR changes seed/config files that require a full refresh, use a
+  seed-refreshing CI command before run/test-only commands.
 
 ## SQL Portability Rules
 
@@ -105,26 +197,12 @@ Outside contributor bridge helper:
   - Microsoft Fabric
   - Redshift
   - DuckDB
-
-## Build Requirements
-
-- `dbt seed` and `dbt build` may require internet access because some seeds/value sets are loaded from public S3 resources.
-
-## Execution Contract Per Task
-
-For each user task:
-
-1. Restate goal briefly and start execution.
-2. Implement code changes directly.
-3. Validate locally by change type and report exact commands/results:
-   - docs changes: `cd docs && npm ci && npm run build`
-   - data model/seed changes: run `scripts/dbt-local` commands from `integration_tests` with local DuckDB
-   - CI workflow changes: run available local workflow lint/syntax checks and confirm `/ci run|build[-warehouse]` behavior plus PR-open `run-snowflake` default
-4. Push/open PR and monitor CI until required checks are green by default, then report final status.
+- Prefer existing Tuva macros and package patterns over warehouse-specific SQL.
 
 ## Outside Contributor PR Workflow
 
-Use this for PRs that do not trigger CI because they originate outside the Tuva GitHub org.
+Use this for PRs that do not trigger CI because they originate outside the Tuva
+GitHub org.
 
 Invocation:
 
@@ -136,18 +214,24 @@ task: outside-pr <pr-number>
 Deterministic flow:
 
 1. Sync local `main` to clean `origin/main`.
-2. Fetch source PR refs and prefer `pull/<pr-number>/merge` so validation runs in clean-main merge context.
-3. Run local validation in DuckDB (`scripts/dbt-local deps` and `scripts/dbt-local build --full-refresh`).
-4. If local validation fails, stop and report failures. Do not create bridge PR.
-5. If local validation passes, push a bridge branch named `codex/outside-pr-<pr-number>-ci-<timestamp>`.
-6. Open a new PR to `main` with title prefix `[outside-pr <pr-number>]` and body linking the source PR.
-7. Monitor CI checks until all required checks are green; if any fail, troubleshoot/fix/push and continue until green.
+2. Fetch source PR refs and prefer `pull/<pr-number>/merge` so validation runs
+   in clean-main merge context.
+3. Run local validation in DuckDB with `scripts/dbt-local deps` and
+   `scripts/dbt-local build --full-refresh`.
+4. If local validation fails, stop and report failures. Do not create a bridge PR.
+5. If local validation passes, push a bridge branch named
+   `codex/outside-pr-<pr-number>-ci-<timestamp>`.
+6. Open a new PR to `main` with title prefix `[outside-pr <pr-number>]` and body
+   linking the source PR.
+7. Monitor CI checks until all required checks are green; if any fail,
+   troubleshoot, fix, push, and continue until green.
 
 Use `scripts/outside-pr-bridge <pr-number>` to execute this flow.
 
 ## Invocation Shortcut: `tuva-dev/`
 
-If a user message starts with `tuva-dev/`, treat it as a request to run this exact local Tuva workflow end-to-end for a feature or bug task.
+If a user message starts with `tuva-dev/`, treat it as a request to run this Tuva
+workflow for a feature, bug, issue, or outside PR task.
 
 Preferred user format:
 
@@ -161,15 +245,21 @@ constraints:
 - <optional guardrails>
 ```
 
-Outside contributor format:
-
-```text
-tuva-dev/
-task: outside-pr 1219
-```
-
 Fallback parsing rules:
 
-- If only one sentence is provided after `tuva-dev/`, treat it as `task`.
-- If `acceptance` is missing, propose concise acceptance criteria and proceed.
-- Assume local DuckDB + `scripts/dbt-local` validation unless user says otherwise.
+- If only one sentence is provided after `tuva-dev/`, treat it as the task.
+- If the task references an existing issue, follow the issue-first worktree
+  workflow.
+- If acceptance is missing and no issue exists, infer concise acceptance criteria
+  and record them in the issue or PR.
+
+## Output Contract
+
+For each task, report:
+
+- Issue and PR URLs when created.
+- Branch and worktree path.
+- What changed and why.
+- Local validation commands run and key outcomes.
+- CI commands/check status when run.
+- Any blockers, assumptions, or required user decisions.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,10 +1,8 @@
-# The Tuva Project Docs -- AI Agent Guide
+# Tuva Docs Agent Guide
 
-The Tuva Project Docs is a docusaurus project contained in the root docs folder which this file is inside of.  The purpose of the docs site is to document the Tuva Project, especially the main Tuva repo.  The docs site is hosted via Netlify and is available on the web at www.thetuvaproject.com.
+The canonical Tuva agent instructions live in the repository root:
 
-The site contains data dictionaries for many data tables in the Tuva Project, including:
-- Input Layer
-- Core Data Model
-- Data Marts
+- `../AGENTS.md`
 
-The data marts use code that extracts table names, column names, descriptions, and data types from the YML files in the Tuva package.  
+Follow the root guide for docs work, including Docusaurus validation, data
+dictionary updates, release labels, and PR workflow.

--- a/scripts/start-issue-worktree
+++ b/scripts/start-issue-worktree
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/start-issue-worktree [--dry-run] [--worktree-root PATH] <issue-number> [slug]
+
+Purpose:
+  Start Tuva issue work from a GitHub-linked branch and an isolated git worktree.
+
+Default behavior:
+  - Creates or reuses branch codex/issue-<issue-number>-<slug> from origin/main
+  - Links the branch to the GitHub issue with `gh issue develop`
+  - Creates or reuses worktree /Users/aaronneiderhiser/code/tuva-worktrees/issue-<issue-number>-<slug>
+
+Examples:
+  scripts/start-issue-worktree 123 add-claim-status
+  scripts/start-issue-worktree --dry-run 123 add-claim-status
+EOF
+}
+
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+normalize_slug() {
+  local raw="$1"
+  echo "${raw}" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/--+/-/g'
+}
+
+run_cmd() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf '+'
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+find_worktree_for_branch() {
+  local branch_ref="refs/heads/$1"
+  git worktree list --porcelain | awk -v branch_ref="${branch_ref}" '
+    $1 == "worktree" { path = $2 }
+    $1 == "branch" && $2 == branch_ref { print path; exit }
+  '
+}
+
+extract_linked_branch() {
+  local issue_number="$1"
+  grep -Eo "codex/issue-${issue_number}-[A-Za-z0-9._/-]+" | head -n 1 || true
+}
+
+DRY_RUN=0
+WORKTREE_ROOT="${TUVA_WORKTREE_ROOT:-/Users/aaronneiderhiser/code/tuva-worktrees}"
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -n|--dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --worktree-root)
+      [[ $# -ge 2 ]] || die "--worktree-root requires a path"
+      WORKTREE_ROOT="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        POSITIONAL+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      die "Unexpected option: $1"
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+[[ ${#POSITIONAL[@]} -ge 1 && ${#POSITIONAL[@]} -le 2 ]] || {
+  usage >&2
+  exit 1
+}
+
+ISSUE_NUMBER="${POSITIONAL[0]}"
+[[ "${ISSUE_NUMBER}" =~ ^[0-9]+$ ]] || die "Issue number must be numeric."
+
+SLUG_RAW="${POSITIONAL[1]:-}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+for cmd in git gh; do
+  command -v "${cmd}" >/dev/null 2>&1 || die "Missing required command: ${cmd}"
+done
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  gh auth status >/dev/null
+fi
+
+if [[ -z "${SLUG_RAW}" ]]; then
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    SLUG_RAW="issue-${ISSUE_NUMBER}"
+  else
+    SLUG_RAW="$(gh issue view "${ISSUE_NUMBER}" --json title --jq '.title')"
+  fi
+fi
+
+SLUG="$(normalize_slug "${SLUG_RAW}")"
+[[ -n "${SLUG}" ]] || die "Slug is empty after normalization."
+
+DESIRED_BRANCH="codex/issue-${ISSUE_NUMBER}-${SLUG}"
+BRANCH="${DESIRED_BRANCH}"
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  LINKED_OUTPUT="$(gh issue develop --list "${ISSUE_NUMBER}" 2>/dev/null || true)"
+  LINKED_BRANCH="$(printf '%s\n' "${LINKED_OUTPUT}" | extract_linked_branch "${ISSUE_NUMBER}")"
+  if [[ -n "${LINKED_BRANCH}" ]]; then
+    BRANCH="${LINKED_BRANCH}"
+  fi
+fi
+
+WORKTREE_NAME="${BRANCH#codex/}"
+WORKTREE_PATH="${WORKTREE_ROOT}/${WORKTREE_NAME}"
+
+echo "Issue: #${ISSUE_NUMBER}"
+echo "Branch: ${BRANCH}"
+echo "Worktree: ${WORKTREE_PATH}"
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  run_cmd git fetch origin main
+  run_cmd gh issue develop --list "${ISSUE_NUMBER}"
+  run_cmd gh issue develop "${ISSUE_NUMBER}" --base main --name "${BRANCH}"
+  run_cmd git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+  run_cmd mkdir -p "${WORKTREE_ROOT}"
+  run_cmd git worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "origin/${BRANCH}"
+  exit 0
+fi
+
+git fetch origin main
+
+EXISTING_WORKTREE="$(find_worktree_for_branch "${BRANCH}")"
+if [[ -n "${EXISTING_WORKTREE}" ]]; then
+  echo "Ready: ${BRANCH} already has worktree ${EXISTING_WORKTREE}"
+  gh issue develop --list "${ISSUE_NUMBER}"
+  exit 0
+fi
+
+if [[ -e "${WORKTREE_PATH}" ]]; then
+  die "Worktree path already exists but is not attached to ${BRANCH}: ${WORKTREE_PATH}"
+fi
+
+if ! git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+  gh issue develop "${ISSUE_NUMBER}" --base main --name "${BRANCH}"
+fi
+
+git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+mkdir -p "${WORKTREE_ROOT}"
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git worktree add "${WORKTREE_PATH}" "${BRANCH}"
+else
+  git worktree add -b "${BRANCH}" "${WORKTREE_PATH}" "origin/${BRANCH}"
+fi
+
+LINKED_AFTER="$(gh issue develop --list "${ISSUE_NUMBER}")"
+printf '%s\n' "${LINKED_AFTER}"
+
+if ! printf '%s\n' "${LINKED_AFTER}" | grep -F "${BRANCH}" >/dev/null; then
+  die "Created worktree, but could not confirm ${BRANCH} is linked to issue #${ISSUE_NUMBER}."
+fi
+
+echo "Ready: ${BRANCH} in ${WORKTREE_PATH}"


### PR DESCRIPTION
## Summary
- make root AGENTS.md the canonical Tuva agent operating manual
- add scripts/start-issue-worktree for GitHub-linked issue branches and isolated worktrees
- point docs/agent.md to root AGENTS.md and align release note categories with current labels

## Validation
- bash -n scripts/start-issue-worktree
- scripts/start-issue-worktree --help
- scripts/start-issue-worktree --dry-run --worktree-root /tmp/tuva-worktrees 123 add-claim-status
- CI_COMMENT_BODY='/ci snowflake dbt seed dbt run' CI_AUTHOR_ASSOCIATION=OWNER python scripts/parse_ci_command.py parse-comment
- git diff --check

## Release label
- enhancement

Requested directly in Codex; no linked issue.