### PR TITLE
Fix CMS HCC missing OREC age fallback

### DIFF
--- a/models/data_marts/cms_hcc/cms_hcc__int_members_unit_tests.yml
+++ b/models/data_marts/cms_hcc/cms_hcc__int_members_unit_tests.yml
@@ -1,0 +1,104 @@
+version: 2
+
+unit_tests:
+  - name: test_cms_hcc_int_members_defaults_missing_orec_by_age
+    description: >
+      Verifies that members with missing OREC and Medicare Status default to the
+      CMS age-based disabled logic: under 65 as Disabled and 65 or older as Aged.
+    model: cms_hcc__int_members
+    config:
+      enabled: "{{ var('claims_enabled', False) | as_bool }}"
+    overrides:
+      vars:
+        tuva_last_run: '2024-01-01 00:00:00'
+    given:
+      - input: ref('cms_hcc__stg_core__eligibility')
+        format: sql
+        rows: |
+          {% set string_type = 'string' if target.type == 'bigquery' else 'varchar' %}
+          {% set integer_type = 'int64' if target.type == 'bigquery' else 'integer' %}
+          select
+              'under_65' as person_id
+            , 'medicare' as payer
+            , cast('2023-01-01' as date) as enrollment_start_date
+            , cast('2024-12-31' as date) as enrollment_end_date
+            , cast(null as {{ string_type }}) as original_reason_entitlement_code
+            , cast(null as {{ string_type }}) as dual_status_code
+            , cast(null as {{ string_type }}) as medicare_status_code
+            , 'Continuing' as enrollment_status
+            , cast(null as {{ integer_type }}) as long_term_institutional_flag
+            , cast(null as {{ integer_type }}) as institutional_snp_flag
+          union all
+          select
+              'sixty_five' as person_id
+            , 'medicare' as payer
+            , cast('2023-01-01' as date) as enrollment_start_date
+            , cast('2024-12-31' as date) as enrollment_end_date
+            , cast(null as {{ string_type }}) as original_reason_entitlement_code
+            , cast(null as {{ string_type }}) as dual_status_code
+            , cast(null as {{ string_type }}) as medicare_status_code
+            , 'Continuing' as enrollment_status
+            , cast(null as {{ integer_type }}) as long_term_institutional_flag
+            , cast(null as {{ integer_type }}) as institutional_snp_flag
+      - input: ref('cms_hcc__stg_core__patient')
+        format: sql
+        rows: |
+          select
+              'under_65' as person_id
+            , 'female' as sex
+            , cast('1959-02-02' as date) as birth_date
+            , cast(null as date) as death_date
+          union all
+          select
+              'sixty_five' as person_id
+            , 'male' as sex
+            , cast('1958-02-02' as date) as birth_date
+            , cast(null as date) as death_date
+      - input: ref('cms_hcc__int_monthly_collection_dates')
+        format: sql
+        rows: |
+          select
+              cast('2023-01-01' as date) as collection_start_date
+            , cast('2023-12-31' as date) as collection_end_date
+            , 2023 as collection_year
+            , 2024 as payment_year
+    expect:
+      rows:
+        - person_id: 'under_65'
+          payer: 'medicare'
+          enrollment_status: 'Continuing'
+          gender: 'Female'
+          age_group: '60-64'
+          medicaid_status: 'No'
+          dual_status: 'Non'
+          orec: 'Disabled'
+          institutional_status: 'No'
+          originally_disabled_flag: 'No'
+          institutional_snp_flag: null
+          enrollment_status_default: false
+          medicaid_dual_status_default: true
+          orec_default: true
+          institutional_status_default: true
+          payment_year: 2024
+          collection_start_date: '2023-01-01'
+          collection_end_date: '2023-12-31'
+          tuva_last_run: '2024-01-01 00:00:00'
+        - person_id: 'sixty_five'
+          payer: 'medicare'
+          enrollment_status: 'Continuing'
+          gender: 'Male'
+          age_group: '65-69'
+          medicaid_status: 'No'
+          dual_status: 'Non'
+          orec: 'Aged'
+          institutional_status: 'No'
+          originally_disabled_flag: 'No'
+          institutional_snp_flag: null
+          enrollment_status_default: false
+          medicaid_dual_status_default: true
+          orec_default: true
+          institutional_status_default: true
+          payment_year: 2024
+          collection_start_date: '2023-01-01'
+          collection_end_date: '2023-12-31'
+          tuva_last_run: '2024-01-01 00:00:00'

--- a/models/data_marts/cms_hcc/cms_hcc_models.yml
+++ b/models/data_marts/cms_hcc/cms_hcc_models.yml
@@ -35,7 +35,9 @@ models:
           Indicates the input data was missing and a default status was used.
       - name: orec_default
         description: >
-          Indicates the input data was missing and a default status was used.
+          Indicates the OREC risk segment was defaulted because source OREC or
+          Medicare Status was missing or indicated ESRD. When both source values
+          are missing, the default follows the CMS age rule.
       - name: institutional_status_default
         description: >
           Indicates the input data was missing and a default status was used.
@@ -76,7 +78,9 @@ models:
           Indicates the input data was missing and a default status was used.
       - name: orec_default
         description: >
-          Indicates the input data was missing and a default status was used.
+          Indicates the OREC risk segment was defaulted because source OREC or
+          Medicare Status was missing or indicated ESRD. When both source values
+          are missing, the default follows the CMS age rule.
       - name: institutional_status_default
         description: >
           Indicates the input data was missing and a default status was used.
@@ -287,7 +291,11 @@ models:
           Indicates whether the patient has "Full", "Partial", or "Non"  dual status.
       - name: orec
         description: >
-          Indicates the Original Reason for Entitlement Code (OREC)  "Aged", "Disabled", or "ESRD".
+          Indicates the Original Reason for Entitlement Code (OREC) risk
+          segment: "Aged", "Disabled", or "ESRD". When OREC is missing,
+          current Medicare Status is used as a proxy; when both source values
+          are missing, CMS age logic assigns "Disabled" for members under 65
+          and "Aged" for members 65 or older.
       - name: institutional_status
         description: >
           Indicates whether the patient resided in an institution for at  least 90 days.
@@ -299,7 +307,9 @@ models:
           Indicates the input data was missing and a default status was used.
       - name: orec_default
         description: >
-          Indicates the input data was missing and a default status was used.
+          Indicates the OREC risk segment was defaulted because source OREC or
+          Medicare Status was missing or indicated ESRD. When both source values
+          are missing, the default follows the CMS age rule.
       - name: institutional_status_default
         description: >
           Indicates the input data was missing and a default status was used.
@@ -585,7 +595,11 @@ models:
           Indicates whether the patient has "Full", "Partial", or "Non"  dual status.
       - name: orec
         description: >
-          Indicates the Original Reason for Entitlement Code (OREC)  "Aged", "Disabled", or "ESRD". If available, current Medicare Status  is used when OREC is missing.
+          Indicates the Original Reason for Entitlement Code (OREC) risk
+          segment: "Aged", "Disabled", or "ESRD". When OREC is missing,
+          current Medicare Status is used as a proxy; when both source values
+          are missing, CMS age logic assigns "Disabled" for members under 65
+          and "Aged" for members 65 or older.
       - name: institutional_status
         description: >
           Indicates whether the patient resided in an institution for at  least 90 days.
@@ -597,7 +611,9 @@ models:
           Indicates the input data was missing and a default status was used.
       - name: orec_default
         description: >
-          Indicates the input data was missing and a default status was used.
+          Indicates the OREC risk segment was defaulted because source OREC or
+          Medicare Status was missing or indicated ESRD. When both source values
+          are missing, the default follows the CMS age rule.
       - name: institutional_status_default
         description: >
           Indicates the input data was missing and a default status was used.

--- a/models/data_marts/cms_hcc/intermediate/cms_hcc__int_members.sql
+++ b/models/data_marts/cms_hcc/intermediate/cms_hcc__int_members.sql
@@ -262,6 +262,8 @@ with stg_eligibility as (
            model (CNA/CFA/CPA), regardless of OREC.
 
            When OREC is missing, latest Medicare status is used as a proxy.
+           If both values are missing, apply the same age-based disabled logic
+           CMS uses for blank OREC.
         */
         , case
             when original_reason_entitlement_code = '0' then 'Aged'
@@ -270,7 +272,8 @@ with stg_eligibility as (
             when original_reason_entitlement_code is null and medicare_status_code in ('10', '11', '31') then 'Aged'
             when original_reason_entitlement_code is null and medicare_status_code in ('20', '21') and payment_year_age >= 65 then 'Aged'
             when original_reason_entitlement_code is null and medicare_status_code in ('20', '21') then 'Disabled'
-            when coalesce(original_reason_entitlement_code, medicare_status_code) is null then 'Aged'
+            when coalesce(original_reason_entitlement_code, medicare_status_code) is null and payment_year_age >= 65 then 'Aged'
+            when coalesce(original_reason_entitlement_code, medicare_status_code) is null then 'Disabled'
           end as orec
         /*
            CMS SAS: ORIGDS = (OREC = '1') * (DISABL = 0)


### PR DESCRIPTION
## Summary
- Fix missing OREC and missing Medicare Status fallback in `cms_hcc__int_members` to follow CMS age-based disabled logic.
- Preserve explicit OREC and Medicare Status proxy handling, and keep `orec_default` true for null/null source values.
- Add a dbt unit test for null/null OREC/status at under-65 and 65+ ages, and update CMS HCC metadata descriptions.

## Validation
- `scripts/dbt-local deps` - pass
- `DBT_PROFILES_DIR=integration_tests/profiles/duckdb DBT_MOTHERDUCK_CI_PATH=/tmp/tuva-1295-orec.duckdb scripts/dbt-local test --select cms_hcc__int_members,test_type:unit` - pass
- `DBT_PROFILES_DIR=integration_tests/profiles/duckdb DBT_MOTHERDUCK_CI_PATH=/tmp/tuva-1295-orec-model.duckdb scripts/dbt-local compile --select cms_hcc__int_members` - pass
- `scripts/dbt-local build --select cms_hcc__int_members+` and `scripts/dbt-local build --full-refresh` were not completed locally because `/Users/aaronneiderhiser/code/duckdb/tuva_dev.duckdb` was locked by another running dbt seed process in the main checkout.

## Release note label
bug

Closes #1295
