### PR TITLE
Document dbt ref behavior flag

### DIFF
--- a/docs/docs/connectors/building-a-connector.md
+++ b/docs/docs/connectors/building-a-connector.md
@@ -65,7 +65,16 @@ models:
     +schema: input_layer
 ```
 
-3. Set the minimal connector variables based on the type of source you are mapping.
+3. Keep the dbt ref behavior flag enabled. The current connector template already includes this flag.
+
+```yaml
+flags:
+  require_ref_searches_node_package_before_root: true
+```
+
+This prevents dbt 1.11 ref warnings when Tuva refs the connector's root-project Input Layer models.
+
+4. Set the minimal connector variables based on the type of source you are mapping.
 
 For a claims connector:
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -167,14 +167,19 @@ If you later want to run clinical models or provider attribution, map those Inpu
 
 ### Step 4: Configure Tuva Vars
 
-Set the broad enablement vars in your `dbt_project.yml`.
+Set the dbt ref behavior flag and broad enablement vars in your `dbt_project.yml`.
 
 ```yaml
+flags:
+  require_ref_searches_node_package_before_root: true
+
 vars:
   claims_enabled: true
   # clinical_enabled: true
   # provider_attribution_enabled: true
 ```
+
+The `require_ref_searches_node_package_before_root` flag aligns dbt's ref resolution with dbt 1.11 behavior and prevents warnings when Tuva refs your root-project Input Layer models.
 
 Start with `claims_enabled: true` for a claims-only implementation. Enable `clinical_enabled` or `provider_attribution_enabled` only after those corresponding Input Layer tables are mapped.
 


### PR DESCRIPTION
## Summary
- Document the dbt ref behavior flag in the real-data getting started workflow.
- Add the same flag to the connector setup guide and note that the current connector template already includes it.

## Validation
- `./scripts/dbt-local deps`
- `./scripts/dbt-local parse --no-partial-parse --show-all-deprecations`
  - Confirmed no `require_ref_prefers_node_package_to_root` warnings.
  - Existing unrelated `MissingArgumentsPropertyInGenericTestDeprecation` warnings still appear.
- `cd docs && npm ci`
- `cd docs && npm run build`
  - Build succeeded; existing Docusaurus/Browserslist/SVG warnings still appear.

## Release note label
- docs

Closes #1277