### PR TITLE
[codex] Add docs release channels

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,7 @@
 name: Create Release
 # creates a draft release if there is a push to main/ that changes "version" in /dbt_project.yml
 # user must manually publish the release and check the latest release option
+# versions ending in -rc or -RC are marked as prereleases
 
 on:
   push:
@@ -36,6 +37,12 @@ jobs:
           if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            NEW_VERSION_LOWER=$(echo "$NEW_VERSION" | tr '[:upper:]' '[:lower:]')
+            if [[ "$NEW_VERSION_LOWER" == *-rc ]]; then
+              echo "prerelease=true" >> $GITHUB_OUTPUT
+            else
+              echo "prerelease=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
@@ -53,5 +60,5 @@ jobs:
           tag_name: v${{ steps.check_version.outputs.version }}
           name: the_tuva_project v${{ steps.check_version.outputs.version }}
           draft: true
-          prerelease: false
+          prerelease: ${{ steps.check_version.outputs.prerelease }}
           generate_release_notes: true

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -133,7 +133,7 @@ This is the normal path for running Tuva on your own data in your existing wareh
 - A warehouse connection already configured in `profiles.yml`
 - Your raw claims data already loaded into the warehouse
 
-The current release of Tuva is <TuvaCurrentRelease />.
+The most recent stable release of Tuva is <TuvaCurrentRelease />.
 
 ### Step 1: Create Or Use A dbt Project
 
@@ -141,7 +141,7 @@ Create a new dbt project if you do not already have one, or use an existing proj
 
 ### Step 2: Add The Tuva Package
 
-Add the Tuva package to your `packages.yml`. Replace `<current-release>` with the release shown above.
+Add the Tuva package to your `packages.yml`. Replace `<current-release>` with the stable release shown above.
 
 ```yaml
 packages:

--- a/docs/docs/welcome.md
+++ b/docs/docs/welcome.md
@@ -7,13 +7,13 @@ image: /img/tuva_project_overview_from_downloads.jpg
 slug: /
 ---
 
-import TuvaCurrentRelease from '@site/src/components/TuvaCurrentRelease';
+import TuvaReleaseChannels from '@site/src/components/TuvaReleaseChannels';
 
 # 👋 Welcome
 
 Welcome to the Tuva Project! Our goal is to **democratize access to high-quality healthcare analytics** by open-sourcing the tools and knowledge needed to transform raw healthcare data into analytics-ready data. To learn more about why we started the Tuva Project read our **manifesto [here](/community/manifesto)**.
 
-**The current release of Tuva is: <TuvaCurrentRelease />**
+<TuvaReleaseChannels />
 
 ![Tuva Project Overview](/img/tuva_project_overview_from_downloads.jpg)
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,17 +7,95 @@
 const lightCodeTheme = require('prism-react-renderer/dist/index').github;
 const darkCodeTheme = require('prism-react-renderer/dist/index').dracula;
 const fs = require('fs');
+const https = require('https');
 const path = require('path');
+const {
+  DEFAULT_BLEEDING_EDGE,
+  addBleedingEdgePublishedAt,
+  buildTuvaReleaseChannels,
+} = require('./src/lib/tuvaReleaseChannels');
 const enableGtag = process.env.ENABLE_DOCS_GTAG === 'true';
-const tuvaDbtProjectPath = path.resolve(__dirname, '..', 'dbt_project.yml');
+const githubReleasesUrl = 'https://api.github.com/repos/tuva-health/tuva/releases?per_page=100';
+const githubMergedPullsUrl = 'https://api.github.com/repos/tuva-health/tuva/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100';
+const releaseChannelsFallbackPath = path.resolve(
+  __dirname,
+  'src/data/tuvaReleaseChannelsFallback.json'
+);
 
-function getTuvaVersion() {
+function readReleaseChannelsFallback() {
+  const fallback = JSON.parse(
+    fs.readFileSync(releaseChannelsFallbackPath, 'utf8')
+  );
+
+  return {
+    ...fallback,
+    bleedingEdge: fallback.bleedingEdge || DEFAULT_BLEEDING_EDGE,
+  };
+}
+
+function requestJson(url) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'tuva-docs-release-channel-build',
+  };
+  const githubToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+  if (githubToken) {
+    headers.Authorization = `Bearer ${githubToken}`;
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, {headers}, (response) => {
+      let body = '';
+
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        body += chunk;
+      });
+      response.on('end', () => {
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          reject(
+            new Error(`GitHub API returned HTTP ${response.statusCode}`)
+          );
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(body));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    request.setTimeout(10000, () => {
+      request.destroy(new Error('GitHub release lookup timed out'));
+    });
+    request.on('error', reject);
+  });
+}
+
+async function getTuvaReleaseChannels() {
   try {
-    const yamlText = fs.readFileSync(tuvaDbtProjectPath, 'utf8');
-    const match = yamlText.match(/^\s*version:\s*["']?([^"'\n#]+)["']?\s*$/m);
-    return match?.[1]?.trim() || 'latest';
-  } catch {
-    return 'latest';
+    const [releases, pullRequests] = await Promise.all([
+      requestJson(githubReleasesUrl),
+      requestJson(githubMergedPullsUrl),
+    ]);
+    const releaseChannels = addBleedingEdgePublishedAt(
+      buildTuvaReleaseChannels(releases),
+      pullRequests
+    );
+
+    if (!releaseChannels.stable) {
+      throw new Error('GitHub releases response did not include a stable release');
+    }
+
+    return releaseChannels;
+  } catch (error) {
+    console.warn(
+      `[docs] Unable to fetch Tuva GitHub releases. Using fallback release channels. ${error.message}`
+    );
+    return readReleaseChannelsFallback();
   }
 }
 
@@ -53,7 +131,6 @@ const config = {
     locales: ['en'],
   },
   customFields: {
-    tuvaVersion: getTuvaVersion(),
   },
 
   themes: ['@docusaurus/theme-mermaid'],
@@ -497,4 +574,15 @@ const config = {
     }),
 };
 
-module.exports = config
+module.exports = async function createConfig() {
+  const tuvaReleaseChannels = await getTuvaReleaseChannels();
+
+  return {
+    ...config,
+    customFields: {
+      ...config.customFields,
+      tuvaVersion: tuvaReleaseChannels.stable?.version || 'latest',
+      tuvaReleaseChannels,
+    },
+  };
+};

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start --host 0.0.0.0",
     "build": "docusaurus build",
+    "test:release-channels": "node scripts/test_release_channels.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/docs/scripts/test_release_channels.js
+++ b/docs/scripts/test_release_channels.js
@@ -1,0 +1,94 @@
+const assert = require('node:assert/strict');
+
+const {
+  NO_ACTIVE_RELEASE_CANDIDATE_LABEL,
+  addBleedingEdgePublishedAt,
+  buildTuvaReleaseChannels,
+  getCandidateReleaseLabel,
+  getLatestMergedPullRequest,
+  isReleaseCandidate,
+  isStableRelease,
+} = require('../src/lib/tuvaReleaseChannels');
+
+const stableRelease = {
+  tag_name: 'v0.17.2',
+  name: 'the_tuva_project v0.17.2',
+  draft: false,
+  prerelease: false,
+  published_at: '2026-04-02T17:07:35Z',
+  html_url: 'https://github.com/tuva-health/tuva/releases/tag/v0.17.2',
+};
+
+const rcRelease = {
+  tag_name: 'v0.18.0-rc',
+  name: 'the_tuva_project v0.18.0-rc',
+  draft: false,
+  prerelease: true,
+  published_at: '2026-04-24T04:35:58Z',
+  html_url: 'https://github.com/tuva-health/tuva/releases/tag/v0.18.0-rc',
+};
+
+const uppercaseRcRelease = {
+  tag_name: 'v0.19.0-RC',
+  name: 'the_tuva_project v0.19.0-RC',
+  draft: false,
+  prerelease: false,
+  published_at: '2026-05-08T17:07:35Z',
+  html_url: 'https://github.com/tuva-health/tuva/releases/tag/v0.19.0-RC',
+};
+
+assert.equal(isReleaseCandidate(rcRelease), true);
+assert.equal(isStableRelease(rcRelease), false);
+
+assert.equal(isStableRelease(stableRelease), true);
+assert.equal(isReleaseCandidate(stableRelease), false);
+
+assert.equal(isReleaseCandidate(uppercaseRcRelease), true);
+assert.equal(isStableRelease(uppercaseRcRelease), false);
+
+const channels = buildTuvaReleaseChannels([
+  stableRelease,
+  rcRelease,
+  uppercaseRcRelease,
+]);
+
+assert.equal(channels.stable.version, '0.17.2');
+assert.equal(channels.candidate.version, '0.19.0-RC');
+assert.equal(channels.bleedingEdge.label, 'main');
+
+const channelsWithoutCandidate = buildTuvaReleaseChannels([stableRelease]);
+
+assert.equal(channelsWithoutCandidate.candidate, null);
+assert.equal(
+  getCandidateReleaseLabel(channelsWithoutCandidate.candidate),
+  NO_ACTIVE_RELEASE_CANDIDATE_LABEL
+);
+
+const olderMergedPullRequest = {
+  merged_at: '2026-04-29T18:27:06Z',
+};
+const latestMergedPullRequest = {
+  merged_at: '2026-04-29T21:37:44Z',
+};
+const unmergedPullRequest = {
+  merged_at: null,
+};
+
+assert.equal(
+  getLatestMergedPullRequest([
+    unmergedPullRequest,
+    olderMergedPullRequest,
+    latestMergedPullRequest,
+  ]),
+  latestMergedPullRequest
+);
+
+assert.equal(
+  addBleedingEdgePublishedAt(channels, [
+    olderMergedPullRequest,
+    latestMergedPullRequest,
+  ]).bleedingEdge.publishedAt,
+  latestMergedPullRequest.merged_at
+);
+
+console.log('Release channel classification tests passed.');

--- a/docs/src/components/TuvaCurrentRelease.js
+++ b/docs/src/components/TuvaCurrentRelease.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-const TUVA_REPO_URL = 'https://github.com/tuva-health/tuva';
+const TUVA_RELEASES_URL = 'https://github.com/tuva-health/tuva/releases';
 
 export default function TuvaCurrentRelease() {
   const {siteConfig} = useDocusaurusContext();
-  const version = siteConfig?.customFields?.tuvaVersion || 'latest';
+  const releaseChannels = siteConfig?.customFields?.tuvaReleaseChannels;
+  const stableRelease = releaseChannels?.stable;
+  const version =
+    stableRelease?.version || siteConfig?.customFields?.tuvaVersion || 'latest';
+  const url = stableRelease?.url || TUVA_RELEASES_URL;
 
-  return <a href={TUVA_REPO_URL}>{version}</a>;
+  return <a href={url}>{version}</a>;
 }

--- a/docs/src/components/TuvaReleaseChannels.js
+++ b/docs/src/components/TuvaReleaseChannels.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {
+  DEFAULT_BLEEDING_EDGE,
+  NO_ACTIVE_RELEASE_CANDIDATE_LABEL,
+  getCandidateReleaseLabel,
+} from '@site/src/lib/tuvaReleaseChannels';
+import styles from './TuvaReleaseChannels.module.css';
+
+function formatPublishedAt(publishedAt) {
+  if (!publishedAt) {
+    return null;
+  }
+
+  const publishedDate = new Date(publishedAt);
+
+  if (Number.isNaN(publishedDate.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(publishedDate);
+}
+
+function ReleaseLink({href, label}) {
+  if (!href) {
+    return <span className={styles.releaseValue}>{label}</span>;
+  }
+
+  return (
+    <a className={styles.releaseValue} href={href}>
+      {label}
+    </a>
+  );
+}
+
+function ReleaseChannel({description, href, label, publishedAt, title}) {
+  const formattedDate = formatPublishedAt(publishedAt);
+
+  return (
+    <article className={styles.channel}>
+      <div className={styles.channelHeader}>
+        <h3 className={styles.channelTitle}>{title}</h3>
+        {formattedDate ? (
+          <span className={styles.publishedDate}>{formattedDate}</span>
+        ) : null}
+      </div>
+      <ReleaseLink href={href} label={label} />
+      <p className={styles.channelDescription}>{description}</p>
+    </article>
+  );
+}
+
+export default function TuvaReleaseChannels() {
+  const {siteConfig} = useDocusaurusContext();
+  const releaseChannels = siteConfig?.customFields?.tuvaReleaseChannels || {};
+  const stable = releaseChannels.stable;
+  const candidate = releaseChannels.candidate;
+  const bleedingEdge = releaseChannels.bleedingEdge || DEFAULT_BLEEDING_EDGE;
+  const candidateLabel = getCandidateReleaseLabel(candidate);
+
+  return (
+    <div className={styles.releaseChannels}>
+      <ReleaseChannel
+        description="Recommended for production dbt package installs."
+        href={stable?.url}
+        label={stable?.version || 'latest'}
+        publishedAt={stable?.publishedAt}
+        title="Most recent stable release"
+      />
+      <ReleaseChannel
+        description="Upcoming release validation build."
+        href={candidate ? candidate.url : null}
+        label={candidateLabel}
+        publishedAt={candidate?.publishedAt}
+        title="Release candidate"
+      />
+      <ReleaseChannel
+        description="Latest merged code on GitHub."
+        href={bleedingEdge.url}
+        label={bleedingEdge.label || 'main'}
+        publishedAt={bleedingEdge.publishedAt}
+        title="Bleeding edge"
+      />
+    </div>
+  );
+}
+
+export {NO_ACTIVE_RELEASE_CANDIDATE_LABEL};

--- a/docs/src/components/TuvaReleaseChannels.module.css
+++ b/docs/src/components/TuvaReleaseChannels.module.css
@@ -1,0 +1,57 @@
+.releaseChannels {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 2rem;
+}
+
+.channel {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 1rem;
+  background: var(--ifm-background-surface-color);
+}
+
+.channelHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 1.5rem;
+}
+
+.channelTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.publishedDate {
+  flex: 0 0 auto;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.releaseValue {
+  display: inline-block;
+  margin-top: 0.65rem;
+  overflow-wrap: anywhere;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.channelDescription {
+  margin: 0.6rem 0 0;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 996px) {
+  .releaseChannels {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/src/data/tuvaReleaseChannelsFallback.json
+++ b/docs/src/data/tuvaReleaseChannelsFallback.json
@@ -1,0 +1,19 @@
+{
+  "stable": {
+    "version": "0.17.2",
+    "tag": "v0.17.2",
+    "url": "https://github.com/tuva-health/tuva/releases/tag/v0.17.2",
+    "publishedAt": "2026-04-02T17:07:35Z"
+  },
+  "candidate": {
+    "version": "0.18.0-rc",
+    "tag": "v0.18.0-rc",
+    "url": "https://github.com/tuva-health/tuva/releases/tag/v0.18.0-rc",
+    "publishedAt": "2026-04-24T04:35:58Z"
+  },
+  "bleedingEdge": {
+    "label": "main",
+    "url": "https://github.com/tuva-health/tuva/tree/main",
+    "publishedAt": "2026-04-29T21:37:44Z"
+  }
+}

--- a/docs/src/lib/tuvaReleaseChannels.js
+++ b/docs/src/lib/tuvaReleaseChannels.js
@@ -1,0 +1,115 @@
+const TUVA_REPO_URL = 'https://github.com/tuva-health/tuva';
+const TUVA_MAIN_BRANCH_URL = `${TUVA_REPO_URL}/tree/main`;
+const NO_ACTIVE_RELEASE_CANDIDATE_LABEL = 'No active release candidate';
+
+const DEFAULT_BLEEDING_EDGE = {
+  label: 'main',
+  url: TUVA_MAIN_BRANCH_URL,
+};
+
+function normalizeTag(tag) {
+  return String(tag || '').trim();
+}
+
+function versionFromTag(tag) {
+  return normalizeTag(tag).replace(/^v/i, '');
+}
+
+function isRcValue(value) {
+  return /-rc$/i.test(normalizeTag(value));
+}
+
+function isReleaseCandidate(release) {
+  return Boolean(release?.prerelease) ||
+    isRcValue(release?.tag_name) ||
+    isRcValue(release?.name);
+}
+
+function isPublishedRelease(release) {
+  return Boolean(release) && !release.draft && Boolean(release.published_at);
+}
+
+function isStableRelease(release) {
+  return isPublishedRelease(release) && !isReleaseCandidate(release);
+}
+
+function releaseTimestamp(release) {
+  const timestamp = Date.parse(release?.published_at || '');
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function formatRelease(release) {
+  if (!release) {
+    return null;
+  }
+
+  const tag = normalizeTag(release.tag_name);
+
+  return {
+    version: versionFromTag(tag),
+    tag,
+    url: release.html_url || `${TUVA_REPO_URL}/releases/tag/${tag}`,
+    publishedAt: release.published_at || null,
+  };
+}
+
+function buildTuvaReleaseChannels(releases) {
+  const publishedReleases = [...(releases || [])]
+    .filter(isPublishedRelease)
+    .sort((left, right) => releaseTimestamp(right) - releaseTimestamp(left));
+
+  const stable = publishedReleases.find(isStableRelease) || null;
+  const candidate = publishedReleases.find(isReleaseCandidate) || null;
+
+  return {
+    stable: formatRelease(stable),
+    candidate: formatRelease(candidate),
+    bleedingEdge: DEFAULT_BLEEDING_EDGE,
+  };
+}
+
+function getCandidateReleaseLabel(candidate) {
+  return candidate?.version || NO_ACTIVE_RELEASE_CANDIDATE_LABEL;
+}
+
+function pullRequestMergedTimestamp(pullRequest) {
+  const timestamp = Date.parse(pullRequest?.merged_at || '');
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function getLatestMergedPullRequest(pullRequests) {
+  return [...(pullRequests || [])]
+    .filter((pullRequest) => Boolean(pullRequest?.merged_at))
+    .sort(
+      (left, right) =>
+        pullRequestMergedTimestamp(right) - pullRequestMergedTimestamp(left)
+    )[0] || null;
+}
+
+function addBleedingEdgePublishedAt(releaseChannels, pullRequests) {
+  const latestMergedPullRequest = getLatestMergedPullRequest(pullRequests);
+
+  return {
+    ...releaseChannels,
+    bleedingEdge: {
+      ...DEFAULT_BLEEDING_EDGE,
+      ...releaseChannels?.bleedingEdge,
+      publishedAt:
+        latestMergedPullRequest?.merged_at ||
+        releaseChannels?.bleedingEdge?.publishedAt ||
+        null,
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_BLEEDING_EDGE,
+  NO_ACTIVE_RELEASE_CANDIDATE_LABEL,
+  addBleedingEdgePublishedAt,
+  buildTuvaReleaseChannels,
+  getCandidateReleaseLabel,
+  getLatestMergedPullRequest,
+  isReleaseCandidate,
+  isStableRelease,
+  versionFromTag,
+};


### PR DESCRIPTION
## Summary
- Replaces the docs homepage single current-release display with GitHub-backed release channel cards for stable, release candidate, and main.
- Resolves the stable version from the latest non-RC published GitHub release instead of `dbt_project.yml`.
- Marks `*-rc` / `*-RC` release workflow outputs as GitHub prereleases and adds release-channel classification coverage.

## Validation
- `cd docs && npm run test:release-channels`
- `cd docs && npm run build`
- Local preview checked at `http://localhost:3000/`

## Release-note label
- docs
