### PR TITLE
fix: correct hcc recapture YAML description key

### DIFF
--- a/models/data_marts/hcc_recapture/final_models.yml
+++ b/models/data_marts/hcc_recapture/final_models.yml
@@ -240,7 +240,7 @@ models:
             - 'Y': condition is a chronic condition appropriate for recapture and has been documented in the prior 2 years
             - 'N': condition is not a chronic condition appropriate for recapture or has not been documented in the prior 2 years- name: recapture_flag
       - name: gap_status
-        desription: >
+        description: >
           definitions for gap_status:
             - 'closed using higher coefficient hcc in hierarchy group': An HCC in the same group was closed, but its coefficient is greater than the prior year HCC
             - 'closed': the specific HCC in question has been observed in a risk adjustable claim during the collection year.


### PR DESCRIPTION
## Summary
- correct the misspelled `desription` key in the HCC recapture model YAML
- restore the supported `description` property so dbt no longer emits the typo warning

## Validation
- ran `scripts/dbt-local deps`
- started a full local `scripts/dbt-local build --full-refresh` on DuckDB with the repo's synthetic data

Closes #1333
