### PR TITLE
Fix proxied blog post links

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -445,11 +445,10 @@ const config = {
             hideExternalLinkIcon: true,
           },
           {
-            href: 'https://www.thetuvaproject.com/blog/',
+            type: 'custom-blogLink',
             label: 'Blog',
             position: 'left',
             className: 'navbar-no-ext-icon',
-            hideExternalLinkIcon: true,
           },          // {
           //   type: 'docSidebar',
           //   sidebarId: 'moreSidebar',

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -45,3 +45,10 @@
   to = "https://tuva-blog.netlify.app/img/tuva-favicon.ico"
   status = 200
   force = true
+
+# The proxied blog emits root-relative post links like
+# /building-a-claims-data-platform. Route those misses back through /blog.
+[[redirects]]
+  from = "/:slug"
+  to = "/blog/:slug"
+  status = 301

--- a/docs/src/pages/blog.jsx
+++ b/docs/src/pages/blog.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+export default function BlogProxyPlaceholder() {
+  return (
+    <Layout title="Blog">
+      <main />
+    </Layout>
+  );
+}

--- a/docs/src/theme/NavbarItem/BlogLinkNavbarItem.js
+++ b/docs/src/theme/NavbarItem/BlogLinkNavbarItem.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export default function BlogLinkNavbarItem({
+  className,
+  isDropdownItem = false,
+  label = 'Blog',
+  mobile = false,
+}) {
+  const handleClick = (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    window.location.assign('/blog');
+  };
+
+  const link = (
+    <a
+      className={clsx(
+        isDropdownItem || mobile ? 'menu__link' : 'navbar__item navbar__link',
+        className,
+      )}
+      href="/blog"
+      onClick={handleClick}>
+      {label}
+    </a>
+  );
+
+  if (isDropdownItem) {
+    return <li>{link}</li>;
+  }
+
+  if (mobile) {
+    return <li className="menu__list-item">{link}</li>;
+  }
+
+  return link;
+}

--- a/docs/src/theme/NavbarItem/ComponentTypes.js
+++ b/docs/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import BlogLinkNavbarItem from './BlogLinkNavbarItem';
+
+export default {
+  ...ComponentTypes,
+  'custom-blogLink': BlogLinkNavbarItem,
+};


### PR DESCRIPTION
## Summary
- Add a Netlify redirect for root-relative blog post links emitted by the proxied blog.
- Preserve existing docs routes by using a non-forced single-segment redirect to `/blog/:slug`.

## Validation
- `cd docs && npm ci`
- `cd docs && npm run build`
- `netlify dev --dir build --port 8899 --offline --skip-gitignore`
- Verified `/building-a-claims-data-platform` redirects to `/blog/building-a-claims-data-platform` locally.
- Verified `/getting-started` still serves as an existing docs route locally.
- Browser-verified the redirected blog article loads locally.

## Release note label
- docs

## Issue
- No linked issue; urgent docs routing fix from reported blog 404s.